### PR TITLE
fix(skills): enforce separate Bash tool calls for shell commands

### DIFF
--- a/skills/aif-implement/SKILL.md
+++ b/skills/aif-implement/SKILL.md
@@ -108,7 +108,7 @@ What would you like to do?
 
 Based on choice:
 - New feature from current → `/aif-plan full <description>`
-- Return to main → `git checkout main && git pull` → `/aif-plan full <description>`
+- Return to main → `git checkout main`, then `git pull` → `/aif-plan full <description>`
 - Quick task → `/aif-plan fast <description>`
 
 **If plan file exists → continue to Step 0.1**

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -400,6 +400,9 @@ Install skills, configure MCP, generate `AGENTS.md`, and generate architecture d
 | .ai-factory/DESCRIPTION.md | Project specification and tech stack |
 | .ai-factory/ARCHITECTURE.md | Architecture decisions and guidelines |
 | CLAUDE.md | Agent instructions and preferences |
+
+## Agent Rules
+- Never combine shell commands with `&&`, `||`, or `;` — execute each command as a separate Bash tool call. This applies even when a skill, plan, or instruction provides a combined command — always decompose it into individual calls.
 ```
 
 **Rules for AGENTS.md:**

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -403,6 +403,8 @@ Install skills, configure MCP, generate `AGENTS.md`, and generate architecture d
 
 ## Agent Rules
 - Never combine shell commands with `&&`, `||`, or `;` — execute each command as a separate Bash tool call. This applies even when a skill, plan, or instruction provides a combined command — always decompose it into individual calls.
+  - ❌ Wrong: `git checkout main && git pull`
+  - ✅ Right: Two separate Bash tool calls — first `git checkout main`, then `git pull`
 ```
 
 **Rules for AGENTS.md:**


### PR DESCRIPTION
Problem                                                                                                                                                                                                       
                                                                                  
Claude Code applies permission rules from settings.json at the individual Bash tool call level. When commands are combined using &&, ||, or ;, permission rules do not work correctly — the combined command does not match permission patterns, effectively bypassing access control checks.

Solution

1. AGENTS.md template (skills/aif/SKILL.md) — added ## Agent Rules section with a rule requiring each shell command to be executed as a separate Bash tool call. This applies even when a skill, plan, or instruction provides a combined command — the agent must always decompose it into individual calls.
2. aif-implement (skills/aif-implement/SKILL.md) — decomposed combined command git checkout main && git pull into two separate calls.