### PR TITLE
fix: detect Windows absolute paths in extension install

### DIFF
--- a/src/core/extensions.ts
+++ b/src/core/extensions.ts
@@ -96,7 +96,7 @@ function isGitUrl(source: string): boolean {
 }
 
 function isLocalPath(source: string): boolean {
-  return source.startsWith('./') || source.startsWith('/') || source.startsWith('../');
+  return source.startsWith('./') || source.startsWith('/') || source.startsWith('../') || path.isAbsolute(source);
 }
 
 export async function installExtensionFromLocal(projectDir: string, sourcePath: string): Promise<ExtensionManifest> {


### PR DESCRIPTION
На Windows такую проблему обнаружил:

<img width="773" height="352" alt="image" src="https://github.com/user-attachments/assets/9682d8fd-7cca-4d6d-a643-9b20af0f850b" />

В PR подправил