### PR TITLE
feat(update): report skill status and add force reinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ ai-factory upgrade
 
 `ai-factory upgrade` removes old bare-named skills (`commit`, `feature`, etc.) and installs new `aif-*` prefixed versions. Custom skills are preserved.
 
-> **Note:** `ai-factory update` automatically checks npm for a newer CLI version and offers to install it before updating skills. You no longer need to run `npm install -g ai-factory@latest` manually.
+> **Note:** `ai-factory update` automatically checks npm for a newer CLI version and offers to install it before updating skills, then reports `changed/unchanged/skipped/removed` for installed base skills. Use `ai-factory update --force` for a clean reinstall of currently installed base skills.
 
 ### Example Workflow
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -40,7 +40,9 @@ ai-factory extension remove aif-ext-example
 
 ### What Happens on Update
 
-Running `ai-factory update` reinstalls base skills from scratch (skipping any skills replaced by extensions), re-installs replacement skills, then **re-applies all extension injections** automatically. MCP server configs and custom commands are not affected by updates.
+Running `ai-factory update` updates previously installed base skills, reports per-agent status (`changed`, `unchanged`, `skipped`, `removed`), skips base skills replaced by extensions, re-installs replacement skills, then **re-applies all extension injections** automatically. MCP server configs and custom commands are not affected by updates.
+
+`ai-factory update --force` performs a clean reinstall of currently installed base skills before extension replacement and injection re-apply. Replaced skills are still handled by extension manifests, and custom extension commands/MCP config remain intact.
 
 ### What Happens on Remove
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,6 +68,9 @@ ai-factory init
 # Update skills to latest version (also checks for CLI updates)
 ai-factory update
 
+# Force clean reinstall of currently installed base skills
+ai-factory update --force
+
 # Migrate existing skills from v1 naming to v2 naming
 ai-factory upgrade
 
@@ -82,6 +85,8 @@ ai-factory extension remove my-extension
 ```
 
 For v1 -> v2 migration, run `ai-factory upgrade` to rename old skills to the new `aif-*` prefix.
+
+`ai-factory update` now prints per-agent status buckets for base skills (`changed`, `unchanged`, `skipped`, `removed`). Skills newly available in the package but not previously installed are shown as `skipped` (not auto-installed).
 
 ## Next Steps
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "bash scripts/test-skills.sh",
+    "test:update": "bash scripts/test-update.sh",
     "lint:unused": "tsc --noEmit --noUnusedLocals --noUnusedParameters",
     "lint:dead": "knip --reporter compact",
     "lint": "npm run lint:unused && npm run lint:dead",

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -233,6 +233,23 @@ else
 fi
 
 # ─────────────────────────────────────────────
+# Part 5: Update command smoke tests
+# ─────────────────────────────────────────────
+echo -e "\n${BOLD}=== Update command smoke tests ===${NC}\n"
+
+set +e
+UPDATE_SMOKE_OUTPUT=$(bash "$ROOT_DIR/scripts/test-update.sh" 2>&1)
+UPDATE_SMOKE_EXIT=$?
+set -e
+
+if [[ $UPDATE_SMOKE_EXIT -eq 0 ]]; then
+    pass "update smoke tests"
+else
+    fail "update smoke tests"
+    echo "$UPDATE_SMOKE_OUTPUT" | sed 's/^/      /'
+fi
+
+# ─────────────────────────────────────────────
 # Summary
 # ─────────────────────────────────────────────
 echo -e "\n${BOLD}=== Results ===${NC}"

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -50,6 +50,26 @@ assert_contains() {
   fi
 }
 
+assert_exists() {
+  local path="$1"
+  local hint="$2"
+  if [[ ! -e "$path" ]]; then
+    echo "Assertion failed: $hint"
+    echo "Missing path: $path"
+    exit 1
+  fi
+}
+
+assert_not_exists() {
+  local path="$1"
+  local hint="$2"
+  if [[ -e "$path" ]]; then
+    echo "Assertion failed: $hint"
+    echo "Unexpected path: $path"
+    exit 1
+  fi
+}
+
 run_update() {
   local mode="$1"
   local output_file="$2"
@@ -88,3 +108,74 @@ assert_contains "$FORCE_OUTPUT" "changed: [0-9]+" "force run should report chang
 assert_contains "$FORCE_OUTPUT" "force reinstall" "force reason should be visible"
 
 echo "update smoke tests passed"
+
+# -------------------------------------------------------------------
+# Antigravity force behavior smoke: preserve custom workflow refs,
+# and clean stale files under .agent/skills/<skill>.
+# -------------------------------------------------------------------
+
+AG_PROJECT_DIR="$TMPDIR/update-smoke-antigravity"
+mkdir -p "$AG_PROJECT_DIR"
+
+cat > "$AG_PROJECT_DIR/.ai-factory.json" << 'EOF'
+{
+  "version": "2.4.0",
+  "agents": [
+    {
+      "id": "antigravity",
+      "skillsDir": ".agent/skills",
+      "installedSkills": ["aif", "aif-docs", "custom/workflow-ref"],
+      "mcp": {
+        "github": false,
+        "filesystem": false,
+        "postgres": false,
+        "chromeDevtools": false,
+        "playwright": false
+      }
+    }
+  ],
+  "extensions": []
+}
+EOF
+
+AG_FIRST_OUTPUT="$TMPDIR/update-antigravity-first.log"
+AG_FORCE_OUTPUT="$TMPDIR/update-antigravity-force.log"
+
+# First update installs baseline antigravity layout.
+(cd "$AG_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update > "$AG_FIRST_OUTPUT" 2>&1)
+assert_contains "$AG_FIRST_OUTPUT" "\[antigravity\] Status:" "antigravity status section must be printed"
+
+# Seed custom workflow reference that must survive force update.
+mkdir -p "$AG_PROJECT_DIR/.agent/workflows/references/custom"
+cat > "$AG_PROJECT_DIR/.agent/workflows/references/custom/keep.md" << 'EOF'
+# custom reference
+keep-me
+EOF
+
+# Seed stale files under managed skill dir that should be cleaned by force.
+mkdir -p "$AG_PROJECT_DIR/.agent/skills/aif-docs/references"
+cat > "$AG_PROJECT_DIR/.agent/skills/aif-docs/stale.txt" << 'EOF'
+stale
+EOF
+cat > "$AG_PROJECT_DIR/.agent/skills/aif-docs/references/stale.md" << 'EOF'
+stale-ref
+EOF
+
+# Force update.
+(cd "$AG_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update --force > "$AG_FORCE_OUTPUT" 2>&1)
+
+# Force output assertions.
+assert_contains "$AG_FORCE_OUTPUT" "Force mode enabled" "force mode banner expected for antigravity"
+assert_contains "$AG_FORCE_OUTPUT" "\[antigravity\] Status:" "antigravity status section must be printed on force run"
+assert_contains "$AG_FORCE_OUTPUT" "aif \(force reinstall\)" "workflow skill should be force reinstalled"
+assert_contains "$AG_FORCE_OUTPUT" "aif-docs \(force reinstall\)" "non-workflow skill should be force reinstalled"
+assert_contains "$AG_FORCE_OUTPUT" "\[antigravity\] Custom skills \(preserved\):" "custom skills section should be printed"
+assert_contains "$AG_FORCE_OUTPUT" "custom/workflow-ref" "custom skill reference should be preserved in config"
+
+# Filesystem assertions for requested antigravity force behavior.
+assert_exists "$AG_PROJECT_DIR/.agent/workflows/references/custom/keep.md" "custom workflow reference must survive force update"
+assert_contains "$AG_PROJECT_DIR/.agent/workflows/references/custom/keep.md" "keep-me" "custom workflow reference content must be preserved"
+assert_not_exists "$AG_PROJECT_DIR/.agent/skills/aif-docs/stale.txt" "stale file in .agent/skills/<skill> must be cleaned on force update"
+assert_not_exists "$AG_PROJECT_DIR/.agent/skills/aif-docs/references/stale.md" "stale reference in .agent/skills/<skill> must be cleaned on force update"
+
+echo "antigravity force smoke tests passed"

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Smoke tests: validates ai-factory update status model and --force behavior
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PROJECT_DIR="$TMPDIR/update-smoke"
+mkdir -p "$PROJECT_DIR"
+
+# Ensure dist/ is up to date for CLI smoke tests.
+(cd "$ROOT_DIR" && npm run build > /dev/null)
+
+cat > "$PROJECT_DIR/.ai-factory.json" << 'EOF'
+{
+  "version": "2.4.0",
+  "agents": [
+    {
+      "id": "universal",
+      "skillsDir": ".agents/skills",
+      "installedSkills": ["aif", "aif-plan", "aif-nonexistent"],
+      "mcp": {
+        "github": false,
+        "filesystem": false,
+        "postgres": false,
+        "chromeDevtools": false,
+        "playwright": false
+      }
+    }
+  ],
+  "extensions": []
+}
+EOF
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  local hint="$3"
+  if ! grep -qE "$pattern" "$file"; then
+    echo "Assertion failed: $hint"
+    echo "Pattern: $pattern"
+    echo "--- output ---"
+    cat "$file"
+    echo "--------------"
+    exit 1
+  fi
+}
+
+run_update() {
+  local mode="$1"
+  local output_file="$2"
+  if [[ "$mode" == "force" ]]; then
+    (cd "$PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update --force > "$output_file" 2>&1)
+  else
+    (cd "$PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update > "$output_file" 2>&1)
+  fi
+}
+
+FIRST_OUTPUT="$TMPDIR/update-first.log"
+SECOND_OUTPUT="$TMPDIR/update-second.log"
+FORCE_OUTPUT="$TMPDIR/update-force.log"
+
+# First update: should repair missing managed state and remove missing package skill.
+run_update normal "$FIRST_OUTPUT"
+assert_contains "$FIRST_OUTPUT" "\[universal\] Status:" "status section must be printed"
+assert_contains "$FIRST_OUTPUT" "changed: [0-9]+" "changed counter must be printed"
+assert_contains "$FIRST_OUTPUT" "skipped: [0-9]+" "skipped counter must be printed"
+assert_contains "$FIRST_OUTPUT" "removed: [0-9]+" "removed counter must be printed"
+assert_contains "$FIRST_OUTPUT" "aif-nonexistent \(removed from package\)" "removed package skill must be reported"
+assert_contains "$FIRST_OUTPUT" "WARN: managed state recovered" "managed state recovery warning expected on first run"
+
+# Managed state should be persisted after first run.
+node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const m=c.agents[0].managedSkills||{};if(!m['aif']||!m['aif-plan']){process.exit(1);}" "$PROJECT_DIR/.ai-factory.json"
+
+# Second update: should converge to unchanged for tracked skills.
+run_update normal "$SECOND_OUTPUT"
+assert_contains "$SECOND_OUTPUT" "unchanged: [0-9]+" "unchanged counter must be printed"
+assert_contains "$SECOND_OUTPUT" "changed: 0" "second run should not report changed skills in steady state"
+
+# Force update: should report force mode and changed entries.
+run_update force "$FORCE_OUTPUT"
+assert_contains "$FORCE_OUTPUT" "Force mode enabled" "force mode banner expected"
+assert_contains "$FORCE_OUTPUT" "changed: [0-9]+" "force run should report changed skills"
+assert_contains "$FORCE_OUTPUT" "force reinstall" "force reason should be visible"
+
+echo "update smoke tests passed"

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,13 +1,14 @@
 import chalk from 'chalk';
 import path from 'path';
 import { runWizard } from '../wizard/prompts.js';
-import { installSkills } from '../../core/installer.js';
+import { buildManagedSkillsState, installSkills } from '../../core/installer.js';
 import { saveConfig, configExists, loadConfig, getCurrentVersion, type AgentInstallation } from '../../core/config.js';
 import { configureMcp, getMcpInstructions } from '../../core/mcp.js';
 import { getAgentConfig } from '../../core/agents.js';
 import { cleanupAgentSetup, getAgentOnboarding } from '../../core/transformer.js';
 import { removeDirectory } from '../../utils/fs.js';
 import { applyExtensionInjections } from '../../core/injections.js';
+import { collectReplacedSkills } from '../../core/extension-ops.js';
 
 async function removeAgentSetup(projectDir: string, agent: AgentInstallation): Promise<void> {
   await removeDirectory(path.join(projectDir, agent.skillsDir));
@@ -85,12 +86,6 @@ export async function initCommand(): Promise<void> {
 
     const existingExtensions = existingConfig?.extensions ?? [];
 
-    await saveConfig(projectDir, {
-      version: getCurrentVersion(),
-      agents: installedAgents,
-      extensions: existingExtensions,
-    });
-
     // Re-apply extension injections after skill installation
     if (existingExtensions.length > 0) {
       let totalInjections = 0;
@@ -101,6 +96,18 @@ export async function initCommand(): Promise<void> {
         console.log(chalk.green(`✓ Re-applied ${totalInjections} extension injection(s)`));
       }
     }
+
+    const replacedSkills = collectReplacedSkills(existingExtensions);
+    for (const agent of installedAgents) {
+      const managedBaseSkills = agent.installedSkills.filter(skill => !replacedSkills.has(skill));
+      agent.managedSkills = await buildManagedSkillsState(projectDir, agent, managedBaseSkills);
+    }
+
+    await saveConfig(projectDir, {
+      version: getCurrentVersion(),
+      agents: installedAgents,
+      extensions: existingExtensions,
+    });
 
     console.log(chalk.green('✓ Configuration saved to .ai-factory.json'));
 

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -4,7 +4,7 @@ import {realpathSync} from 'fs';
 import {execSync} from 'child_process';
 import inquirer from 'inquirer';
 import {getCurrentVersion, loadConfig, saveConfig} from '../../core/config.js';
-import {getAvailableSkills, partitionSkills, updateSkills} from '../../core/installer.js';
+import {buildManagedSkillsState, getAvailableSkills, partitionSkills, type SkillUpdateEntry, updateSkills} from '../../core/installer.js';
 import {applyExtensionInjections} from '../../core/injections.js';
 import {getExtensionsDir, loadExtensionManifest} from '../../core/extensions.js';
 import {
@@ -12,6 +12,47 @@ import {
   installSkillsForAllAgents,
   collectReplacedSkills,
 } from '../../core/extension-ops.js';
+import {fileExists} from '../../utils/fs.js';
+
+interface UpdateCommandOptions {
+  force?: boolean;
+}
+
+function formatReason(reason: string): string {
+  switch (reason) {
+    case 'source-hash-changed':
+      return 'source changed';
+    case 'installed-hash-drift':
+      return 'local drift';
+    case 'missing-managed-state':
+      return 'state missing';
+    case 'missing-installed-artifact':
+      return 'artifact missing';
+    case 'package-removed':
+      return 'removed from package';
+    case 'new-skill-not-installed':
+      return 'new in package';
+    case 'replaced-by-extension':
+      return 'replaced by extension';
+    case 'force-clean-reinstall':
+      return 'force reinstall';
+    case 'install-failed':
+      return 'install failed';
+    case 'source-missing':
+      return 'source unavailable';
+    default:
+      return reason;
+  }
+}
+
+function groupEntriesByStatus(entries: SkillUpdateEntry[]): Record<'changed' | 'unchanged' | 'skipped' | 'removed', SkillUpdateEntry[]> {
+  return {
+    changed: entries.filter(entry => entry.status === 'changed').sort((a, b) => a.skill.localeCompare(b.skill)),
+    unchanged: entries.filter(entry => entry.status === 'unchanged').sort((a, b) => a.skill.localeCompare(b.skill)),
+    skipped: entries.filter(entry => entry.status === 'skipped').sort((a, b) => a.skill.localeCompare(b.skill)),
+    removed: entries.filter(entry => entry.status === 'removed').sort((a, b) => a.skill.localeCompare(b.skill)),
+  };
+}
 
 function parseVersion(v: string): { parts: number[]; prerelease: string | null } {
   const [core, ...rest] = v.split('-');
@@ -114,8 +155,9 @@ async function selfUpdate(currentVersion: string): Promise<boolean> {
   }
 }
 
-export async function updateCommand(): Promise<void> {
+export async function updateCommand(options: UpdateCommandOptions = {}): Promise<void> {
   const projectDir = process.cwd();
+  const force = Boolean(options.force);
 
   console.log(chalk.bold.blue('\n🏭 AI Factory - Update Skills\n'));
 
@@ -135,31 +177,16 @@ export async function updateCommand(): Promise<void> {
   const selfUpdated = await selfUpdate(currentVersion);
   if (selfUpdated) return;
 
+  if (force) {
+    console.log(chalk.yellow('⚠ Force mode enabled: clean reinstall of installed base skills\n'));
+  }
+
   console.log(chalk.dim('Updating skills...\n'));
 
   try {
     const availableSkills = await getAvailableSkills();
-    const previousBaseSkillsByAgent = new Map<string, string[]>();
+    const entriesByAgent = new Map<string, SkillUpdateEntry[]>();
 
-    for (const agent of config.agents) {
-      const { base: previousBaseSkills } = partitionSkills(agent.installedSkills);
-      previousBaseSkillsByAgent.set(agent.id, previousBaseSkills);
-      const newSkills = availableSkills.filter(s => !previousBaseSkills.includes(s));
-
-      const removedSkills = previousBaseSkills.filter(s => !availableSkills.includes(s));
-
-      if (newSkills.length > 0) {
-        console.log(chalk.cyan(`📦 [${agent.id}] New skills available: ${newSkills.join(', ')}`));
-      }
-      if (removedSkills.length > 0) {
-        console.log(chalk.yellow(`🗑️  [${agent.id}] Removed skills: ${removedSkills.join(', ')}`));
-      }
-    }
-    if (config.agents.length > 0) {
-      console.log('');
-    }
-
-    // Collect all replaced skills from extensions
     const extensions = config.extensions ?? [];
     const allReplacedSkills = collectReplacedSkills(extensions);
 
@@ -168,7 +195,12 @@ export async function updateCommand(): Promise<void> {
     }
 
     for (const agent of config.agents) {
-      agent.installedSkills = await updateSkills(agent, projectDir, [...allReplacedSkills]);
+      const result = await updateSkills(agent, projectDir, {
+        excludeSkills: [...allReplacedSkills],
+        force,
+      });
+      agent.installedSkills = result.installedSkills;
+      entriesByAgent.set(agent.id, result.entries);
     }
 
     // Re-install replacement skills from extensions
@@ -241,6 +273,14 @@ export async function updateCommand(): Promise<void> {
       }
     }
 
+    // Rebuild managed state after final update + replacement + injection pipeline.
+    const finalReplacedSkills = collectReplacedSkills(extensions);
+    for (const agent of config.agents) {
+      const { base: baseSkills } = partitionSkills(agent.installedSkills);
+      const managedBaseSkills = baseSkills.filter(skill => availableSkills.includes(skill) && !finalReplacedSkills.has(skill));
+      agent.managedSkills = await buildManagedSkillsState(projectDir, agent, managedBaseSkills);
+    }
+
     config.version = currentVersion;
     await saveConfig(projectDir, config);
 
@@ -248,15 +288,64 @@ export async function updateCommand(): Promise<void> {
     console.log(chalk.green('✓ Configuration updated'));
 
     for (const agent of config.agents) {
-      const previousBaseSkills = previousBaseSkillsByAgent.get(agent.id) ?? [];
-      const newSkills = availableSkills.filter(s => !previousBaseSkills.includes(s));
-      const { base: baseSkills, custom: customSkills } = partitionSkills(agent.installedSkills);
+      const entries = entriesByAgent.get(agent.id) ?? [];
+      const grouped = groupEntriesByStatus(entries);
+      const changedWithContextWarnings: string[] = [];
 
-      console.log(chalk.bold(`\n[${agent.id}] Base skills:`));
-      for (const skill of baseSkills) {
-        const isNew = newSkills.includes(skill);
-        console.log(chalk.dim(`  - ${skill}`) + (isNew ? chalk.green(' (new)') : ''));
+      for (const entry of grouped.changed) {
+        const skillContextPath = path.join(projectDir, '.ai-factory', 'skill-context', entry.skill, 'SKILL.md');
+        if (await fileExists(skillContextPath)) {
+          changedWithContextWarnings.push(entry.skill);
+        }
       }
+
+      console.log(chalk.bold(`\n[${agent.id}] Status:`));
+      console.log(chalk.dim(`  changed: ${grouped.changed.length}`));
+      console.log(chalk.dim(`  unchanged: ${grouped.unchanged.length}`));
+      console.log(chalk.dim(`  skipped: ${grouped.skipped.length}`));
+      console.log(chalk.dim(`  removed: ${grouped.removed.length}`));
+
+      if (grouped.changed.length > 0) {
+        console.log(chalk.bold('  Changed:'));
+        for (const entry of grouped.changed) {
+          console.log(chalk.dim(`    - ${entry.skill} (${formatReason(entry.reason)})`));
+        }
+      }
+
+      if (grouped.skipped.length > 0) {
+        console.log(chalk.bold('  Skipped:'));
+        for (const entry of grouped.skipped) {
+          console.log(chalk.dim(`    - ${entry.skill} (${formatReason(entry.reason)})`));
+        }
+      }
+
+      if (grouped.removed.length > 0) {
+        console.log(chalk.bold('  Removed:'));
+        for (const entry of grouped.removed) {
+          console.log(chalk.dim(`    - ${entry.skill} (${formatReason(entry.reason)})`));
+        }
+      }
+
+      const recoveryEntries = grouped.changed.filter(entry => [
+        'missing-managed-state',
+        'missing-installed-artifact',
+        'source-missing',
+      ].includes(entry.reason));
+      if (recoveryEntries.length > 0) {
+        console.log(chalk.yellow('  WARN: managed state recovered for:'));
+        for (const entry of recoveryEntries) {
+          console.log(chalk.yellow(`    - ${entry.skill} (${formatReason(entry.reason)})`));
+        }
+      }
+
+      if (changedWithContextWarnings.length > 0) {
+        console.log(chalk.yellow('  WARN: skill-context override may need review for changed skills:'));
+        for (const skill of changedWithContextWarnings) {
+          console.log(chalk.yellow(`    - ${skill} (.ai-factory/skill-context/${skill}/SKILL.md)`));
+        }
+      }
+
+      const { custom: customSkills } = partitionSkills(agent.installedSkills);
 
       if (customSkills.length > 0) {
         console.log(chalk.bold(`[${agent.id}] Custom skills (preserved):`));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,6 +21,7 @@ program
 program
   .command('update')
   .description('Update installed skills to latest version')
+  .option('--force', 'Force clean reinstall of currently installed base skills')
   .action(updateCommand);
 
 program

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -14,10 +14,16 @@ export interface McpConfig {
   playwright: boolean;
 }
 
+export interface ManagedSkillState {
+  sourceHash: string;
+  installedHash: string;
+}
+
 export interface AgentInstallation {
   id: string;
   skillsDir: string;
   installedSkills: string[];
+  managedSkills?: Record<string, ManagedSkillState>;
   mcp: McpConfig;
 }
 
@@ -65,8 +71,32 @@ function createAgentInstallation(agentId: string, legacy?: LegacyAiFactoryConfig
     skillsDir: legacy?.skillsDir ?? agent.skillsDir,
     id: agentId,
     installedSkills: legacy?.installedSkills ?? [],
+    managedSkills: {},
     mcp: normalizeMcp(legacy?.mcp),
   };
+}
+
+function normalizeManagedSkills(raw: unknown): Record<string, ManagedSkillState> {
+  if (!raw || typeof raw !== 'object') {
+    return {};
+  }
+
+  const result: Record<string, ManagedSkillState> = {};
+
+  for (const [skillName, state] of Object.entries(raw as Record<string, unknown>)) {
+    if (!skillName || typeof state !== 'object' || !state) {
+      continue;
+    }
+
+    const sourceHash = (state as { sourceHash?: unknown }).sourceHash;
+    const installedHash = (state as { installedHash?: unknown }).installedHash;
+
+    if (typeof sourceHash === 'string' && sourceHash.length > 0 && typeof installedHash === 'string' && installedHash.length > 0) {
+      result[skillName] = { sourceHash, installedHash };
+    }
+  }
+
+  return result;
 }
 
 export async function loadConfig(projectDir: string): Promise<AiFactoryConfig | null> {
@@ -83,6 +113,7 @@ export async function loadConfig(projectDir: string): Promise<AiFactoryConfig | 
         id: agent.id,
         skillsDir: agent.skillsDir || agentConfig.skillsDir,
         installedSkills: Array.isArray(agent.installedSkills) ? agent.installedSkills : [],
+        managedSkills: normalizeManagedSkills((agent as { managedSkills?: unknown }).managedSkills),
         mcp: normalizeMcp(agent.mcp),
       };
     });

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -4,7 +4,7 @@ import { copyDirectory, getSkillsDir, ensureDir, listDirectories, listFilesRecur
 import type { AgentInstallation, ManagedSkillState } from './config.js';
 import { getAgentConfig } from './agents.js';
 import { processSkillTemplates, buildTemplateVars, processTemplate } from './template.js';
-import { cleanupAgentSetup, getTransformer, extractFrontmatterName, replaceFrontmatterName } from './transformer.js';
+import { getTransformer, extractFrontmatterName, replaceFrontmatterName } from './transformer.js';
 
 const EXTENSION_INJECTION_BLOCK_PATTERN = /\n?<!-- aif-ext:[^:]+:[^:]+:[^:]+:start -->\n[\s\S]*?\n<!-- aif-ext:[^:]+:[^:]+:[^:]+:end -->\n?/g;
 
@@ -439,11 +439,7 @@ export async function updateSkills(
   const skillsToInstall = updatableBaseSkills.filter(skillName => shouldInstall.get(skillName)?.install === true);
 
   if (force && skillsToInstall.length > 0) {
-    if (agentInstallation.id === 'antigravity') {
-      await cleanupAgentSetup(agentInstallation.id, projectDir, agentInstallation.skillsDir);
-    } else {
-      await removeSkillsByName(projectDir, agentInstallation, skillsToInstall);
-    }
+    await removeSkillsByName(projectDir, agentInstallation, skillsToInstall);
   }
 
   const installedBaseSkills = skillsToInstall.length > 0

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -1,15 +1,204 @@
 import path from 'path';
-import { copyDirectory, getSkillsDir, ensureDir, listDirectories, readTextFile, writeTextFile, removeDirectory, fileExists } from '../utils/fs.js';
-import type { AgentInstallation } from './config.js';
+import { createHash } from 'crypto';
+import { copyDirectory, getSkillsDir, ensureDir, listDirectories, listFilesRecursive, readTextFile, readFileBuffer, writeTextFile, removeDirectory, fileExists, hashDirectory } from '../utils/fs.js';
+import type { AgentInstallation, ManagedSkillState } from './config.js';
 import { getAgentConfig } from './agents.js';
 import { processSkillTemplates, buildTemplateVars, processTemplate } from './template.js';
-import { getTransformer, extractFrontmatterName, replaceFrontmatterName } from './transformer.js';
+import { cleanupAgentSetup, getTransformer, extractFrontmatterName, replaceFrontmatterName } from './transformer.js';
+
+const EXTENSION_INJECTION_BLOCK_PATTERN = /\n?<!-- aif-ext:[^:]+:[^:]+:[^:]+:start -->\n[\s\S]*?\n<!-- aif-ext:[^:]+:[^:]+:[^:]+:end -->\n?/g;
+
+export type SkillUpdateStatus = 'changed' | 'unchanged' | 'skipped' | 'removed';
+
+export interface SkillUpdateEntry {
+  skill: string;
+  status: SkillUpdateStatus;
+  reason: string;
+}
+
+export interface UpdateSkillsResult {
+  installedSkills: string[];
+  entries: SkillUpdateEntry[];
+}
+
+export interface UpdateSkillsOptions {
+  excludeSkills?: string[];
+  force?: boolean;
+}
 
 export interface InstallOptions {
   projectDir: string;
   skillsDir: string;
   skills: string[];
   agentId: string;
+}
+
+interface ResolvedSkillPaths {
+  sourceSkillDir: string;
+  targetSkillDir: string;
+  targetSkillFile: string;
+  targetRefsDir: string;
+  sourceRefsDir: string;
+  flat: boolean;
+}
+
+function normalizeMarkdownForManagedHash(content: string): string {
+  return content
+    .replace(/\r\n/g, '\n')
+    .replace(EXTENSION_INJECTION_BLOCK_PATTERN, '')
+    .trimEnd();
+}
+
+async function readManagedFileForHash(filePath: string): Promise<Buffer | null> {
+  if (path.extname(filePath).toLowerCase() === '.md') {
+    const content = await readTextFile(filePath);
+    if (!content) {
+      return null;
+    }
+    return Buffer.from(normalizeMarkdownForManagedHash(content), 'utf-8');
+  }
+
+  return readFileBuffer(filePath);
+}
+
+async function hashManagedFiles(files: Array<{ absPath: string; relPath: string }>): Promise<string | null> {
+  if (files.length === 0) {
+    return null;
+  }
+
+  const sortedFiles = [...files].sort((a, b) => a.relPath.localeCompare(b.relPath));
+  const hasher = createHash('sha256');
+
+  for (const file of sortedFiles) {
+    const content = await readManagedFileForHash(file.absPath);
+    if (!content) {
+      return null;
+    }
+    hasher.update(`path:${file.relPath}\n`);
+    hasher.update(content);
+    hasher.update('\n');
+  }
+
+  return hasher.digest('hex');
+}
+
+async function hashManagedDirectory(dirPath: string): Promise<string | null> {
+  const files = await listFilesRecursive(dirPath);
+  if (files.length === 0) {
+    return null;
+  }
+
+  const mapped = files.map(absPath => ({
+    absPath,
+    relPath: path.relative(dirPath, absPath).replaceAll('\\', '/'),
+  }));
+
+  return hashManagedFiles(mapped);
+}
+
+function resolveSkillPaths(
+  projectDir: string,
+  skillsDir: string,
+  agentId: string,
+  skillName: string,
+  sourceSkillDir: string,
+): ResolvedSkillPaths {
+  const transformer = getTransformer(agentId);
+  const agentConfig = getAgentConfig(agentId);
+  const transformed = transformer.transform(skillName, '');
+
+  const sourceRefsDir = path.join(sourceSkillDir, 'references');
+  if (transformed.flat) {
+    const targetSkillDir = path.join(projectDir, agentConfig.configDir, transformed.targetDir);
+    return {
+      sourceSkillDir,
+      targetSkillDir,
+      targetSkillFile: path.join(targetSkillDir, transformed.targetName),
+      targetRefsDir: path.join(targetSkillDir, 'references'),
+      sourceRefsDir,
+      flat: true,
+    };
+  }
+
+  const targetSkillDir = path.join(projectDir, skillsDir, transformed.targetDir);
+  return {
+    sourceSkillDir,
+    targetSkillDir,
+    targetSkillFile: path.join(targetSkillDir, 'SKILL.md'),
+    targetRefsDir: path.join(targetSkillDir, 'references'),
+    sourceRefsDir,
+    flat: false,
+  };
+}
+
+async function hashInstalledSkill(paths: ResolvedSkillPaths): Promise<string | null> {
+  if (!paths.flat) {
+    return hashManagedDirectory(paths.targetSkillDir);
+  }
+
+  const mainFileExists = await fileExists(paths.targetSkillFile);
+  if (!mainFileExists) {
+    return null;
+  }
+
+  const filesToHash: Array<{ absPath: string; relPath: string }> = [
+    {
+      absPath: paths.targetSkillFile,
+      relPath: path.basename(paths.targetSkillFile),
+    },
+  ];
+
+  const sourceRefs = await listFilesRecursive(paths.sourceRefsDir);
+  for (const sourceRef of sourceRefs) {
+    const relPath = path.relative(paths.sourceRefsDir, sourceRef).replaceAll('\\', '/');
+    const targetRef = path.join(paths.targetRefsDir, relPath);
+    filesToHash.push({
+      absPath: targetRef,
+      relPath: `references/${relPath}`,
+    });
+  }
+
+  return hashManagedFiles(filesToHash);
+}
+
+async function getManagedSkillState(
+  projectDir: string,
+  agentInstallation: AgentInstallation,
+  skillName: string,
+): Promise<ManagedSkillState | null> {
+  const sourceSkillDir = path.join(getSkillsDir(), skillName);
+  const sourceHash = await hashDirectory(sourceSkillDir);
+  if (!sourceHash) {
+    return null;
+  }
+
+  const paths = resolveSkillPaths(projectDir, agentInstallation.skillsDir, agentInstallation.id, skillName, sourceSkillDir);
+  const installedHash = await hashInstalledSkill(paths);
+  if (!installedHash) {
+    return null;
+  }
+
+  return {
+    sourceHash,
+    installedHash,
+  };
+}
+
+export async function buildManagedSkillsState(
+  projectDir: string,
+  agentInstallation: AgentInstallation,
+  baseSkills: string[],
+): Promise<Record<string, ManagedSkillState>> {
+  const state: Record<string, ManagedSkillState> = {};
+
+  for (const skillName of baseSkills) {
+    const managed = await getManagedSkillState(projectDir, agentInstallation, skillName);
+    if (managed) {
+      state[skillName] = managed;
+    }
+  }
+
+  return state;
 }
 
 async function installSkillWithTransformer(
@@ -158,25 +347,142 @@ export async function removeExtensionSkills(
   return removeSkillsByName(projectDir, agentInstallation, skillPaths.map(p => path.basename(p)));
 }
 
-export async function updateSkills(agentInstallation: AgentInstallation, projectDir: string, excludeSkills?: string[]): Promise<string[]> {
+export async function updateSkills(
+  agentInstallation: AgentInstallation,
+  projectDir: string,
+  options: UpdateSkillsOptions = {},
+): Promise<UpdateSkillsResult> {
+  const { excludeSkills = [], force = false } = options;
   const availableSkills = await getAvailableSkills();
-  const excludeSet = new Set(excludeSkills ?? []);
-  const skillsToInstall = availableSkills.filter(s => !excludeSet.has(s));
+  const availableSet = new Set(availableSkills);
+  const excludeSet = new Set(excludeSkills);
+
+  const entries: SkillUpdateEntry[] = [];
 
   const { base: previousBaseSkills, custom } = partitionSkills(agentInstallation.installedSkills);
-  const availableSet = new Set(availableSkills);
+  const previousBaseSet = new Set(previousBaseSkills);
+  const previousManaged = agentInstallation.managedSkills ?? {};
 
   const removedSkills = previousBaseSkills.filter(s => !availableSet.has(s) && !excludeSet.has(s));
   if (removedSkills.length > 0) {
     await removeSkillsByName(projectDir, agentInstallation, removedSkills);
+    for (const skill of removedSkills) {
+      entries.push({
+        skill,
+        status: 'removed',
+        reason: 'package-removed',
+      });
+    }
   }
 
-  const installedBaseSkills = await installSkills({
-    projectDir,
-    skillsDir: agentInstallation.skillsDir,
-    skills: skillsToInstall,
-    agentId: agentInstallation.id,
-  });
+  const replacedSkills = previousBaseSkills.filter(s => excludeSet.has(s));
+  for (const skill of replacedSkills) {
+    entries.push({
+      skill,
+      status: 'skipped',
+      reason: 'replaced-by-extension',
+    });
+  }
 
-  return [...installedBaseSkills, ...custom];
+  const newlyAvailable = availableSkills.filter(s => !previousBaseSet.has(s) && !excludeSet.has(s));
+  for (const skill of newlyAvailable) {
+    entries.push({
+      skill,
+      status: 'skipped',
+      reason: 'new-skill-not-installed',
+    });
+  }
+
+  const updatableBaseSkills = previousBaseSkills.filter(s => availableSet.has(s) && !excludeSet.has(s));
+  const shouldInstall = new Map<string, { install: boolean; reason: string }>();
+
+  for (const skillName of updatableBaseSkills) {
+    const sourceSkillDir = path.join(getSkillsDir(), skillName);
+    const sourceHash = await hashDirectory(sourceSkillDir);
+    const paths = resolveSkillPaths(projectDir, agentInstallation.skillsDir, agentInstallation.id, skillName, sourceSkillDir);
+    const installedHash = await hashInstalledSkill(paths);
+    const previousState = previousManaged[skillName];
+
+    if (force) {
+      shouldInstall.set(skillName, { install: true, reason: 'force-clean-reinstall' });
+      continue;
+    }
+
+    if (!sourceHash) {
+      shouldInstall.set(skillName, { install: true, reason: 'source-missing' });
+      continue;
+    }
+
+    if (!previousState) {
+      shouldInstall.set(skillName, { install: true, reason: 'missing-managed-state' });
+      continue;
+    }
+
+    if (!installedHash) {
+      shouldInstall.set(skillName, { install: true, reason: 'missing-installed-artifact' });
+      continue;
+    }
+
+    if (previousState.sourceHash !== sourceHash) {
+      shouldInstall.set(skillName, { install: true, reason: 'source-hash-changed' });
+      continue;
+    }
+
+    if (previousState.installedHash !== installedHash) {
+      shouldInstall.set(skillName, { install: true, reason: 'installed-hash-drift' });
+      continue;
+    }
+
+    shouldInstall.set(skillName, { install: false, reason: 'up-to-date' });
+  }
+
+  const skillsToInstall = updatableBaseSkills.filter(skillName => shouldInstall.get(skillName)?.install === true);
+
+  if (force && skillsToInstall.length > 0) {
+    if (agentInstallation.id === 'antigravity') {
+      await cleanupAgentSetup(agentInstallation.id, projectDir, agentInstallation.skillsDir);
+    } else {
+      await removeSkillsByName(projectDir, agentInstallation, skillsToInstall);
+    }
+  }
+
+  const installedBaseSkills = skillsToInstall.length > 0
+    ? await installSkills({
+      projectDir,
+      skillsDir: agentInstallation.skillsDir,
+      skills: skillsToInstall,
+      agentId: agentInstallation.id,
+    })
+    : [];
+
+  const installedSet = new Set(installedBaseSkills);
+
+  for (const skillName of updatableBaseSkills) {
+    const decision = shouldInstall.get(skillName);
+    if (!decision) {
+      continue;
+    }
+
+    if (decision.install) {
+      entries.push({
+        skill: skillName,
+        status: installedSet.has(skillName) ? 'changed' : 'skipped',
+        reason: installedSet.has(skillName) ? decision.reason : 'install-failed',
+      });
+      continue;
+    }
+
+    entries.push({
+      skill: skillName,
+      status: 'unchanged',
+      reason: decision.reason,
+    });
+  }
+
+  const retainedBaseSkills = previousBaseSkills.filter(s => (availableSet.has(s) || excludeSet.has(s)) && !removedSkills.includes(s));
+
+  return {
+    installedSkills: [...retainedBaseSkills, ...custom],
+    entries,
+  };
 }

--- a/src/core/transformers/antigravity.ts
+++ b/src/core/transformers/antigravity.ts
@@ -1,6 +1,6 @@
 import type { AgentTransformer, TransformResult } from '../transformer.js';
 import { WORKFLOW_SKILLS, simplifyFrontmatter } from '../transformer.js';
-import { writeTextFile, fileExists, removeFile, removeDirectory } from '../../utils/fs.js';
+import { writeTextFile, fileExists, removeFile } from '../../utils/fs.js';
 import path from 'path';
 
 export class AntigravityTransformer implements AgentTransformer {
@@ -95,11 +95,6 @@ Always-active guardrails and conventions that apply to every interaction.
       if (await fileExists(workflowFile)) {
         await removeFile(workflowFile);
       }
-    }
-
-    const refsDir = path.join(workflowsDir, 'references');
-    if (await fileExists(refsDir)) {
-      await removeDirectory(refsDir);
     }
 
     for (const ruleFile of ['aif-guardrails.md', 'aif-conventions.md']) {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
+import { createHash } from 'crypto';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -53,6 +54,14 @@ export async function readTextFile(filePath: string): Promise<string | null> {
   }
 }
 
+export async function readFileBuffer(filePath: string): Promise<Buffer | null> {
+  try {
+    return await fs.readFile(filePath);
+  } catch {
+    return null;
+  }
+}
+
 export async function listDirectories(dirPath: string): Promise<string[]> {
   try {
     const entries = await fs.readdir(dirPath, { withFileTypes: true });
@@ -67,6 +76,70 @@ export async function listDirectories(dirPath: string): Promise<string[]> {
 export async function writeTextFile(filePath: string, content: string): Promise<void> {
   await fs.ensureDir(path.dirname(filePath));
   await fs.writeFile(filePath, content, 'utf-8');
+}
+
+export async function listFilesRecursive(dirPath: string): Promise<string[]> {
+  const files: string[] = [];
+
+  async function walk(currentDir: string): Promise<void> {
+    const entries = await fs.readdir(currentDir, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.isFile()) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  try {
+    const stats = await fs.stat(dirPath);
+    if (!stats.isDirectory()) {
+      return [];
+    }
+  } catch {
+    return [];
+  }
+
+  await walk(dirPath);
+  files.sort((a, b) => a.localeCompare(b));
+  return files;
+}
+
+export function hashBuffer(content: Buffer | string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+export async function hashFile(filePath: string): Promise<string | null> {
+  const content = await readFileBuffer(filePath);
+  if (!content) {
+    return null;
+  }
+  return hashBuffer(content);
+}
+
+export async function hashDirectory(dirPath: string): Promise<string | null> {
+  const files = await listFilesRecursive(dirPath);
+  if (files.length === 0) {
+    return null;
+  }
+
+  const hasher = createHash('sha256');
+  for (const absFile of files) {
+    const content = await readFileBuffer(absFile);
+    if (!content) {
+      return null;
+    }
+    const relPath = path.relative(dirPath, absFile).replaceAll('\\', '/');
+    hasher.update(`path:${relPath}\n`);
+    hasher.update(content);
+    hasher.update('\n');
+  }
+
+  return hasher.digest('hex');
 }
 
 export async function ensureDir(dirPath: string): Promise<void> {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -109,18 +109,6 @@ export async function listFilesRecursive(dirPath: string): Promise<string[]> {
   return files;
 }
 
-export function hashBuffer(content: Buffer | string): string {
-  return createHash('sha256').update(content).digest('hex');
-}
-
-export async function hashFile(filePath: string): Promise<string | null> {
-  const content = await readFileBuffer(filePath);
-  if (!content) {
-    return null;
-  }
-  return hashBuffer(content);
-}
-
 export async function hashDirectory(dirPath: string): Promise<string | null> {
   const files = await listFilesRecursive(dirPath);
   if (files.length === 0) {


### PR DESCRIPTION
## Зачем

Сейчас `ai-factory update` показывает список базовых скиллов, но не отвечает на главный вопрос: что реально обновилось.
Из-за этого сложно понять результат обновления, отловить дрейф установленного состояния и безопасно восстановиться после локальных правок/битого state.

## Почему так

Выбран подход с managed-state (source hash + installed hash), потому что он:
- детерминированно отличает `changed` от `unchanged`;
- позволяет явно показывать `skipped` (новые, но не установленные скиллы) и `removed`;
- обнаруживает локальный drift/пропавшие артефакты и восстанавливает состояние;
- совместим с extension replacements и injection flow;
- дает предсказуемый recovery-режим через `--force` (clean reinstall), включая Antigravity cleanup.

## Что сделано

- Добавлен managed state для base skills в `.ai-factory.json` (`managedSkills` с `sourceHash` и `installedHash`).
- Переработан `update`:
  - статусы `changed/unchanged/skipped/removed` с причинами;
  - вывод по агентам в компактном виде;
  - warning для skill-context override у измененных скиллов.
- Добавлен `ai-factory update --force` для clean reinstall managed base skills.
- Добавлена нормализация контента для hash (без `aif-ext` injection markers), чтобы избежать ложного drift.
- Managed state пересобирается после полного update pipeline (base/replacements/injections).
- Добавлены smoke-тесты update:
  - новый `scripts/test-update.sh`;
  - интеграция в `scripts/test-skills.sh`;
  - npm script `test:update`.
- Обновлена документация:
  - `README.md`
  - `docs/getting-started.md`
  - `docs/extensions.md`

## Проверка

- `npm run build` ✅
- `npm test` ✅

## ai-factory update

Первый в любом случае будет change (так как нет хешей у установленных)
<img width="569" height="548" alt="image" src="https://github.com/user-attachments/assets/9c7ef79c-a860-4e71-9b09-70818cc3d4e9" />

Но в следующем уже будет, то есть не будут обновляться скиллы (тратятся ресурсы только на хеши)
<img width="354" height="459" alt="image" src="https://github.com/user-attachments/assets/877dbd19-6d0d-4e9d-9ca9-5116ca284220" />

Если использовать --force
<img width="596" height="499" alt="image" src="https://github.com/user-attachments/assets/93ae903f-66d8-476e-b96c-d353353e0639" />


## Как это работает

ai-factory update
  - сравнивает source-hash по ранее установленным base skills
  - changed -> reinstall
  - unchanged -> skip
  - removed -> remove
  - new but not previously installed -> skipped
  - changed + skill-context exists -> warn

ai-factory update --force
  - clean reinstall всех ранее установленных base skills
  - для Antigravity: cleanup agent setup, затем reinstall
  - custom skills preserve
  - extension replacements reinstall по текущей логике


То есть
```
Пакет skill:
  SKILL.md
  references/A.md
  references/B.md

У пользователя до --force:
  SKILL.md
  references/A.md
  references/OLD.md -> останоесть, без force

После --force:
  SKILL.md
  references/A.md
  references/B.md
```
