### PR TITLE
feat(cli): show concise hints in init skill picker

### DIFF
--- a/src/cli/wizard/prompts.ts
+++ b/src/cli/wizard/prompts.ts
@@ -1,6 +1,8 @@
 import inquirer from 'inquirer';
+import chalk from 'chalk';
 import { getAvailableSkills } from '../../core/installer.js';
 import { getAgentConfig, getAgentChoices } from '../../core/agents.js';
+import { formatSkillChoiceName } from './skill-hints.js';
 
 export interface AgentWizardSelection {
   id: string;
@@ -43,7 +45,8 @@ export async function runWizard(defaultAgentIds: string[] = []): Promise<WizardA
       name: 'selectedSkills',
       message: 'Base skills to install:',
       choices: availableSkills.map(skill => ({
-        name: skill,
+        name: formatSkillChoiceName(skill, hint => chalk.gray(hint)),
+        short: skill,
         value: skill,
         checked: true, // All skills selected by default
       })),

--- a/src/cli/wizard/skill-hints.ts
+++ b/src/cli/wizard/skill-hints.ts
@@ -1,0 +1,49 @@
+const SKILL_HINTS: Record<string, string> = {
+    'aif': 'Set up AI context',
+    'aif-architecture': 'Generate architecture guide',
+    'aif-best-practices': 'Clean code guidelines',
+    'aif-build-automation': 'Build file automation',
+    'aif-ci': 'CI/CD pipeline setup',
+    'aif-commit': 'Conventional commit helper',
+    'aif-dockerize': 'Docker and Compose setup',
+    'aif-docs': 'Docs generation and maintenance',
+    'aif-evolve': 'Evolve skills from patches',
+    'aif-explore': 'Explore ideas and options',
+    'aif-fix': 'Fix specific bugs quickly',
+    'aif-grounded': 'Reliability gate (no guesses)',
+    'aif-implement': 'Execute current plan tasks',
+    'aif-improve': 'Improve existing plan quality',
+    'aif-loop': 'Iterative quality refinement loop',
+    'aif-plan': 'Plan tasks for feature',
+    'aif-review': 'Review staged changes/PR',
+    'aif-roadmap': 'Roadmap and milestones',
+    'aif-rules': 'Project rules and conventions',
+    'aif-security-checklist': 'Security audit checklist',
+    'aif-skill-generator': 'Generate new agent skills',
+    'aif-verify': 'Verify implementation completeness',
+};
+
+const DEFAULT_SKILL_HINT = 'Additional custom skill';
+const DEFAULT_HINT_MAX_LENGTH = 44;
+
+function truncateHint(hint: string, maxLength: number): string {
+    if (hint.length <= maxLength) {
+        return hint;
+    }
+
+    const base = hint.slice(0, Math.max(0, maxLength - 3)).trimEnd();
+    return `${base}...`;
+}
+
+export function getSkillHint(skillId: string): string {
+    return SKILL_HINTS[skillId] ?? DEFAULT_SKILL_HINT;
+}
+
+export function formatSkillChoiceName(
+    skillId: string,
+    renderHint: (hint: string) => string,
+    maxHintLength: number = DEFAULT_HINT_MAX_LENGTH,
+): string {
+    const hint = truncateHint(getSkillHint(skillId), maxHintLength);
+    return `${skillId} ${renderHint(`- ${hint}`)}`;
+}


### PR DESCRIPTION
В `ai-factory init` в списке “Base skills to install” теперь показывается короткий hint (на английском) рядом с названием каждого базового skill’а, подсвеченный серым (менее заметным) цветом.

Важно:
- `value` выбора не менялся (по-прежнему устанавливаются те же skill id)
- добавлен `short: skill`, чтобы итоговое summary после выбора не засорялось подсказками
- есть fallback для неизвестных/кастомных skill’ов + ограничение длины hint

Close #45 