### PR TITLE
docs: добавить сравнение aif-explore vs aif-grounded и их место в workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ ai-factory upgrade
 # Explore options and requirements before planning (optional)
 /aif-explore Add user authentication with OAuth
 
+# Need a strictly verified answer before changing anything?
+/aif-grounded Does this repo already support OAuth providers?
+
 # Plan a feature — creates branch, analyzes codebase, builds step-by-step plan
 /aif-plan Add user authentication with OAuth
 
@@ -139,9 +142,9 @@ AI Factory can generate and maintain your project docs with a single command:
 | Guide | Description |
 |-------|-------------|
 | [Getting Started](docs/getting-started.md) | What is AI Factory, supported agents, CLI commands |
-| [Development Workflow](docs/workflow.md) | Workflow diagram, when to use what, spec-driven approach |
+| [Development Workflow](docs/workflow.md) | Workflow diagram, when to use `explore` vs `grounded`, spec-driven approach |
 | [Reflex Loop](docs/loop.md) | Iterative generate → evaluate → critique → refine workflow |
-| [Core Skills](docs/skills.md) | All slash commands — explore, plan, fix, implement, evolve, docs, and more |
+| [Core Skills](docs/skills.md) | All slash commands — explore, grounded, plan, fix, implement, evolve, docs, and more |
 | [Skill Evolution](docs/evolve.md) | How /aif-fix patches feed into /aif-evolve to generate smarter skill rules |
 | [Plan Files](docs/plan-files.md) | Plan files, self-improvement patches, skill acquisition |
 | [Security](docs/security.md) | Two-level security scanning for external skills |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,7 +57,7 @@ ai-factory init
 /aif-plan Add user authentication with OAuth
 ```
 
-If scope is unclear, start with `/aif-explore` (optionally save results to `.ai-factory/RESEARCH.md`); if it is already clear, jump straight to `/aif-plan`. From there, AI Factory creates a branch (full mode), builds a plan, and you run `/aif-implement` to execute it step by step.
+If scope is unclear, start with `/aif-explore` (optionally save results to `.ai-factory/RESEARCH.md`); if the task is clear but the answer must be strictly verified, use `/aif-grounded`; if the direction is already clear, jump straight to `/aif-plan`. From there, AI Factory creates a branch (full mode), builds a plan, and you run `/aif-implement` to execute it step by step.
 
 ## CLI Commands
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -17,6 +17,7 @@ Explore ideas, constraints, and trade-offs before planning:
 - Reads project context from `.ai-factory/DESCRIPTION.md`, `ARCHITECTURE.md`, `RULES.md`, `.ai-factory/RESEARCH.md`, and active plan files when present
 - Does **not** implement code in this mode; when direction is clear, move to `/aif-plan`
 - Can optionally persist exploration context to `.ai-factory/RESEARCH.md` so you can `/clear` and still feed results into `/aif-plan`
+- Best when the problem is still fuzzy: requirements unclear, trade-offs unresolved, or you want to inspect the codebase before choosing a direction
 
 ### `/aif-plan [fast|full] <description>`
 Plans implementation for a feature or task:
@@ -213,6 +214,21 @@ Reliability gate that prevents guessing:
 - Only provides a final answer if confidence is **100/100** based on evidence (repo files, command output, provided docs)
 - If confidence is < 100, returns **INSUFFICIENT INFORMATION** with a concrete checklist of what’s needed to reach 100
 - Forces verification for changeable facts (“latest”, “current”, version-specific behavior)
+- Best when the task is already clear but the answer must be strictly verified: high-stakes questions, version-sensitive facts, or any prompt that says “no assumptions”
+
+#### `/aif-explore` vs `/aif-grounded`
+
+| Skill | Use it for | Output style | If things are unclear |
+|-------|------------|--------------|------------------------|
+| `/aif-explore` | discovery, requirement shaping, trade-off discussion, repo investigation before planning | open-ended thinking partner | keeps exploring, reframing, and comparing options |
+| `/aif-grounded` | evidence-only answers, strict verification, high-stakes or changeable facts | confidence-gated answer with explicit evidence | stops and returns `INSUFFICIENT INFORMATION` |
+
+Typical sequence when both are useful:
+1. `/aif-explore` — figure out what problem you are really solving.
+2. `/aif-grounded` — verify the important claims or current-state facts.
+3. `/aif-plan` — turn the clarified, verified direction into executable tasks.
+
+For the workflow view of where these fit, see [Development Workflow](workflow.md).
 
 ### `/aif-architecture [clean|ddd|microservices|monolith|layers]`
 Generates architecture guidelines tailored to your project:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -50,7 +50,9 @@ The repeatable development loop. Each skill feeds into the next, sharing context
 
 Optional discovery step: use `/aif-explore` before planning to investigate ideas, compare options, and clarify requirements.
 
-If you want exploration results to survive `/clear` and feed directly into planning, ask it to save to `.ai-factory/RESEARCH.md`.
+Reliability gate: use `/aif-grounded` when the main problem is not discovery but certainty - high-stakes answers, changeable facts, version-sensitive behavior, or any request where the model must refuse to guess.
+
+If you want exploration results to survive `/clear` and feed directly into planning, ask `/aif-explore` to save them to `.ai-factory/RESEARCH.md`.
 
 ![workflow](https://github.com/lee-to/ai-factory/raw/2.x/art/workflow.png)
 
@@ -58,6 +60,18 @@ If you want exploration results to survive `/clear` and feed directly into plann
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                       DEVELOPMENT WORKFLOW                              │
 └─────────────────────────────────────────────────────────────────────────┘
+
+   Need to think first?                         Need certainty first?
+          │                                             │
+          ▼                                             ▼
+   ┌───────────────┐                            ┌────────────────┐
+   │ /aif-explore  │                            │ /aif-grounded  │
+   │ clarify scope │                            │ verify facts   │
+   │ compare paths │                            │ reject guesses │
+   └───────┬───────┘                            └────────┬───────┘
+           │                                             │
+           └──────────────────────┬──────────────────────┘
+                                  ▼
 
                ┌──────────────────────────┐                         ┌──────────────┐
                │                          │                         │              │
@@ -144,6 +158,7 @@ If you want exploration results to survive `/clear` and feed directly into plann
 | Command | Use Case | Creates Branch? | Creates Plan? |
 |---------|----------|-----------------|---------------|
 | `/aif-explore` | Discovery, option comparison, and requirements clarification before planning | No | No (optional `.ai-factory/RESEARCH.md` on request) |
+| `/aif-grounded` | Evidence-only answers, strict verification, and high-stakes questions where guessing is unacceptable | No | No |
 | `/aif-roadmap` | Strategic planning, milestones, long-term vision | No | `.ai-factory/ROADMAP.md` |
 | `/aif-plan fast` | Small tasks, quick fixes, experiments | No | `.ai-factory/PLAN.md` |
 | `/aif-plan full` | Full features, stories, epics | Yes | `.ai-factory/plans/<branch>.md` |
@@ -187,6 +202,15 @@ These skills form the development pipeline. Each one feeds into the next.
 ```
 
 Thinking-partner mode for exploring ideas, constraints, and trade-offs without implementing code. Reads `.ai-factory/DESCRIPTION.md`, `ARCHITECTURE.md`, `RULES.md`, `.ai-factory/RESEARCH.md`, and active plan files for context. If you want the context to persist across sessions (or after `/clear`), save it to `.ai-factory/RESEARCH.md`. When direction is clear, transition to `/aif-plan fast` or `/aif-plan full`.
+
+### `/aif-grounded [question or task]` — certainty before action
+
+```
+/aif-grounded Does this repo already support feature flags?
+/aif-grounded Which command should I use if I need a fully verified answer?
+```
+
+Reliability-gate mode for evidence-backed answers. Use it when the task is already clear but the answer must be strictly verified: high-stakes requests, version-sensitive facts, current-state questions, or any prompt that says "no assumptions". Unlike `/aif-explore`, it is not for brainstorming or open-ended trade-off mapping; it either answers from evidence with `Confidence: 100/100` or stops with `INSUFFICIENT INFORMATION` and tells you what is missing.
 
 ### `/aif-roadmap [check | vision]` — strategic planning
 


### PR DESCRIPTION
## Что сделано

Добавил документацию, которая явно объясняет разницу между `/aif-explore` и `/aif-grounded` и показывает, где каждый навык используется в общем workflow.

### Изменения

**docs/workflow.md**
- Добавил `/aif-grounded` как reliability gate в development workflow
- Обновил ASCII-диаграмму: теперь показывает два optional pre-planning пути — explore для discovery, grounded для verification
- Добавил `/aif-grounded` в таблицу "When to Use What?"
- Добавил отдельный раздел с описанием `/aif-grounded`

**docs/skills.md**
- Расширил описание `/aif-explore` — добавил "когда использовать"
- Расширил описание `/aif-grounded` — добавил "когда использовать"
- Добавил comparison-таблицу `/aif-explore` vs `/aif-grounded`
- Добавил типичный порядок использования: explore → grounded → plan

**README.md**
- Добавил пример `/aif-grounded` в example workflow
- Обновил описания в таблице документации

**docs/getting-started.md**
- Добавил короткое правило выбора: `explore` для неясного scope, `grounded` для строго проверенного ответа

## Почему это важно

Раньше `/aif-grounded` был задокументирован только как utility skill без явного места в workflow. Пользователи могли не понимать, когда использовать `explore`, а когда `grounded`.

Теперь:
- Оба навыка показаны как optional pre-planning шаги с разным назначением
- Есть явная comparison-таблица и типичный порядок использования
- Новый пользователь может быстро выбрать нужный навык

## Скриншоты (optional)

ASCII-диаграмма из docs/workflow.md теперь показывает оба навыка:

```
   Need to think first?                         Need certainty first?
          │                                             │
          ▼                                             ▼
   ┌───────────────┐                            ┌────────────────┐
   │ /aif-explore  │                            │ /aif-grounded  │
   │ clarify scope │                            │ verify facts   │
   │ compare paths │                            │ reject guesses │
   └───────┬───────┘                            └────────┬───────┘
           │                                             │
           └──────────────────────┬──────────────────────┘
                                  ▼
                          /aif-plan
```

## Checklist

- [x] Документация обновлена
- [x] Нет изменений в коде (только docs)
- [x] Ссылки между документами корректны
