### PR TITLE
feat: self update

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,12 @@ npx ai-factory init
 ### Upgrading from v1 to v2
 
 ```bash
-# 1) Update the CLI package
-npm install -g ai-factory@latest
-
-# 2) Migrate existing skills to v2 naming
 ai-factory upgrade
 ```
 
 `ai-factory upgrade` removes old bare-named skills (`commit`, `feature`, etc.) and installs new `aif-*` prefixed versions. Custom skills are preserved.
+
+> **Note:** `ai-factory update` automatically checks npm for a newer CLI version and offers to install it before updating skills. You no longer need to run `npm install -g ai-factory@latest` manually.
 
 ### Example Workflow
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,13 +62,10 @@ If scope is unclear, start with `/aif-explore` (optionally save results to `.ai-
 ## CLI Commands
 
 ```bash
-# Update npm package to latest version
-npm install -g ai-factory@latest
-
 # Initialize project
 ai-factory init
 
-# Update skills to latest version
+# Update skills to latest version (also checks for CLI updates)
 ai-factory update
 
 # Migrate existing skills from v1 naming to v2 naming
@@ -84,9 +81,7 @@ ai-factory extension list
 ai-factory extension remove my-extension
 ```
 
-For v1 -> v2 migration, run both commands in order:
-1. `npm install -g ai-factory@latest`
-2. `ai-factory upgrade`
+For v1 -> v2 migration, run `ai-factory upgrade` to rename old skills to the new `aif-*` prefix.
 
 ## Next Steps
 

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,5 +1,8 @@
 import chalk from 'chalk';
 import path from 'path';
+import {realpathSync} from 'fs';
+import {execSync} from 'child_process';
+import inquirer from 'inquirer';
 import {getCurrentVersion, loadConfig, saveConfig} from '../../core/config.js';
 import {getAvailableSkills, partitionSkills, updateSkills} from '../../core/installer.js';
 import {applyExtensionInjections} from '../../core/injections.js';
@@ -9,6 +12,107 @@ import {
   installSkillsForAllAgents,
   collectReplacedSkills,
 } from '../../core/extension-ops.js';
+
+function parseVersion(v: string): { parts: number[]; prerelease: string | null } {
+  const [core, ...rest] = v.split('-');
+  return {
+    parts: core.split('.').map(Number),
+    prerelease: rest.length > 0 ? rest.join('-') : null,
+  };
+}
+
+function isNewerVersion(latest: string, current: string): boolean {
+  const l = parseVersion(latest);
+  const c = parseVersion(current);
+  for (let i = 0; i < 3; i++) {
+    if ((l.parts[i] ?? 0) > (c.parts[i] ?? 0)) return true;
+    if ((l.parts[i] ?? 0) < (c.parts[i] ?? 0)) return false;
+  }
+  // Equal major.minor.patch: prerelease is older than stable (semver §11)
+  if (c.prerelease && !l.prerelease) return true;
+  if (!c.prerelease && l.prerelease) return false;
+  return false;
+}
+
+async function getLatestVersion(): Promise<string | null> {
+  try {
+    const response = await fetch('https://registry.npmjs.org/ai-factory/latest', {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) return null;
+    const data = await response.json() as {version: string};
+    if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(data.version)) return null;
+    return data.version;
+  } catch {
+    return null;
+  }
+}
+
+function getInstallCommand(version: string): string {
+  try {
+    const whichCmd = process.platform === 'win32' ? 'where' : 'which';
+    const binPath = execSync(`${whichCmd} ai-factory`, {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).split('\n')[0].trim();
+    const realPath = realpathSync(binPath).replaceAll('\\', '/');
+
+    if (realPath.includes('.bun/')) return `bun add -g ai-factory@${version}`;
+    if (realPath.includes('/mise/')) return `mise use -g npm:ai-factory@${version}`;
+    if (realPath.includes('/volta/')) return `volta install ai-factory@${version}`;
+    if (realPath.includes('/pnpm/')) return `pnpm add -g ai-factory@${version}`;
+    if (realPath.includes('/yarn/')) return `yarn global add ai-factory@${version}`;
+  } catch {
+    // Binary not found or symlink resolution failed, default to npm
+  }
+  return `npm install -g ai-factory@${version}`;
+}
+
+async function selfUpdate(currentVersion: string): Promise<boolean> {
+  const latestVersion = await getLatestVersion();
+  if (!latestVersion) {
+    console.log(chalk.dim('Could not check for new versions\n'));
+    return false;
+  }
+
+  if (!isNewerVersion(latestVersion, currentVersion)) {
+    console.log(chalk.dim('ai-factory is up to date\n'));
+    return false;
+  }
+
+  console.log(chalk.cyan(`📦 New version available: ${currentVersion} → ${latestVersion}`));
+
+  if (!process.stdin.isTTY) {
+    console.log(chalk.dim('Non-interactive mode — skipping self-update\n'));
+    return false;
+  }
+
+  const {shouldUpdate} = await inquirer.prompt([{
+    type: 'confirm',
+    name: 'shouldUpdate',
+    message: `Update ai-factory to ${latestVersion}?`,
+    default: true,
+  }]);
+
+  if (!shouldUpdate) {
+    console.log(chalk.dim('Skipping package update\n'));
+    return false;
+  }
+
+  try {
+    const installCmd = getInstallCommand(latestVersion);
+    console.log(chalk.dim(`\n$ ${installCmd}`));
+    execSync(installCmd, {stdio: 'inherit'});
+    console.log(chalk.green(`\n✓ Updated to ${latestVersion}`));
+    console.log(chalk.cyan('Please re-run `ai-factory update` to update skills with the new version.\n'));
+    process.exitCode = 75; // EX_TEMPFAIL — signals caller to re-run
+    return true;
+  } catch (error) {
+    console.log(chalk.yellow(`⚠ Self-update failed: ${(error as Error).message}`));
+    return false;
+  }
+}
 
 export async function updateCommand(): Promise<void> {
   const projectDir = process.cwd();
@@ -27,6 +131,9 @@ export async function updateCommand(): Promise<void> {
 
   console.log(chalk.dim(`Config version: ${config.version}`));
   console.log(chalk.dim(`Package version: ${currentVersion}\n`));
+
+  const selfUpdated = await selfUpdate(currentVersion);
+  if (selfUpdated) return;
 
   console.log(chalk.dim('Updating skills...\n'));
 


### PR DESCRIPTION
# Self-update for ai-factory update                                                                                                                                   
                                                                                                                                                                      
The update command now checks the npm registry for a newer version of the ai-factory CLI before updating skills. If a new version is available, it prompts the user to install it automatically, detecting the correct package manager (npm, yarn, pnpm, bun, volta, mise) from the binary's real path. Non-interactive environments
(CI/CD) skip the prompt gracefully. On successful self-update, the process exits with code 75 (EX_TEMPFAIL) to signal the caller to re-run.