### PR TITLE
feat(skills): add docs policy checkpoint and warn-only mode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+* text=auto eol=lf
 *.sh text eol=lf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,10 @@ Prompts for commits at checkpoints
     ↓
 Checks .ai-factory/ROADMAP.md → marks completed milestones
     ↓
+Docs policy:
+    - Docs: yes → mandatory docs checkpoint (update/create/skip) routed via /aif-docs
+    - Docs: no or unset → WARN [docs] only (no mandatory prompt)
+    ↓
 Offers to delete PLAN.md when done (keeps feature-*.md)
 
 /aif-fix <bug description>

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ AI Factory can generate and maintain your project docs with a single command:
 
 - **Generates docs from scratch** — analyzes your codebase and creates a lean README + detailed `docs/` pages by topic
 - **Cleans up scattered files** — finds loose CONTRIBUTING.md, ARCHITECTURE.md, SETUP.md in your root and consolidates them into a structured `docs/` directory
-- **Keeps docs in sync** — integrates with `/aif-implement` so documentation is updated automatically after each feature
+- **Keeps docs in sync** — integrates with `/aif-implement` docs policy (`Docs: yes` = mandatory docs checkpoint routed to `/aif-docs`, `Docs: no` = visible `WARN [docs]`)
 - **Builds a docs website** — `--web` generates a static HTML site with navigation and dark mode, ready to host
 
 ---

--- a/docs/plan-files.md
+++ b/docs/plan-files.md
@@ -51,7 +51,7 @@ Created: 2024-01-15
 ## Settings
 - Testing: no
 - Logging: verbose
-- Docs: yes          # /aif-implement will run /aif-docs after completion
+- Docs: yes          # /aif-implement shows mandatory docs checkpoint, then routes through /aif-docs
 
 ## Research Context (optional)
 Source: .ai-factory/RESEARCH.md (Active Summary)

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -28,7 +28,7 @@ Plans implementation for a feature or task:
 
 Two modes:
 - **Fast** — no git branch, saves plan to `.ai-factory/PLAN.md`, asks fewer questions
-- **Full** — creates git branch (`feature/user-authentication`), asks about testing/logging/docs, saves plan to `.ai-factory/plans/<branch>.md`
+- **Full** — creates git branch (`feature/user-authentication`), asks about testing/logging/docs policy, saves plan to `.ai-factory/plans/<branch>.md`
 
 Both modes explore your codebase for patterns, create tasks with dependencies, and include commit checkpoints for 5+ tasks.
 
@@ -121,7 +121,10 @@ Executes the plan:
 - `--list` mode is read-only: shows available plan files and exits
 - Executes tasks one by one
 - Prompts for commits at checkpoints
-- If plan has `Docs: yes` — runs `/aif-docs` after completion
+- Docs policy after completion:
+  - `Docs: yes` → mandatory documentation checkpoint (update docs / create feature page / skip)
+  - `Docs: no` or unset → `WARN [docs]` only (no mandatory checkpoint)
+  - Docs updates are always routed through `/aif-docs`
 - Offers to delete .ai-factory/PLAN.md when done
 
 ### `/aif-verify [--strict]`
@@ -238,7 +241,7 @@ Generates and maintains project documentation:
 
 **Scattered .md cleanup** — finds loose markdown files in your project root (CONTRIBUTING.md, ARCHITECTURE.md, SETUP.md, DEPLOYMENT.md, etc.) and proposes consolidating them into a structured `docs/` directory. No more documentation scattered across 10 root-level files.
 
-**Stays in sync with your code** — when `/aif-plan full` asks "Update documentation?" and you say yes, the plan gets `Docs: yes`. After `/aif-implement` finishes all tasks, it automatically runs `/aif-docs` to update documentation. Your docs grow with your codebase, not after the fact.
+**Stays in sync with your code** — when `/aif-plan full` asks for docs policy and you choose `Docs: yes`, `/aif-implement` shows a mandatory docs checkpoint and routes changes through `/aif-docs`. If `Docs: no` (or unset), `/aif-implement` emits `WARN [docs]` so potential drift is visible without blocking the flow.
 
 **Documentation website** — `--web` flag generates a complete static HTML site in `docs-html/` with navigation bar, dark mode support, and clean typography. Ready to host on GitHub Pages or any static hosting.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -207,7 +207,7 @@ High-level project planning. Creates `.ai-factory/ROADMAP.md` — a strategic ch
 /aif-plan full --parallel Add Stripe checkout      # Parallel worktree
 ```
 
-Two modes — **fast** (no branch, saves to `.ai-factory/PLAN.md`) and **full** (creates git branch, asks about testing/logging/docs and optional roadmap milestone linkage when `.ai-factory/ROADMAP.md` exists, saves to `.ai-factory/plans/<branch>.md`). Analyzes requirements, explores codebase for patterns, creates tasks with dependencies. For 5+ tasks, includes commit checkpoints. For parallel work on multiple features, use `full --parallel` to create isolated worktrees.
+Two modes — **fast** (no branch, saves to `.ai-factory/PLAN.md`) and **full** (creates git branch, asks about testing/logging/docs policy and optional roadmap milestone linkage when `.ai-factory/ROADMAP.md` exists, saves to `.ai-factory/plans/<branch>.md`). Analyzes requirements, explores codebase for patterns, creates tasks with dependencies. For 5+ tasks, includes commit checkpoints. For parallel work on multiple features, use `full --parallel` to create isolated worktrees.
 
 ### `/aif-improve [--list] [@plan-file] [prompt]` — refine the plan
 
@@ -245,7 +245,7 @@ For full contracts and state transition rules, see [Reflex Loop](loop.md).
 /aif-implement status # Check progress
 ```
 
-Reads past patches from `.ai-factory/patches/` to learn from previous mistakes, then executes tasks one by one with commit checkpoints. Plan source priority: `@plan-file` argument, then branch-based `.ai-factory/plans/<branch>.md`, then `.ai-factory/PLAN.md`, then `.ai-factory/FIX_PLAN.md` (redirects to `/aif-fix`). `--list` is a read-only discovery mode that shows available plan files and exits. If the plan has `Docs: yes`, runs `/aif-docs` after completion.
+Reads past patches from `.ai-factory/patches/` to learn from previous mistakes, then executes tasks one by one with commit checkpoints. Plan source priority: `@plan-file` argument, then branch-based `.ai-factory/plans/<branch>.md`, then `.ai-factory/PLAN.md`, then `.ai-factory/FIX_PLAN.md` (redirects to `/aif-fix`). `--list` is a read-only discovery mode that shows available plan files and exits. Docs policy after completion: `Docs: yes` → mandatory docs checkpoint (update docs / create feature page / skip, routed via `/aif-docs`), `Docs: no` or unset → `WARN [docs]` only.
 
 ### `/aif-verify [--strict]` — check completeness
 

--- a/skills/aif-implement/SKILL.md
+++ b/skills/aif-implement/SKILL.md
@@ -364,6 +364,7 @@ Files modified:
 - src/services/search.ts (created)
 - src/api/products/search.ts (created)
 - src/types/search.ts (created)
+Documentation: updated existing docs | created docs/<feature-slug>.md | skipped by user | warn-only (Docs: no/unset)
 
 What's next?
 
@@ -439,17 +440,35 @@ Options:
 If user chooses "Verify first" → suggest invoking `/aif-verify`.
 If user chooses "Skip to commit" → suggest invoking `/aif-commit`.
 
-**Check if documentation needs updating:**
+**Documentation policy checkpoint (after completion, before plan cleanup):**
 
-Read the plan file settings. If documentation preference is set to "yes" (from `/aif-plan full` questions), run `/aif-docs` to update documentation.
+Read the plan file setting `Docs: yes/no`.
 
-If documentation preference is "no" or not set — skip this step silently.
-
-If documentation preference is "yes":
+If plan setting is `Docs: yes`:
 ```
-📝 Updating project documentation...
+AskUserQuestion: Documentation checkpoint — how should we document this feature?
+
+Options:
+1. Update existing docs (recommended) — invoke /aif-docs
+2. Create a new feature doc page — invoke /aif-docs with feature-page context
+3. Skip documentation
 ```
-→ Invoke `/aif-docs` to analyze changes and update docs.
+
+Handling:
+- Option 1 → invoke `/aif-docs` to update README/docs based on completed work
+- Option 2 → invoke `/aif-docs` with context to create `docs/<feature-slug>.md`, include sections (Summary, Usage/user-facing behavior, Configuration, API/CLI changes, Examples, Troubleshooting, See Also), and add a README docs-table link
+- Option 3 → do not invoke `/aif-docs`; emit `WARN [docs] Documentation skipped by user`
+
+If plan setting is `Docs: no` or setting is unset:
+- Do **not** show a mandatory docs checkpoint prompt
+- Do **not** invoke `/aif-docs` automatically
+- Emit `WARN [docs] Docs policy is no/unset; skipping documentation checkpoint`
+
+**Always include documentation outcome in the final completion output:**
+- `Documentation: updated existing docs`
+- `Documentation: created docs/<feature-slug>.md`
+- `Documentation: skipped by user`
+- `Documentation: warn-only (Docs: no/unset)`
 
 **Handle plan file after completion:**
 

--- a/skills/aif-plan/SKILL.md
+++ b/skills/aif-plan/SKILL.md
@@ -174,9 +174,9 @@ AskUserQuestion: Before we start, a few questions:
    - [ ] Standard - INFO level, key events only
    - [ ] Minimal - only WARN/ERROR
 
-3. Update documentation after implementation?
-   - [ ] Yes, update docs (/aif-docs)
-   - [ ] No, skip docs
+3. Documentation policy after implementation?
+   - [ ] Yes — mandatory docs checkpoint at completion (recommended)
+   - [ ] No — warn-only (`WARN [docs]`), no mandatory checkpoint
 
 4. Roadmap milestone linkage (only if `.ai-factory/ROADMAP.md` exists):
    - [ ] Link this plan to a milestone
@@ -191,6 +191,10 @@ AskUserQuestion: Before we start, a few questions:
 - Missing logs during development wastes debugging time
 
 Store all preferences — they will be used in the plan file and passed to `/aif-implement`.
+
+Docs policy semantics:
+- `Docs: yes` → `/aif-implement` MUST show a mandatory documentation checkpoint and route docs changes through `/aif-docs`
+- `Docs: no` (or unset) → `/aif-implement` emits `WARN [docs]` and continues without a mandatory docs checkpoint
 
 **If `.ai-factory/ROADMAP.md` exists and the user chose milestone linkage:**
 - Read `.ai-factory/ROADMAP.md` and list candidate milestones (prefer unchecked items)
@@ -414,7 +418,7 @@ CONTEXT FROM /aif-plan:
 - Plan file: .ai-factory/plans/<branch-name>.md
 - Testing: yes/no
 - Logging: verbose/standard/minimal
-- Docs: yes/no
+- Docs: yes/no  # yes => mandatory docs checkpoint, no => warn-only
 ```
 
 **Full mode normal:** STOP after planning. The user reviews the plan and decides when to implement.

--- a/skills/aif-plan/references/TASK-FORMAT.md
+++ b/skills/aif-plan/references/TASK-FORMAT.md
@@ -11,7 +11,7 @@ Created: [date]
 ## Settings
 - Testing: yes/no
 - Logging: verbose/standard/minimal
-- Docs: yes/no
+- Docs: yes/no  # yes => mandatory docs checkpoint in /aif-implement, no/unset => WARN [docs] only
 
 ## Roadmap Linkage (optional)
 <!-- Only when .ai-factory/ROADMAP.md exists -->


### PR DESCRIPTION
Update /aif-implement documentation behavior so Docs: yes requires a completion checkpoint and Docs: no/unset emits WARN [docs] without blocking flow. Align /aif-plan templates, workflow docs, README, and AGENTS guidance with the new policy, and enforce LF line endings via .gitattributes.