### PR TITLE
feat: persist explore context via RESEARCH.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,7 +57,7 @@ ai-factory init
 /aif-plan Add user authentication with OAuth
 ```
 
-If scope is unclear, start with `/aif-explore`; if it is already clear, jump straight to `/aif-plan`. From there, AI Factory creates a branch (full mode), builds a plan, and you run `/aif-implement` to execute it step by step.
+If scope is unclear, start with `/aif-explore` (optionally save results to `.ai-factory/RESEARCH.md`); if it is already clear, jump straight to `/aif-plan`. From there, AI Factory creates a branch (full mode), builds a plan, and you run `/aif-implement` to execute it step by step.
 
 ## CLI Commands
 

--- a/docs/plan-files.md
+++ b/docs/plan-files.md
@@ -9,6 +9,14 @@ AI Factory uses markdown files to track implementation plans:
 | `/aif-plan fast` | `.ai-factory/PLAN.md` | Offer to delete |
 | `/aif-plan full` | `.ai-factory/plans/<branch-name>.md` | Keep (user decides) |
 
+## Research File (Optional)
+
+`.ai-factory/RESEARCH.md` is a persisted exploration artifact. Use it to capture constraints, decisions, and open questions during `/aif-explore` so you can `/clear` and still feed the same context into `/aif-plan`.
+
+Typical structure:
+- `## Active Summary (input for /aif-plan)` — compact, up-to-date snapshot
+- `## Sessions` — append-only history (keep prior notes verbatim)
+
 **Example plan file:**
 
 ```markdown
@@ -21,6 +29,13 @@ Created: 2024-01-15
 - Testing: no
 - Logging: verbose
 - Docs: yes          # /aif-implement will run /aif-docs after completion
+
+## Research Context (optional)
+Source: .ai-factory/RESEARCH.md (Active Summary)
+Goal: Add OAuth + email login
+Constraints: Must support existing session middleware
+Decisions: Use JWT for API auth
+Open questions: Do we need refresh tokens?
 
 ## Commit Plan
 - **Commit 1** (tasks 1-3): "feat: add user model and types"

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -14,9 +14,9 @@ Explore ideas, constraints, and trade-offs before planning:
 /aif-explore add-auth-system
 ```
 - Uses a thinking-partner mode: open questions, option mapping, and ASCII visualization
-- Reads project context from `.ai-factory/DESCRIPTION.md`, `ARCHITECTURE.md`, `RULES.md`, and active plan files when present
+- Reads project context from `.ai-factory/DESCRIPTION.md`, `ARCHITECTURE.md`, `RULES.md`, `.ai-factory/RESEARCH.md`, and active plan files when present
 - Does **not** implement code in this mode; when direction is clear, move to `/aif-plan`
-- Can capture decisions in context files on request (for example architecture notes, rules, and roadmap updates)
+- Can optionally persist exploration context to `.ai-factory/RESEARCH.md` so you can `/clear` and still feed results into `/aif-plan`
 
 ### `/aif-plan [fast|full] <description>`
 Plans implementation for a feature or task:
@@ -31,6 +31,8 @@ Two modes:
 - **Full** — creates git branch (`feature/user-authentication`), asks about testing/logging/docs, saves plan to `.ai-factory/plans/<branch>.md`
 
 Both modes explore your codebase for patterns, create tasks with dependencies, and include commit checkpoints for 5+ tasks.
+
+If `.ai-factory/RESEARCH.md` exists, `/aif-plan` reads the `Active Summary` and includes it as `Research Context` in the plan.
 
 **Parallel mode** — work on multiple features simultaneously using `git worktree`:
 ```

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -50,11 +50,13 @@ The repeatable development loop. Each skill feeds into the next, sharing context
 
 Optional discovery step: use `/aif-explore` before planning to investigate ideas, compare options, and clarify requirements.
 
+If you want exploration results to survive `/clear` and feed directly into planning, ask it to save to `.ai-factory/RESEARCH.md`.
+
 ![workflow](https://github.com/lee-to/ai-factory/raw/2.x/art/workflow.png)
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                       DEVELOPMENT WORKFLOW                               │
+│                       DEVELOPMENT WORKFLOW                              │
 └─────────────────────────────────────────────────────────────────────────┘
 
                ┌──────────────────────────┐                         ┌──────────────┐
@@ -141,7 +143,7 @@ Optional discovery step: use `/aif-explore` before planning to investigate ideas
 
 | Command | Use Case | Creates Branch? | Creates Plan? |
 |---------|----------|-----------------|---------------|
-| `/aif-explore` | Discovery, option comparison, and requirements clarification before planning | No | No (reads existing context) |
+| `/aif-explore` | Discovery, option comparison, and requirements clarification before planning | No | No (optional `.ai-factory/RESEARCH.md` on request) |
 | `/aif-roadmap` | Strategic planning, milestones, long-term vision | No | `.ai-factory/ROADMAP.md` |
 | `/aif-plan fast` | Small tasks, quick fixes, experiments | No | `.ai-factory/PLAN.md` |
 | `/aif-plan full` | Full features, stories, epics | Yes | `.ai-factory/plans/<branch>.md` |
@@ -163,7 +165,7 @@ These skills form the development pipeline. Each one feeds into the next.
 /aif-explore add-auth-system
 ```
 
-Thinking-partner mode for exploring ideas, constraints, and trade-offs without implementing code. Reads `.ai-factory/DESCRIPTION.md`, `ARCHITECTURE.md`, `RULES.md`, and active plan files for context. When direction is clear, transition to `/aif-plan fast` or `/aif-plan full`.
+Thinking-partner mode for exploring ideas, constraints, and trade-offs without implementing code. Reads `.ai-factory/DESCRIPTION.md`, `ARCHITECTURE.md`, `RULES.md`, `.ai-factory/RESEARCH.md`, and active plan files for context. If you want the context to persist across sessions (or after `/clear`), save it to `.ai-factory/RESEARCH.md`. When direction is clear, transition to `/aif-plan fast` or `/aif-plan full`.
 
 ### `/aif-roadmap [check | vision]` — strategic planning
 

--- a/scripts/security-self-scan.sh
+++ b/scripts/security-self-scan.sh
@@ -8,15 +8,30 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCANNER="$ROOT_DIR/skills/aif-skill-generator/scripts/security-scan.py"
 ALLOWLIST="$ROOT_DIR/scripts/security-scan-allowlist-ai-factory.json"
 
-PYTHON_BIN="$(command -v python3 || command -v python || true)"
-if [[ -z "$PYTHON_BIN" ]]; then
-    echo "ERROR: Python not found (python3/python)."
+try_python3() {
+    # Some environments (notably Windows Git Bash) may have a non-functional
+    # python3 shim earlier in PATH. Verify we can actually execute Python 3.
+    local -a cmd=("$@")
+    "${cmd[@]}" -c 'import sys; raise SystemExit(0 if sys.version_info[0] == 3 else 1)' >/dev/null 2>&1
+}
+
+PYTHON_CMD=()
+if try_python3 python3; then
+    PYTHON_CMD=(python3)
+elif try_python3 python; then
+    PYTHON_CMD=(python)
+elif try_python3 py -3; then
+    PYTHON_CMD=(py -3)
+elif try_python3 py; then
+    PYTHON_CMD=(py)
+else
+    echo "ERROR: Python 3 not found (python3/python/py)."
     exit 3
 fi
 
 set +e
 # Self-scan focuses on skill markdown/reference content; scanner source code is out of scope here.
-"$PYTHON_BIN" "$SCANNER" --md-only --allowlist "$ALLOWLIST" "$ROOT_DIR/skills"
+"${PYTHON_CMD[@]}" "$SCANNER" --md-only --allowlist "$ALLOWLIST" "$ROOT_DIR/skills"
 EXIT_CODE=$?
 set -e
 

--- a/skills/aif-explore/SKILL.md
+++ b/skills/aif-explore/SKILL.md
@@ -2,13 +2,13 @@
 name: aif-explore
 description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
 argument-hint: "[topic or plan name]"
-allowed-tools: Read Glob Grep Bash AskUserQuestion Questions
+allowed-tools: Read Glob Grep Write Edit Bash AskUserQuestion Questions
 disable-model-invocation: true
 ---
 
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
 
-**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks to implement something, remind them to exit explore mode first (e.g., start with `/aif-plan`). You MAY update AI Factory context files (DESCRIPTION.md, ARCHITECTURE.md, RULES.md) if the user asks—that's capturing thinking, not implementing.
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER implement features or modify project code. If the user asks to implement something, remind them to exit explore mode first (e.g., start with `/aif-plan`). If the user asks to persist exploration context, write/edit **only** `.ai-factory/RESEARCH.md` (this is capturing thinking, not implementing).
 
 **This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
 
@@ -83,6 +83,7 @@ At the start, read these files if present:
 - `.ai-factory/DESCRIPTION.md` — project description, tech stack, constraints
 - `.ai-factory/ARCHITECTURE.md` — architecture decisions, folder structure
 - `.ai-factory/RULES.md` — project conventions and rules
+- `.ai-factory/RESEARCH.md` — persisted exploration notes (so you can `/clear` and still keep context)
 - `.ai-factory/PLAN.md` — active fast plan (if any)
 - `.ai-factory/plans/<branch>.md` — active full plans (if any)
 - `.ai-factory/ROADMAP.md` — strategic milestones (if any)
@@ -91,6 +92,7 @@ This tells you:
 - What the project is about
 - What conventions to follow
 - If there's active work in progress
+- Any prior exploration context worth carrying into planning
 
 ### Input handling
 
@@ -122,21 +124,80 @@ If the user mentions a plan or you detect one is relevant:
 
 3. **Offer to capture when decisions are made**
 
-   | Insight Type | Where to Capture |
-   |--------------|------------------|
-   | New requirement | `.ai-factory/DESCRIPTION.md` (stack section) |
-   | Architecture decision | `.ai-factory/ARCHITECTURE.md` |
-   | Project convention | `.ai-factory/RULES.md` |
-   | New task/feature | Run `/aif-plan` to create plan |
-   | Strategic direction | `.ai-factory/ROADMAP.md` |
-   | Assumption invalidated | Relevant file |
+   Default in explore mode: capture everything in `.ai-factory/RESEARCH.md` so it survives `/clear`.
+   Later (during planning), you can migrate stabilized decisions into the appropriate context file.
+
+   | Insight Type | Capture Now (Explore) | Later (Optional) |
+   |--------------|------------------------|------------------|
+   | New requirement | `.ai-factory/RESEARCH.md` | `.ai-factory/DESCRIPTION.md` |
+   | Architecture decision | `.ai-factory/RESEARCH.md` | `.ai-factory/ARCHITECTURE.md` |
+   | Project convention | `.ai-factory/RESEARCH.md` | `.ai-factory/RULES.md` |
+   | Strategic direction | `.ai-factory/RESEARCH.md` | `.ai-factory/ROADMAP.md` |
+   | Assumption invalidated | `.ai-factory/RESEARCH.md` | Relevant file |
+   | Exploration context (persisted) | `.ai-factory/RESEARCH.md` | (keep in RESEARCH) |
+   | New task/feature | Run `/aif-plan` | `.ai-factory/PLAN.md` or `.ai-factory/plans/<branch>.md` |
 
    Example offers:
-   - "That's an architecture decision. Add it to ARCHITECTURE.md?"
-   - "This is a new convention. Add it to RULES.md?"
-   - "This changes the plan. Update the plan file?"
+   - "Want me to save this to `.ai-factory/RESEARCH.md` so you can `/clear` and come back later?"
+   - "That's an architecture decision — save it to RESEARCH now and we can migrate it to ARCHITECTURE during planning."
 
 4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+### Optional: Persist exploration context (`.ai-factory/RESEARCH.md`)
+
+If the conversation is crystallizing (you're about to plan, you want to `/clear`, or you want to continue later), offer to save a compact, durable research snapshot.
+
+**Hard rule in explore mode:** If the user chooses to save, you may write/edit **only** `.ai-factory/RESEARCH.md` (and create the `.ai-factory/` directory if missing). Do not write or modify any other project files.
+
+Ask:
+
+```
+Save these exploration results to .ai-factory/RESEARCH.md so we can /clear and /aif-plan can reuse them?
+
+Options:
+1. Yes — update Active Summary + append a new Session (recommended)
+2. Yes — update Active Summary only
+3. No
+```
+
+If user selects (1) or (2):
+- Ensure `.ai-factory/` exists (`mkdir -p .ai-factory`)
+- If `.ai-factory/RESEARCH.md` does not exist, create it with this skeleton:
+
+```markdown
+# Research
+
+Updated: YYYY-MM-DD HH:MM
+Status: active
+
+## Active Summary (input for /aif-plan)
+<!-- aif:active-summary:start -->
+Topic:
+Goal:
+Constraints:
+Decisions:
+Open questions:
+Success signals:
+Next step:
+<!-- aif:active-summary:end -->
+
+## Sessions
+<!-- aif:sessions:start -->
+<!-- aif:sessions:end -->
+```
+
+- Update the `Updated:` timestamp
+- Replace only the content inside `aif:active-summary:start/end`
+- If user selected option (1), append a new session entry just before `<!-- aif:sessions:end -->`:
+
+```markdown
+### YYYY-MM-DD HH:MM — <short title>
+What changed:
+Key notes:
+Links (paths):
+```
+
+Keep prior sessions verbatim (do not rewrite history).
 
 ---
 

--- a/skills/aif-plan/SKILL.md
+++ b/skills/aif-plan/SKILL.md
@@ -34,6 +34,11 @@ Use this context when:
 - Planning file structure (follow project conventions)
 - **Follow architecture guidelines from `.ai-factory/ARCHITECTURE.md` when planning file structure and task organization**
 
+**OPTIONAL (recommended):** Read `.ai-factory/RESEARCH.md` if it exists:
+- Treat `## Active Summary (input for /aif-plan)` as an additional requirements source
+- Carry over constraints/decisions into tasks and plan settings
+- Prefer the summary over raw notes; use `## Sessions` only when you need deeper rationale
+
 ### Step 0.1: Ensure Git Repository
 
 ```bash
@@ -179,6 +184,7 @@ WORKTREE="../${DIRNAME}-<branch-name-with-hyphens>"
 # Project context
 cp .ai-factory/DESCRIPTION.md "${WORKTREE}/.ai-factory/DESCRIPTION.md" 2>/dev/null
 cp .ai-factory/ARCHITECTURE.md "${WORKTREE}/.ai-factory/ARCHITECTURE.md" 2>/dev/null
+cp .ai-factory/RESEARCH.md "${WORKTREE}/.ai-factory/RESEARCH.md" 2>/dev/null
 
 # Past lessons / patches
 cp -r .ai-factory/patches/ "${WORKTREE}/.ai-factory/patches/" 2>/dev/null
@@ -330,8 +336,13 @@ mkdir -p .ai-factory/plans  # only when saving to branch-named plan files
 - Title with feature name
 - Branch and creation date
 - `Settings` section (Testing, Logging, Docs)
+- `Research Context` section (optional, if `.ai-factory/RESEARCH.md` exists)
 - `Tasks` section grouped by phases
 - `Commit Plan` section when there are 5+ tasks
+
+If `.ai-factory/RESEARCH.md` exists:
+- Include `## Research Context` by copying only the `Active Summary` (do not paste full `Sessions`)
+- Keep it compact; it should be readable as a one-screen requirements snapshot
 
 Use the canonical template in `references/TASK-FORMAT.md` (Plan File Template).
 

--- a/skills/aif-plan/SKILL.md
+++ b/skills/aif-plan/SKILL.md
@@ -38,6 +38,7 @@ Use this context when:
 - Treat `## Active Summary (input for /aif-plan)` as an additional requirements source
 - Carry over constraints/decisions into tasks and plan settings
 - Prefer the summary over raw notes; use `## Sessions` only when you need deeper rationale
+ - If the user omitted the feature description, use `Active Summary -> Topic:` as the default description
 
 ### Step 0.1: Ensure Git Repository
 
@@ -62,6 +63,10 @@ full        → Full mode (first word)
 - Remaining text becomes the description
 - `--list` and `--cleanup` execute immediately and **STOP** (do NOT continue to Step 1+)
 
+**If the description is empty:**
+- If `.ai-factory/RESEARCH.md` exists and its `Active Summary` has a non-empty `Topic:`, default the description to that topic (no extra user input required)
+- Otherwise, ask the user for a short feature description
+
 **If `--list` is present**, jump to [--list Subcommand](#--list-subcommand).
 **If `--cleanup` is present**, jump to [--cleanup Subcommand](#--cleanup-subcommand).
 
@@ -77,6 +82,10 @@ Options:
 1. Full (Recommended) — creates git branch, asks preferences, full plan
 2. Fast — quick plan, no branch, saves to PLAN.md
 ```
+
+If the user did not provide a description and `.ai-factory/RESEARCH.md` exists:
+- Mention that you will default the description to the `Active Summary` topic
+- Only ask for `full` vs `fast` (no description prompt needed)
 
 For concrete parsing examples and expected behavior per command shape, read `references/EXAMPLES.md` (Argument Parsing).
 

--- a/skills/aif-plan/references/EXAMPLES.md
+++ b/skills/aif-plan/references/EXAMPLES.md
@@ -16,6 +16,14 @@
 -> mode=full, description="Add user authentication with OAuth"
 ```
 
+### Full mode with description omitted (defaults from RESEARCH.md)
+
+```text
+/aif-plan full
+-> mode=full
+-> description defaults to .ai-factory/RESEARCH.md Active Summary Topic (if present)
+```
+
 ### Full mode with parallel worktree
 
 ```text
@@ -42,6 +50,14 @@
 ```text
 /aif-plan Add user authentication
 -> ask mode interactively, description="Add user authentication"
+```
+
+### No mode + no description (defaults from RESEARCH.md)
+
+```text
+/aif-plan
+-> ask mode interactively
+-> description defaults to .ai-factory/RESEARCH.md Active Summary Topic (if present)
 ```
 
 ## Flow Scenarios

--- a/skills/aif-plan/references/TASK-FORMAT.md
+++ b/skills/aif-plan/references/TASK-FORMAT.md
@@ -13,6 +13,15 @@ Created: [date]
 - Logging: verbose/standard/minimal
 - Docs: yes/no
 
+## Research Context (optional)
+<!-- If .ai-factory/RESEARCH.md exists, copy/paste the Active Summary here -->
+Source: .ai-factory/RESEARCH.md (Active Summary)
+
+Goal:
+Constraints:
+Decisions:
+Open questions:
+
 ## Commit Plan
 <!-- For plans with 5+ tasks, define commit checkpoints -->
 - **Commit 1** (after tasks 1-3): "feat: add base models and types"


### PR DESCRIPTION
## What
- Add optional `.ai-factory/RESEARCH.md` as a persisted bridge between `/aif-explore` and `/aif-plan`.
- Keep an up-to-date `Active Summary` for planning + append-only `Sessions` so context survives `/clear` without losing details.

## Key Changes
- `/aif-explore`: allow persisting insights to `.ai-factory/RESEARCH.md` (and **only** that file) when the user opts in.
- `/aif-plan`: read `RESEARCH.md` (Active Summary), include it as `Research Context` in the plan, and copy it into `full --parallel` worktrees.
- Docs: document `RESEARCH.md` usage in workflow and plan-file docs.
- Fix internal `security-self-scan.sh` to reliably find a working Python on Windows Git Bash (python3 shim fallback).

## Testing
- `npm test`