### PR TITLE
Feature/remote skills

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -90,10 +90,15 @@ export async function initCommand(): Promise<void> {
         mcpSummary[agentSelection.id] = configuredMcp;
       }
 
+      // Preserve remote skills from previous config if the agent existed before
+      const previousAgent = existingConfig?.agents.find(a => a.id === agentSelection.id);
+      const remoteSkills = previousAgent?.remoteSkills ?? [];
+
       installedAgents.push({
         id: agentSelection.id,
         skillsDir: agentConfig.skillsDir,
         installedSkills,
+        remoteSkills,
         mcp: {
           github: agentSelection.mcpGithub,
           filesystem: agentSelection.mcpFilesystem,

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -1,0 +1,374 @@
+import chalk from 'chalk';
+import path from 'path';
+import inquirer from 'inquirer';
+import { loadConfig, saveConfig, type RemoteSkill } from '../../core/config.js';
+import { getAgentConfig } from '../../core/agents.js';
+import { getAvailableSkills, installRemoteSkill } from '../../core/installer.js';
+import { parseRemoteSource, formatSourceUri, downloadAndExtract, resolveCommitHash, detectSkills, cleanupTemp, type DetectedSkill } from '../../core/remote-skill.js';
+import { removeDirectory } from '../../utils/fs.js';
+
+// ─── skill add ───────────────────────────────────────────────
+
+export async function skillAddCommand(source: string): Promise<void> {
+  const projectDir = process.cwd();
+
+  console.log(chalk.bold.blue('\n🏭 AI Factory - Add Remote Skill\n'));
+
+  const config = await loadConfig(projectDir);
+  if (!config || config.agents.length === 0) {
+    console.log(chalk.red('Error: No .ai-factory.json found or no agents configured.'));
+    console.log(chalk.dim('Run "ai-factory init" first.'));
+    process.exit(1);
+  }
+
+  // 1. Parse source
+  let parsed;
+  try {
+    parsed = parseRemoteSource(source);
+  } catch (error) {
+    console.log(chalk.red((error as Error).message));
+    process.exit(1);
+  }
+
+  // 2. Download
+  console.log(chalk.dim(`Downloading ${parsed.owner}/${parsed.repo}...`));
+  let repoDir: string;
+  try {
+    repoDir = await downloadAndExtract(parsed);
+  } catch (error) {
+    console.log(chalk.red((error as Error).message));
+    process.exit(1);
+  }
+
+  try {
+    // 3. Detect skills
+    const allDetected = await detectSkills(repoDir);
+
+    // 4. Filter by skillPath if specified
+    let selectedSkills: DetectedSkill[];
+
+    if (parsed.skillPath) {
+      const match = allDetected.find(s =>
+        s.relativePath === parsed.skillPath || s.name === parsed.skillPath
+      );
+      if (!match) {
+        console.log(chalk.red(`Skill "${parsed.skillPath}" not found in repository.`));
+        console.log(chalk.dim('Available skills:'));
+        for (const s of allDetected) {
+          console.log(chalk.dim(`  - ${s.name} (${s.relativePath || 'root'})`));
+        }
+        process.exit(1);
+      }
+      selectedSkills = [match];
+    } else if (allDetected.length === 1) {
+      selectedSkills = allDetected;
+      console.log(chalk.dim(`Detected skill: ${allDetected[0].name}`));
+    } else {
+      // Interactive selection for collections
+      console.log(chalk.dim(`Found ${allDetected.length} skills:\n`));
+
+      const { chosen } = await inquirer.prompt([{
+        type: 'checkbox',
+        name: 'chosen',
+        message: 'Select skills to install:',
+        choices: allDetected.map(s => ({
+          name: `${s.name}${s.description ? chalk.dim(` — ${s.description}`) : ''}`,
+          value: s.name,
+          checked: true,
+        })),
+        validate: (input: string[]) => input.length > 0 || 'Select at least one skill.',
+      }]);
+
+      selectedSkills = allDetected.filter(s => chosen.includes(s.name));
+    }
+
+    // 5. Check for conflicts with built-in skills
+    const builtInSkills = await getAvailableSkills();
+    for (const skill of selectedSkills) {
+      if (builtInSkills.includes(skill.name)) {
+        console.log(chalk.red(`Skill "${skill.name}" conflicts with a built-in skill. Skipping.`));
+        selectedSkills = selectedSkills.filter(s => s.name !== skill.name);
+      }
+    }
+
+    if (selectedSkills.length === 0) {
+      console.log(chalk.yellow('No skills to install.'));
+      return;
+    }
+
+    // 6. Resolve commit hash for versioning
+    const version = await resolveCommitHash(parsed);
+
+    // 7. Install for each agent
+    console.log('');
+    for (const agent of config.agents) {
+      const agentConfig = getAgentConfig(agent.id);
+
+      for (const skill of selectedSkills) {
+        // Check if already installed — update it
+        const existingIdx = agent.remoteSkills.findIndex(r => r.name === skill.name);
+
+        await installRemoteSkill({
+          skillDir: skill.dirPath,
+          skillName: skill.name,
+          projectDir,
+          agentId: agent.id,
+        });
+
+        const remoteEntry: RemoteSkill = {
+          name: skill.name,
+          source: `github:${parsed.owner}/${parsed.repo}`,
+          path: skill.relativePath,
+          ref: parsed.ref,
+          version,
+          installedAt: new Date().toISOString(),
+        };
+
+        if (existingIdx >= 0) {
+          agent.remoteSkills[existingIdx] = remoteEntry;
+        } else {
+          agent.remoteSkills.push(remoteEntry);
+        }
+      }
+
+      const names = selectedSkills.map(s => s.name).join(', ');
+      console.log(chalk.green(`  ✓ [${agentConfig.displayName}] Installed: ${names}`));
+    }
+
+    // 8. Save config
+    await saveConfig(projectDir, config);
+    console.log(chalk.green('\n✓ Configuration saved'));
+
+  } finally {
+    await cleanupTemp(repoDir);
+  }
+}
+
+// ─── skill remove ────────────────────────────────────────────
+
+export async function skillRemoveCommand(name: string): Promise<void> {
+  const projectDir = process.cwd();
+
+  console.log(chalk.bold.blue('\n🏭 AI Factory - Remove Remote Skill\n'));
+
+  const config = await loadConfig(projectDir);
+  if (!config || config.agents.length === 0) {
+    console.log(chalk.red('Error: No .ai-factory.json found or no agents configured.'));
+    process.exit(1);
+  }
+
+  let removedCount = 0;
+
+  for (const agent of config.agents) {
+    const agentConfig = getAgentConfig(agent.id);
+    const idx = agent.remoteSkills.findIndex(r => r.name === name);
+
+    if (idx >= 0) {
+      // Remove skill directory
+      const skillDir = path.join(projectDir, agentConfig.skillsDir, name);
+      await removeDirectory(skillDir);
+
+      agent.remoteSkills.splice(idx, 1);
+      removedCount++;
+      console.log(chalk.green(`  ✓ Removed "${name}" from ${agentConfig.displayName}`));
+    }
+  }
+
+  if (removedCount === 0) {
+    console.log(chalk.yellow(`Remote skill "${name}" not found in any agent configuration.`));
+    return;
+  }
+
+  await saveConfig(projectDir, config);
+  console.log(chalk.green(`\n✓ Removed "${name}" from ${removedCount} agent(s)`));
+}
+
+// ─── skill list ──────────────────────────────────────────────
+
+export async function skillListCommand(): Promise<void> {
+  const projectDir = process.cwd();
+
+  const config = await loadConfig(projectDir);
+  if (!config || config.agents.length === 0) {
+    console.log(chalk.red('Error: No .ai-factory.json found or no agents configured.'));
+    process.exit(1);
+  }
+
+  console.log(chalk.bold.blue('\n🏭 AI Factory - Installed Skills\n'));
+
+  for (const agent of config.agents) {
+    const agentConfig = getAgentConfig(agent.id);
+
+    console.log(chalk.bold(`${agentConfig.displayName} (${agent.skillsDir}):`));
+
+    // Built-in skills
+    const baseSkills = agent.installedSkills.filter(s => !s.includes('/'));
+    const customSkills = agent.installedSkills.filter(s => s.includes('/'));
+
+    console.log(chalk.dim(`  Built-in: ${baseSkills.length} skills`));
+    if (customSkills.length > 0) {
+      console.log(chalk.dim(`  Custom: ${customSkills.join(', ')}`));
+    }
+
+    // Remote skills
+    if (agent.remoteSkills.length > 0) {
+      console.log(chalk.cyan('  Remote:'));
+      for (const rs of agent.remoteSkills) {
+        const age = timeSince(rs.installedAt);
+        console.log(chalk.dim(`    ${rs.name}  ${rs.source}  ${rs.version}  ${age}`));
+      }
+    } else {
+      console.log(chalk.dim('  Remote: none'));
+    }
+    console.log('');
+  }
+}
+
+function timeSince(isoDate: string): string {
+  const diff = Date.now() - new Date(isoDate).getTime();
+  const days = Math.floor(diff / 86400000);
+  if (days === 0) return 'today';
+  if (days === 1) return '1 day ago';
+  if (days < 30) return `${days} days ago`;
+  const months = Math.floor(days / 30);
+  return months === 1 ? '1 month ago' : `${months} months ago`;
+}
+
+// ─── skill update ────────────────────────────────────────────
+
+export async function skillUpdateCommand(name?: string): Promise<void> {
+  const projectDir = process.cwd();
+
+  console.log(chalk.bold.blue('\n🏭 AI Factory - Update Remote Skills\n'));
+
+  const config = await loadConfig(projectDir);
+  if (!config || config.agents.length === 0) {
+    console.log(chalk.red('Error: No .ai-factory.json found or no agents configured.'));
+    process.exit(1);
+  }
+
+  // Collect unique sources across all agents
+  interface SourceGroup {
+    source: string;
+    ref: string;
+    owner: string;
+    repo: string;
+    skills: Array<{ agentIdx: number; remoteIdx: number; skillPath: string; skillName: string }>;
+    currentVersion: string;
+  }
+
+  const sourceGroups = new Map<string, SourceGroup>();
+
+  for (let ai = 0; ai < config.agents.length; ai++) {
+    const agent = config.agents[ai];
+    for (let ri = 0; ri < agent.remoteSkills.length; ri++) {
+      const rs = agent.remoteSkills[ri];
+
+      // Filter by name if specified
+      if (name && rs.name !== name) continue;
+
+      const key = `${rs.source}#${rs.ref}`;
+      if (!sourceGroups.has(key)) {
+        const parsed = parseRemoteSource(rs.source + (rs.ref !== 'main' ? `#${rs.ref}` : ''));
+        sourceGroups.set(key, {
+          source: rs.source,
+          ref: rs.ref,
+          owner: parsed.owner,
+          repo: parsed.repo,
+          skills: [],
+          currentVersion: rs.version,
+        });
+      }
+      sourceGroups.get(key)!.skills.push({
+        agentIdx: ai,
+        remoteIdx: ri,
+        skillPath: rs.path,
+        skillName: rs.name,
+      });
+    }
+  }
+
+  if (sourceGroups.size === 0) {
+    if (name) {
+      console.log(chalk.yellow(`Remote skill "${name}" not found.`));
+    } else {
+      console.log(chalk.yellow('No remote skills installed.'));
+    }
+    return;
+  }
+
+  let updatedCount = 0;
+  let upToDateCount = 0;
+
+  for (const [, group] of sourceGroups) {
+    const source: { host: 'github'; owner: string; repo: string; ref: string } = {
+      host: 'github',
+      owner: group.owner,
+      repo: group.repo,
+      ref: group.ref,
+    };
+
+    // Check for new version
+    const latestVersion = await resolveCommitHash(source);
+
+    if (latestVersion === group.currentVersion) {
+      for (const s of group.skills) {
+        console.log(chalk.dim(`  ${s.skillName}: already up to date (${group.currentVersion})`));
+        upToDateCount++;
+      }
+      continue;
+    }
+
+    // Download and reinstall
+    console.log(chalk.dim(`  Downloading ${group.owner}/${group.repo}...`));
+    let repoDir: string;
+    try {
+      repoDir = await downloadAndExtract(source);
+    } catch (error) {
+      console.log(chalk.red(`  Failed to download ${group.source}: ${(error as Error).message}`));
+      continue;
+    }
+
+    try {
+      const allDetected = await detectSkills(repoDir);
+
+      for (const s of group.skills) {
+        const detected = allDetected.find(d =>
+          d.name === s.skillName || d.relativePath === s.skillPath
+        );
+
+        if (!detected) {
+          console.log(chalk.yellow(`  ${s.skillName}: not found in updated repo, skipping`));
+          continue;
+        }
+
+        const agent = config.agents[s.agentIdx];
+
+        await installRemoteSkill({
+          skillDir: detected.dirPath,
+          skillName: s.skillName,
+          projectDir,
+          agentId: agent.id,
+        });
+
+        agent.remoteSkills[s.remoteIdx].version = latestVersion;
+        agent.remoteSkills[s.remoteIdx].installedAt = new Date().toISOString();
+
+        console.log(chalk.green(`  ✓ ${s.skillName}: updated ${group.currentVersion} → ${latestVersion}`));
+        updatedCount++;
+      }
+    } finally {
+      await cleanupTemp(repoDir);
+    }
+  }
+
+  await saveConfig(projectDir, config);
+
+  console.log('');
+  if (updatedCount > 0) {
+    console.log(chalk.green(`✓ Updated ${updatedCount} skill(s)`));
+  }
+  if (upToDateCount > 0) {
+    console.log(chalk.dim(`${upToDateCount} skill(s) already up to date`));
+  }
+}

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -67,6 +67,13 @@ export async function updateCommand(): Promise<void> {
           console.log(chalk.dim(`  - ${skill}`));
         }
       }
+
+      if (agent.remoteSkills && agent.remoteSkills.length > 0) {
+        console.log(chalk.bold(`[${agent.id}] Remote skills (preserved):`));
+        for (const rs of agent.remoteSkills) {
+          console.log(chalk.dim(`  - ${rs.name} (${rs.source})`));
+        }
+      }
     }
     console.log('');
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -39,7 +39,7 @@ skill
 
 skill
   .command('remove')
-  .argument('<name>', 'Skill name to remove')
+  .argument('[name]', 'Skill name to remove (interactive if omitted)')
   .description('Remove a remote skill')
   .action(skillRemoveCommand);
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { initCommand } from './commands/init.js';
 import { updateCommand } from './commands/update.js';
 import { upgradeCommand } from './commands/upgrade.js';
+import { skillAddCommand, skillRemoveCommand, skillListCommand, skillUpdateCommand } from './commands/skill.js';
 import { getCurrentVersion } from '../core/config.js';
 
 const program = new Command();
@@ -25,5 +26,32 @@ program
   .command('upgrade')
   .description('Upgrade from v1 to v2 (removes old-format skills, installs new)')
   .action(upgradeCommand);
+
+const skill = program
+  .command('skill')
+  .description('Manage remote skills');
+
+skill
+  .command('add')
+  .argument('<source>', 'Skill source (e.g. github:owner/repo)')
+  .description('Install a remote skill')
+  .action(skillAddCommand);
+
+skill
+  .command('remove')
+  .argument('<name>', 'Skill name to remove')
+  .description('Remove a remote skill')
+  .action(skillRemoveCommand);
+
+skill
+  .command('list')
+  .description('List installed skills')
+  .action(skillListCommand);
+
+skill
+  .command('update')
+  .argument('[name]', 'Skill name to update (all if omitted)')
+  .description('Update remote skills')
+  .action(skillUpdateCommand);
 
 program.parse();

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -13,10 +13,20 @@ export interface McpConfig {
   chromeDevtools: boolean;
 }
 
+export interface RemoteSkill {
+  name: string;
+  source: string;
+  path: string;
+  ref: string;
+  version: string;
+  installedAt: string;
+}
+
 export interface AgentInstallation {
   id: string;
   skillsDir: string;
   installedSkills: string[];
+  remoteSkills: RemoteSkill[];
   mcp: McpConfig;
 }
 
@@ -55,6 +65,7 @@ function createAgentInstallation(agentId: string, legacy?: LegacyAiFactoryConfig
     skillsDir: legacy?.skillsDir ?? agent.skillsDir,
     id: agentId,
     installedSkills: legacy?.installedSkills ?? [],
+    remoteSkills: [],
     mcp: normalizeMcp(legacy?.mcp),
   };
 }
@@ -81,6 +92,7 @@ export async function loadConfig(projectDir: string): Promise<AiFactoryConfig | 
         id: agent.id,
         skillsDir: agent.skillsDir || agentConfig.skillsDir,
         installedSkills: Array.isArray(agent.installedSkills) ? agent.installedSkills : [],
+        remoteSkills: Array.isArray(agent.remoteSkills) ? agent.remoteSkills : [],
         mcp: normalizeMcp(agent.mcp),
       };
     });

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -99,6 +99,24 @@ export async function getAvailableTemplates(): Promise<string[]> {
   return listDirectories(templatesDir);
 }
 
+export interface InstallRemoteSkillOptions {
+  skillDir: string;
+  skillName: string;
+  projectDir: string;
+  agentId: string;
+}
+
+export async function installRemoteSkill(options: InstallRemoteSkillOptions): Promise<string> {
+  const { skillDir, skillName, projectDir, agentId } = options;
+  const agentConfig = getAgentConfig(agentId);
+
+  const targetDir = path.join(projectDir, agentConfig.skillsDir);
+  await ensureDir(targetDir);
+
+  await installSkillWithTransformer(skillDir, skillName, projectDir, agentConfig.skillsDir, agentId, agentConfig);
+  return skillName;
+}
+
 export async function updateSkills(agentInstallation: AgentInstallation, projectDir: string): Promise<string[]> {
   const availableSkills = await getAvailableSkills();
   const customSkills = agentInstallation.installedSkills.filter(s => s.includes('/'));

--- a/src/core/remote-skill.ts
+++ b/src/core/remote-skill.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import os from 'os';
-import { execSync } from 'child_process';
+import fs from 'fs';
+import zlib from 'zlib';
 import { fileExists, readTextFile, listDirectories, removeDirectory, ensureDir } from '../utils/fs.js';
 
 /** Timeout controller helper for fetch calls. */
@@ -27,6 +28,42 @@ export interface DetectedSkill {
 }
 
 /**
+ * Convert a GitHub URL to the internal github: format.
+ *
+ * Examples:
+ *   https://github.com/owner/repo          → github:owner/repo
+ *   https://github.com/owner/repo.git      → github:owner/repo
+ *   https://github.com/owner/repo/tree/dev → github:owner/repo#dev
+ *   https://github.com/owner/repo/tree/dev/path/to/skill → github:owner/repo/path/to/skill#dev
+ */
+function normalizeGitHubUrl(url: string): string {
+  // Strip trailing slash and .git suffix
+  let cleaned = url.replace(/\/+$/, '').replace(/\.git$/, '');
+
+  // Remove protocol + host
+  const match = cleaned.match(/^https?:\/\/github\.com\/(.+)$/);
+  if (!match) return url;
+
+  const segments = match[1].split('/');
+  if (segments.length < 2) return url;
+
+  const owner = segments[0];
+  const repo = segments[1];
+
+  // /tree/<ref>[/path...] pattern
+  if (segments.length >= 4 && segments[2] === 'tree') {
+    const ref = segments[3];
+    const skillPath = segments.length > 4 ? segments.slice(4).join('/') : '';
+    let result = `github:${owner}/${repo}`;
+    if (skillPath) result += `/${skillPath}`;
+    result += `#${ref}`;
+    return result;
+  }
+
+  return `github:${owner}/${repo}`;
+}
+
+/**
  * Parse a remote source URI.
  *
  * Supported formats:
@@ -34,10 +71,18 @@ export interface DetectedSkill {
  *   github:owner/repo#ref
  *   github:owner/repo/skill-path
  *   github:owner/repo/skill-path#ref
+ *   https://github.com/owner/repo
+ *   https://github.com/owner/repo/tree/branch
+ *   https://github.com/owner/repo/tree/branch/skill-path
  */
 export function parseRemoteSource(uri: string): RemoteSource {
+  // Normalize GitHub URLs to github: format
+  if (uri.startsWith('https://github.com/') || uri.startsWith('http://github.com/')) {
+    uri = normalizeGitHubUrl(uri);
+  }
+
   if (!uri.startsWith('github:')) {
-    throw new Error(`Unsupported source format: "${uri}". Use github:owner/repo`);
+    throw new Error(`Unsupported source format: "${uri}". Use github:owner/repo or https://github.com/owner/repo`);
   }
 
   let body = uri.slice('github:'.length);
@@ -76,12 +121,7 @@ export function formatSourceUri(source: RemoteSource): string {
 }
 
 /**
- * Convert a Windows path to POSIX format for tools that need it (e.g. tar).
- * On Windows, C:\Users\... becomes /c/Users/...
- *
- * Note: Windows `curl.exe` expects native Windows paths — do NOT convert
- * paths passed to curl. Only `tar` (GNU tar from Git for Windows) needs
- * POSIX paths because it interprets `C:` as a remote host otherwise.
+ * Format a RemoteSource back to a URI string.
  */
 function toPosixPath(p: string): string {
   if (process.platform !== 'win32') return p;
@@ -111,6 +151,8 @@ async function resolveDefaultBranch(owner: string, repo: string): Promise<string
  * Download a repository archive and extract it to a temp directory.
  * Returns the path to the extracted repo root.
  * Also mutates source.ref to the resolved branch if it was empty.
+ *
+ * Uses Node.js native fetch + zlib + tar parser — no shell dependencies.
  */
 export async function downloadAndExtract(source: RemoteSource): Promise<string> {
   // Resolve default branch if not specified
@@ -124,24 +166,19 @@ export async function downloadAndExtract(source: RemoteSource): Promise<string> 
   const archiveUrl = `https://github.com/${source.owner}/${source.repo}/archive/refs/heads/${source.ref}.tar.gz`;
 
   try {
-    // Download and extract using curl + tar (available on macOS, Linux, and Windows with Git)
-    const archivePath = path.join(tmpBase, 'archive.tar.gz');
+    // Download tarball via fetch
+    const res = await fetchWithTimeout(archiveUrl, { timeout: 60000 });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} from ${archiveUrl}`);
+    }
 
-    // curl on Windows expects native Windows paths.
-    // tar (GNU tar from Git for Windows) needs POSIX paths to avoid
-    // interpreting "C:" as a remote host.
-    execSync(`curl -fsSL -o "${archivePath}" "${archiveUrl}"`, {
-      timeout: 60000,
-      stdio: 'pipe',
-    });
+    const buffer = Buffer.from(await res.arrayBuffer());
 
-    // Extract — use POSIX paths for tar on Windows
-    const archivePathPosix = toPosixPath(archivePath);
-    const tmpBasePosix = toPosixPath(tmpBase);
-    execSync(`tar -xzf "${archivePathPosix}" -C "${tmpBasePosix}"`, {
-      timeout: 30000,
-      stdio: 'pipe',
-    });
+    // Decompress gzip → raw tar
+    const tarBuffer = zlib.gunzipSync(buffer);
+
+    // Extract tar archive using pure Node.js parser
+    extractTar(tarBuffer, tmpBase);
 
     // GitHub archives extract to {repo}-{ref}/ directory
     const entries = await listDirectories(tmpBase);
@@ -155,13 +192,66 @@ export async function downloadAndExtract(source: RemoteSource): Promise<string> 
   } catch (error) {
     await removeDirectory(tmpBase).catch(() => {});
     const msg = (error as Error).message;
-    if (msg.includes('curl') || msg.includes('404')) {
+    if (msg.includes('HTTP') || msg.includes('fetch') || msg.includes('404')) {
       throw new Error(
         `Failed to download from ${archiveUrl}. ` +
         `Check that the repository "${source.owner}/${source.repo}" exists and branch "${source.ref}" is correct.`
       );
     }
     throw error;
+  }
+}
+
+/**
+ * Minimal tar extractor — reads a POSIX/UStar tar buffer and writes files to disk.
+ * Supports regular files and directories. Handles long names via pax headers (type 'x').
+ */
+function extractTar(tar: Buffer, destDir: string): void {
+  let offset = 0;
+  let paxPath = '';
+
+  while (offset + 512 <= tar.length) {
+    const header = tar.subarray(offset, offset + 512);
+
+    // End-of-archive: two consecutive zero blocks
+    if (header.every(b => b === 0)) break;
+
+    // Parse header fields
+    const rawName = header.subarray(0, 100).toString('utf-8').replace(/\0+$/, '');
+    const sizeStr = header.subarray(124, 136).toString('utf-8').replace(/\0+$/, '').trim();
+    const typeFlag = String.fromCharCode(header[156]);
+    const prefix = header.subarray(345, 500).toString('utf-8').replace(/\0+$/, '');
+
+    const fileSize = sizeStr ? parseInt(sizeStr, 8) : 0;
+    const entryName = paxPath || (prefix ? `${prefix}/${rawName}` : rawName);
+    paxPath = ''; // reset after use
+
+    offset += 512; // advance past header
+
+    if (typeFlag === 'x' || typeFlag === 'g') {
+      // Pax extended header — extract path= field
+      const paxData = tar.subarray(offset, offset + fileSize).toString('utf-8');
+      const pathMatch = paxData.match(/(?:^|\n)\d+ path=([^\n]+)/);
+      if (pathMatch) paxPath = pathMatch[1];
+      offset += Math.ceil(fileSize / 512) * 512;
+      continue;
+    }
+
+    if (typeFlag === '5' || entryName.endsWith('/')) {
+      // Directory
+      const dirPath = path.join(destDir, entryName);
+      fs.mkdirSync(dirPath, { recursive: true });
+    } else if (typeFlag === '0' || typeFlag === '' || typeFlag === '\0') {
+      // Regular file
+      const filePath = path.join(destDir, entryName);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      const data = tar.subarray(offset, offset + fileSize);
+      fs.writeFileSync(filePath, data);
+    }
+    // Skip symlinks, hardlinks, etc.
+
+    // Advance past data blocks (512-byte aligned)
+    offset += Math.ceil(fileSize / 512) * 512;
   }
 }
 

--- a/src/core/remote-skill.ts
+++ b/src/core/remote-skill.ts
@@ -1,0 +1,223 @@
+import path from 'path';
+import os from 'os';
+import { execSync } from 'child_process';
+import { fileExists, readTextFile, listDirectories, removeDirectory, ensureDir } from '../utils/fs.js';
+
+export interface RemoteSource {
+  host: 'github';
+  owner: string;
+  repo: string;
+  skillPath?: string;
+  ref: string;
+}
+
+export interface DetectedSkill {
+  name: string;
+  description: string;
+  dirPath: string;
+  relativePath: string;
+}
+
+/**
+ * Parse a remote source URI.
+ *
+ * Supported formats:
+ *   github:owner/repo
+ *   github:owner/repo#ref
+ *   github:owner/repo/skill-path
+ *   github:owner/repo/skill-path#ref
+ */
+export function parseRemoteSource(uri: string): RemoteSource {
+  if (!uri.startsWith('github:')) {
+    throw new Error(`Unsupported source format: "${uri}". Use github:owner/repo`);
+  }
+
+  let body = uri.slice('github:'.length);
+  let ref = 'main';
+
+  const hashIdx = body.indexOf('#');
+  if (hashIdx !== -1) {
+    ref = body.slice(hashIdx + 1);
+    body = body.slice(0, hashIdx);
+  }
+
+  const parts = body.split('/');
+  if (parts.length < 2) {
+    throw new Error(`Invalid GitHub source: "${uri}". Expected github:owner/repo`);
+  }
+
+  const owner = parts[0];
+  const repo = parts[1];
+  const skillPath = parts.length > 2 ? parts.slice(2).join('/') : undefined;
+
+  return { host: 'github', owner, repo, skillPath, ref };
+}
+
+/**
+ * Format a RemoteSource back to a URI string.
+ */
+export function formatSourceUri(source: RemoteSource): string {
+  let uri = `github:${source.owner}/${source.repo}`;
+  if (source.skillPath) {
+    uri += `/${source.skillPath}`;
+  }
+  if (source.ref !== 'main') {
+    uri += `#${source.ref}`;
+  }
+  return uri;
+}
+
+/**
+ * Download a repository archive and extract it to a temp directory.
+ * Returns the path to the extracted repo root.
+ */
+export async function downloadAndExtract(source: RemoteSource): Promise<string> {
+  const tmpBase = path.join(os.tmpdir(), `ai-factory-remote-${Date.now()}`);
+  await ensureDir(tmpBase);
+
+  const archiveUrl = `https://github.com/${source.owner}/${source.repo}/archive/refs/heads/${source.ref}.tar.gz`;
+
+  try {
+    // Download and extract using tar (available on macOS, Linux, and Windows with Git)
+    const archivePath = path.join(tmpBase, 'archive.tar.gz');
+
+    // Use curl for download (available on all modern OS)
+    execSync(`curl -fsSL -o "${archivePath}" "${archiveUrl}"`, {
+      timeout: 60000,
+      stdio: 'pipe',
+    });
+
+    // Extract
+    execSync(`tar -xzf "${archivePath}" -C "${tmpBase}"`, {
+      timeout: 30000,
+      stdio: 'pipe',
+    });
+
+    // GitHub archives extract to {repo}-{ref}/ directory
+    const entries = await listDirectories(tmpBase);
+    const repoDir = entries.find(e => e.startsWith(`${source.repo}-`));
+
+    if (!repoDir) {
+      throw new Error('Could not find extracted repository directory');
+    }
+
+    return path.join(tmpBase, repoDir);
+  } catch (error) {
+    await removeDirectory(tmpBase).catch(() => {});
+    const msg = (error as Error).message;
+    if (msg.includes('curl') || msg.includes('404')) {
+      throw new Error(
+        `Failed to download from ${archiveUrl}. ` +
+        `Check that the repository "${source.owner}/${source.repo}" exists and branch "${source.ref}" is correct.`
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Resolve the current commit hash for a remote source using the GitHub API.
+ */
+export async function resolveCommitHash(source: RemoteSource): Promise<string> {
+  try {
+    const output = execSync(
+      `curl -fsSL "https://api.github.com/repos/${source.owner}/${source.repo}/commits/${source.ref}" -H "Accept: application/vnd.github.sha"`,
+      { timeout: 15000, stdio: 'pipe', encoding: 'utf-8' },
+    );
+    return output.trim().slice(0, 12);
+  } catch {
+    // Fallback: use timestamp as version if API fails
+    return `unknown-${Date.now()}`;
+  }
+}
+
+/**
+ * Extract the `name:` and `description:` from SKILL.md YAML frontmatter.
+ */
+function parseFrontmatter(content: string): { name: string; description: string } {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match) {
+    return { name: '', description: '' };
+  }
+
+  const frontmatter = match[1];
+  const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
+  const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
+
+  return {
+    name: nameMatch ? nameMatch[1].trim() : '',
+    description: descMatch ? descMatch[1].trim().slice(0, 100) : '',
+  };
+}
+
+/**
+ * Detect skills in a downloaded repository.
+ *
+ * Detection order:
+ * 1. SKILL.md at root → single skill (entire repo is one skill)
+ * 2. skills/\*\/SKILL.md → collection in skills/ subdirectory
+ * 3. \*\/SKILL.md at first level → collection at root level
+ */
+export async function detectSkills(repoDir: string): Promise<DetectedSkill[]> {
+  // Pattern 1: Single skill — SKILL.md at root
+  const rootSkillMd = path.join(repoDir, 'SKILL.md');
+  if (await fileExists(rootSkillMd)) {
+    const content = await readTextFile(rootSkillMd);
+    const { name, description } = parseFrontmatter(content ?? '');
+    const dirName = path.basename(repoDir);
+    return [{
+      name: name || dirName,
+      description,
+      dirPath: repoDir,
+      relativePath: '',
+    }];
+  }
+
+  // Pattern 2: Collection in skills/ directory
+  const skillsSubDir = path.join(repoDir, 'skills');
+  if (await fileExists(skillsSubDir)) {
+    const skills = await scanForSkills(skillsSubDir, 'skills');
+    if (skills.length > 0) return skills;
+  }
+
+  // Pattern 3: Collection at root level
+  const rootSkills = await scanForSkills(repoDir, '');
+  if (rootSkills.length > 0) return rootSkills;
+
+  throw new Error('No skills found in repository. Expected SKILL.md at root or in subdirectories.');
+}
+
+async function scanForSkills(parentDir: string, relativePrefx: string): Promise<DetectedSkill[]> {
+  const skills: DetectedSkill[] = [];
+  const dirs = await listDirectories(parentDir);
+
+  for (const dir of dirs) {
+    // Skip hidden directories and common non-skill directories
+    if (dir.startsWith('.') || dir.startsWith('_') || dir === 'node_modules') continue;
+
+    const skillMdPath = path.join(parentDir, dir, 'SKILL.md');
+    if (await fileExists(skillMdPath)) {
+      const content = await readTextFile(skillMdPath);
+      const { name, description } = parseFrontmatter(content ?? '');
+      skills.push({
+        name: name || dir,
+        description,
+        dirPath: path.join(parentDir, dir),
+        relativePath: relativePrefx ? `${relativePrefx}/${dir}` : dir,
+      });
+    }
+  }
+
+  return skills;
+}
+
+/**
+ * Clean up a temp directory created by downloadAndExtract.
+ */
+export async function cleanupTemp(repoDir: string): Promise<void> {
+  // Go up one level to remove the entire temp base (includes archive.tar.gz)
+  const tmpBase = path.dirname(repoDir);
+  if (tmpBase.includes('ai-factory-remote-')) {
+    await removeDirectory(tmpBase).catch(() => {});
+  }
+}


### PR DESCRIPTION
## AI Factory — Remote Skills (новое)

### Новые команды

```bash
ai-factory skill add <source>     # Установить скилл из GitHub-репозитория
ai-factory skill remove [name]    # Удалить скилл (без имени — чекбоксы для выбора)
ai-factory skill list             # Показать все установленные скиллы
ai-factory skill update [name]    # Обновить скиллы (все или выборочно)
```

### Форматы источника

```bash
ai-factory skill add github:owner/repo
ai-factory skill add github:owner/repo/skill-path
ai-factory skill add github:owner/repo#branch
ai-factory skill add https://github.com/owner/repo
ai-factory skill add https://github.com/owner/repo/tree/branch/path
```

### Что изменилось в `.ai-factory.json`

В каждом агенте появилось поле `remoteSkills`:

```json
{
  "agents": [
    {
      "id": "claude",
      "skillsDir": ".claude/skills",
      "installedSkills": ["aif", "aif-plan", "..."],
      "remoteSkills": [
        {
          "name": "frontend-design",
          "source": "github:IncomeStreamSurfer/claude-skills-collection",
          "path": "frontend-design",
          "ref": "main",
          "version": "02807f13aae3",
          "installedAt": "2026-02-22T10:00:00.000Z"
        }
      ]
    }
  ]
}
```

### Ключевые моменты

- **Без новых зависимостей** — скачивание через `fetch()`, распаковка через `zlib` + свой tar-парсер
- **Мульти-агент** — скилл ставится сразу во все настроенные агенты
- **Защита от конфликтов** — нельзя поставить скилл с именем встроенного `aif-*`
- **При `init`** — если добавляешь нового агента, remote-скиллы копируются с диска (без повторного скачивания)
- **При `update`** — спрашивает обновить все или выбрать конкретные, показывает имена агентов в выводе
