### PR TITLE
feat(skills): add aif-explore workflow skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 **AI Factory** (v2) is an npm package + skill system that automates AI agent context setup for projects. It provides:
 
 1. **CLI tool** (`ai-factory init/update/upgrade`) — installs skills and configures MCP
-2. **Built-in skills** (22 skills, all `aif-*` prefixed) — workflow commands for spec-driven development
+2. **Built-in skills** (23 skills, all `aif-*` prefixed) — workflow commands for spec-driven development
 3. **Spec-driven workflow** — structured approach: plan → implement → commit
 4. **Multi-agent support** — 15 agents (Claude Code, Cursor, Windsurf, Roo Code, Kilo Code, Antigravity, OpenCode, Warp, Zencoder, Codex CLI, GitHub Copilot, Gemini CLI, Junie, Qwen Code, Universal)
 
@@ -32,6 +32,7 @@ ai-factory/
 │   ├── aif-dockerize/          # Docker/compose generator
 │   ├── aif-docs/               # Documentation generation & maintenance
 │   ├── aif-evolve/             # Self-improve skills based on context
+│   ├── aif-explore/            # Explore mode (thinking partner)
 │   ├── aif-fix/                # Quick bug fixes (no plans)
 │   ├── aif-implement/          # Execute plan tasks
 │   ├── aif-improve/            # Plan refinement (second iteration)
@@ -71,6 +72,7 @@ All AI Factory files in user projects go to `.ai-factory/`:
 All skills use `aif-` prefix (v1 used bare names like `commit`, `feature`):
 - `/aif` — main setup
 - `/aif-plan`
+- `/aif-explore`
 - `/aif-implement`
 - `/aif-roadmap`
 - `/aif-rules`

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ ai-factory upgrade
 ### Example Workflow
 
 ```bash
+# Explore options and requirements before planning (optional)
+/aif-explore Add user authentication with OAuth
+
 # Plan a feature — creates branch, analyzes codebase, builds step-by-step plan
 /aif-plan Add user authentication with OAuth
 
@@ -140,7 +143,7 @@ AI Factory can generate and maintain your project docs with a single command:
 | [Getting Started](docs/getting-started.md) | What is AI Factory, supported agents, CLI commands |
 | [Development Workflow](docs/workflow.md) | Workflow diagram, when to use what, spec-driven approach |
 | [Reflex Loop](docs/loop.md) | Iterative generate → evaluate → critique → refine workflow |
-| [Core Skills](docs/skills.md) | All slash commands — feature, task, fix, implement, evolve, docs, and more |
+| [Core Skills](docs/skills.md) | All slash commands — explore, plan, fix, implement, evolve, docs, and more |
 | [Plan Files](docs/plan-files.md) | Plan files, self-improvement patches, skill acquisition |
 | [Security](docs/security.md) | Two-level security scanning for external skills |
 | [Extensions](docs/extensions.md) | Writing and installing extensions — commands, injections, MCP, agents |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,11 +50,14 @@ ai-factory init
 # 4. Open your AI agent (Claude Code, Cursor, etc.) and run:
 /aif
 
-# 5. Start building
+# 5. Optional discovery before planning
+/aif-explore Add user authentication with OAuth
+
+# 6. Start building
 /aif-plan Add user authentication with OAuth
 ```
 
-From here, AI Factory creates a branch, builds a plan, and you run `/aif-implement` to execute it step by step.
+If scope is unclear, start with `/aif-explore`; if it is already clear, jump straight to `/aif-plan`. From there, AI Factory creates a branch (full mode), builds a plan, and you run `/aif-implement` to execute it step by step.
 
 ## CLI Commands
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -6,6 +6,18 @@
 
 These skills form the core development loop. See [Development Workflow](workflow.md) for the full diagram and how they connect.
 
+### `/aif-explore [topic or plan name]`
+Explore ideas, constraints, and trade-offs before planning:
+```
+/aif-explore real-time collaboration
+/aif-explore the auth system is getting unwieldy
+/aif-explore add-auth-system
+```
+- Uses a thinking-partner mode: open questions, option mapping, and ASCII visualization
+- Reads project context from `.ai-factory/DESCRIPTION.md`, `ARCHITECTURE.md`, `RULES.md`, and active plan files when present
+- Does **not** implement code in this mode; when direction is clear, move to `/aif-plan`
+- Can capture decisions in context files on request (for example architecture notes, rules, and roadmap updates)
+
 ### `/aif-plan [fast|full] <description>`
 Plans implementation for a feature or task:
 ```

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -2,7 +2,7 @@
 
 # Development Workflow
 
-AI Factory has two phases: **configuration** (one-time project setup) and the **development workflow** (repeatable loop of plan → implement → verify → commit → evolve).
+AI Factory has two phases: **configuration** (one-time project setup) and the **development workflow** (repeatable loop of explore → plan → improve → implement → verify → commit → evolve).
 
 ## Project Configuration
 
@@ -47,6 +47,8 @@ Run once per project. Sets up context files that all workflow skills depend on.
 ## Development Workflow
 
 The repeatable development loop. Each skill feeds into the next, sharing context through plan files and patches.
+
+Optional discovery step: use `/aif-explore` before planning to investigate ideas, compare options, and clarify requirements.
 
 ![workflow](https://github.com/lee-to/ai-factory/raw/2.x/art/workflow.png)
 
@@ -139,6 +141,7 @@ The repeatable development loop. Each skill feeds into the next, sharing context
 
 | Command | Use Case | Creates Branch? | Creates Plan? |
 |---------|----------|-----------------|---------------|
+| `/aif-explore` | Discovery, option comparison, and requirements clarification before planning | No | No (reads existing context) |
 | `/aif-roadmap` | Strategic planning, milestones, long-term vision | No | `.ai-factory/ROADMAP.md` |
 | `/aif-plan fast` | Small tasks, quick fixes, experiments | No | `.ai-factory/PLAN.md` |
 | `/aif-plan full` | Full features, stories, epics | Yes | `.ai-factory/plans/<branch>.md` |
@@ -151,6 +154,16 @@ The repeatable development loop. Each skill feeds into the next, sharing context
 ## Workflow Skills
 
 These skills form the development pipeline. Each one feeds into the next.
+
+### `/aif-explore [topic or plan name]` — discovery before planning
+
+```
+/aif-explore real-time collaboration
+/aif-explore the auth system is getting unwieldy
+/aif-explore add-auth-system
+```
+
+Thinking-partner mode for exploring ideas, constraints, and trade-offs without implementing code. Reads `.ai-factory/DESCRIPTION.md`, `ARCHITECTURE.md`, `RULES.md`, and active plan files for context. When direction is clear, transition to `/aif-plan fast` or `/aif-plan full`.
 
 ### `/aif-roadmap [check | vision]` — strategic planning
 

--- a/skills/aif-explore/SKILL.md
+++ b/skills/aif-explore/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: aif-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+argument-hint: "[topic or plan name]"
+allowed-tools: Read Glob Grep Bash AskUserQuestion Questions
+disable-model-invocation: true
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks to implement something, remind them to exit explore mode first (e.g., start with `/aif-plan`). You MAY update AI Factory context files (DESCRIPTION.md, ARCHITECTURE.md, RULES.md) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
++-----------------------------------------+
+|     Use ASCII diagrams liberally        |
++-----------------------------------------+
+|                                         |
+|   +--------+         +--------+        |
+|   | State  |-------->| State  |        |
+|   |   A    |         |   B    |        |
+|   +--------+         +--------+        |
+|                                         |
+|   System diagrams, state machines,      |
+|   data flows, architecture sketches,    |
+|   dependency graphs, comparison tables  |
+|                                         |
++-----------------------------------------+
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## AI Factory Context
+
+You have access to AI Factory's project context. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, read these files if present:
+
+- `.ai-factory/DESCRIPTION.md` — project description, tech stack, constraints
+- `.ai-factory/ARCHITECTURE.md` — architecture decisions, folder structure
+- `.ai-factory/RULES.md` — project conventions and rules
+- `.ai-factory/PLAN.md` — active fast plan (if any)
+- `.ai-factory/plans/<branch>.md` — active full plans (if any)
+- `.ai-factory/ROADMAP.md` — strategic milestones (if any)
+
+This tells you:
+- What the project is about
+- What conventions to follow
+- If there's active work in progress
+
+### Input handling
+
+The argument after `/aif-explore` can be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A plan name: to explore in context of `.ai-factory/plans/<name>.md`
+- A comparison: "postgres vs sqlite for this"
+- Nothing: just enter explore mode
+
+### When no plan exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to plan. Want me to start `/aif-plan`?"
+- Or keep exploring - no pressure to formalize
+
+### When a plan exists
+
+If the user mentions a plan or you detect one is relevant:
+
+1. **Read existing plan for context**
+   - `.ai-factory/PLAN.md` (fast mode)
+   - `.ai-factory/plans/<branch>.md` (full mode)
+
+2. **Reference it naturally in conversation**
+   - "Your plan mentions adding Redis, but we just realized SQLite fits better..."
+   - "Task 3 scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement | `.ai-factory/DESCRIPTION.md` (stack section) |
+   | Architecture decision | `.ai-factory/ARCHITECTURE.md` |
+   | Project convention | `.ai-factory/RULES.md` |
+   | New task/feature | Run `/aif-plan` to create plan |
+   | Strategic direction | `.ai-factory/ROADMAP.md` |
+   | Assumption invalidated | Relevant file |
+
+   Example offers:
+   - "That's an architecture decision. Add it to ARCHITECTURE.md?"
+   - "This is a new convention. Add it to RULES.md?"
+   - "This changes the plan. Update the plan file?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+
+      Awareness          Coordination         Sync
+          |                   |                 |
+          v                   v                 v
+      +--------+         +--------+        +--------+
+      |Presence|         |Cursors |        |  CRDT  |
+      |  "3    |         | Multi  |        |Conflict|
+      |online" |         | select |        |  free  |
+      +--------+         +--------+        +--------+
+          |                   |                 |
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     +---------------------------------------------+
+     |              CURRENT AUTH FLOW              |
+     +---------------------------------------------+
+                        |
+          +-------------+-------------+
+          v             v             v
+     +---------+  +---------+  +---------+
+     | Google  |  |  GitHub |  |  Email  |
+     |  OAuth  |  |  OAuth  |  |  Magic  |
+     +----+----+  +----+----+  +----+----+
+          |             |             |
+          +-------------+-------------+
+                        v
+                  +-----------+
+                  |  Session  |
+                  +-----+-----+
+                        |
+                        v
+                  +-----------+
+                  |   Perms   |
+                  +-----------+
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /aif-explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads plan from .ai-factory/plans/add-auth-system.md]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the plan to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     +---------------------------------------------+
+     |         CLI TOOL DATA STORAGE               |
+     +---------------------------------------------+
+
+     Key constraints:
+     * No daemon running
+     * Must work offline
+     * Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ok     needs server no
+     Offline      yes ok          no no
+     Single file  yes ok          no no
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into action**: "Ready to plan? Run `/aif-plan`"
+- **Result in context updates**: "Updated ARCHITECTURE.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a plan: /aif-plan [fast|full] <description>
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Updating AI Factory context files is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/src/core/transformer.ts
+++ b/src/core/transformer.ts
@@ -27,6 +27,7 @@ export interface AgentOnboarding {
 export const WORKFLOW_SKILLS = new Set([
   'aif',
   'aif-commit',
+  'aif-explore',
   'aif-fix',
   'aif-implement',
   'aif-improve',

--- a/src/core/transformers/antigravity.ts
+++ b/src/core/transformers/antigravity.ts
@@ -37,6 +37,7 @@ export class AntigravityTransformer implements AgentTransformer {
 
 ## Skill Usage
 
+- Use \`/aif-explore\` to think through ideas before planning — no implementation, just exploration
 - Use \`/aif-plan\` for new features — creates branch, plan, and tasks
 - Use \`/aif-fix\` for bug fixes — analyzes, fixes, suggests tests
 - Use \`/aif-commit\` for commits — follows conventional commits
@@ -58,6 +59,7 @@ AI Factory organizes skills into three categories:
 
 ### Workflows (.agent/workflows/)
 Action-oriented skills that execute specific tasks:
+- \`aif-explore.md\` — Think through ideas, investigate problems
 - \`aif-plan.md\` — Plan and develop new features
 - \`aif-fix.md\` — Fix bugs with structured approach
 - \`aif-implement.md\` — Execute plans step by step


### PR DESCRIPTION
Add interactive exploration skill adapted from OpenSpec's openspec-explore.
Provides a thinking partner stance for exploring ideas, investigating problems,
and clarifying requirements before planning or implementation.

Key adaptations for AI Factory:
- Context: reads .ai-factory/*.md files instead of openspec/changes/
- Transitions: offers /aif-plan instead of /opsx-new or /opsx-ff
- Insight capture: maps to DESCRIPTION.md, ARCHITECTURE.md, RULES.md, ROADMAP.md