### PR TITLE
refactor(skills): standardize interactive prompts and response handling

### DIFF
--- a/skills/aif-docs/SKILL.md
+++ b/skills/aif-docs/SKILL.md
@@ -498,16 +498,7 @@ Read `AGENTS.md` and find the `## Documentation` section. Update it to reflect t
 
 ### Context Cleanup
 
-Context is heavy after codebase scanning and documentation generation. All docs are saved — suggest freeing space:
-
-```
-AskUserQuestion: Free up context before continuing?
-
-Options:
-1. /clear — Full reset (recommended)
-2. /compact — Compress history
-3. Continue as is
-```
+Suggest the user to free up context space if needed: `/clear` (full reset) or `/compact` (compress history).
 
 ## Important Rules
 

--- a/skills/aif-docs/SKILL.md
+++ b/skills/aif-docs/SKILL.md
@@ -91,15 +91,18 @@ State C: README.md + docs/ exist     → Depends on flags (see below)
 ```
 Documentation already exists (README.md + docs/).
 
-What would you like to do?
-- [ ] Generate HTML only — build site from current docs as-is
-- [ ] Audit & improve first — check for issues, then generate HTML
-- [ ] Audit only — check for issues without generating HTML
+AskUserQuestion: What would you like to do?
+
+Options:
+1. Generate HTML only — build site from current docs as-is
+2. Audit & improve first — check for issues, then generate HTML
+3. Audit only — check for issues without generating HTML
 ```
 
-- **"Generate HTML only"** → skip Step 1.1, Step 2, Step 4 — go directly to Step 3 (HTML generation), then done
-- **"Audit & improve first"** → run Step 1.1 → Step 2 (State C) → Step 3 → Step 4 → Step 4.1
-- **"Audit only"** → run Step 1.1 → Step 2 (State C) → Step 4 → Step 4.1 (skip Step 3)
+**Based on choice:**
+- Generate HTML only → skip Step 1.1, Step 2, Step 4 — go directly to Step 3 (HTML generation), then done
+- Audit & improve first → run Step 1.1 → Step 2 (State C) → Step 3 → Step 4 → Step 4.1
+- Audit only → run Step 1.1 → Step 2 (State C) → Step 4 → Step 4.1 (skip Step 3)
 
 **State C without `--web` flag** → run Step 2 (State C) as usual.
 
@@ -142,11 +145,18 @@ Suggested actions:
   → Move DEPLOYMENT.md → docs/deployment.md
   → Merge SETUP.md into docs/getting-started.md
 
-Would you like to:
-- [ ] Apply all suggestions
-- [ ] Let me pick which ones
-- [ ] Skip — keep files where they are
+AskUserQuestion: Would you like to apply the consolidation?
+
+Options:
+1. Apply all suggestions
+2. Let me pick which ones
+3. Skip — keep files where they are
 ```
+
+**Based on choice:**
+- Apply all suggestions → move/merge all listed files, continue to Step 2
+- Let me pick which ones → present each file individually for approval, apply selected
+- Skip → leave files where they are, continue to Step 2
 
 **When moving/merging:**
 1. Create the target file in `docs/` with prev/next navigation header (following Documentation table order) and "See Also" footer
@@ -191,11 +201,18 @@ I've analyzed your project and suggest these documentation pages:
 3. api.md — API endpoints reference
 4. configuration.md — Environment variables and config
 
-Would you like to:
-- [ ] Generate all of these
-- [ ] Let me pick which ones
-- [ ] Add more topics
+AskUserQuestion: Would you like to generate these documentation pages?
+
+Options:
+1. Generate all of these
+2. Let me pick which ones
+3. Add more topics
 ```
+
+**Based on choice:**
+- Generate all → proceed to generate README.md and all listed docs/ files
+- Let me pick → present each topic for individual approval, generate only approved
+- Add more topics → ask what additional topics to include, confirm final list, then generate
 
 #### 2.2: Generate README.md
 
@@ -458,11 +475,18 @@ The following root files have been incorporated into docs/:
   DEPLOYMENT.md → now in docs/deployment.md
   SETUP.md → merged into docs/getting-started.md
 
-These originals are no longer needed. Delete them?
-- [ ] Yes, delete all originals
-- [ ] Let me pick which ones to delete
-- [ ] No, keep them (I'll clean up later)
+AskUserQuestion: These originals are no longer needed. Delete them?
+
+Options:
+1. Yes, delete all originals
+2. Let me pick which ones to delete
+3. No, keep them (I'll clean up later)
 ```
+
+**Based on choice:**
+- Yes, delete all → delete all listed originals (see "When deleting" below)
+- Let me pick → present each file individually, delete only approved
+- No, keep them → leave originals in place, continue to Step 5
 
 **When deleting:**
 1. Verify one more time that the target docs/ file contains all content from the original

--- a/skills/aif-evolve/SKILL.md
+++ b/skills/aif-evolve/SKILL.md
@@ -434,10 +434,13 @@ For improvements — ask:
 - Let me pick
 - No, just save report (no changes applied)
 
-**If user chooses "Let me pick":** present improvements in batches of up to 4
-per `AskUserQuestion` call (same approach as Step 4 stale rules). For each
-improvement, options: Apply / Skip. Continue until all improvements are resolved.
-Then proceed to 7.2 with only approved improvements.
+**Based on choice:**
+- "Yes, apply all improvements" → proceed to 7.2 with all improvements
+- "Let me pick" → present improvements in batches of up to 4
+  per `AskUserQuestion` call (same approach as Step 4 stale rules). For each
+  improvement, options: Apply / Skip. Continue until all improvements are resolved.
+  Then proceed to 7.2 with only approved improvements.
+- "No, just save report" → no changes applied, **STOP**
 
 **Do NOT apply any changes until the user answers.**
 

--- a/skills/aif-fix/SKILL.md
+++ b/skills/aif-fix/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aif-fix
 description: Fix a specific bug or problem in the codebase. Supports two modes - immediate fix or plan-first. Without arguments executes existing FIX_PLAN.md. Always suggests test coverage and adds logging. Use when user says "fix bug", "debug this", "something is broken", or pastes an error message.
-argument-hint: <bug description or error message>
+argument-hint: "<bug description or error message>"
 allowed-tools: Read Write Edit Glob Grep Bash AskUserQuestion Questions Task
 disable-model-invocation: false
 ---
@@ -273,10 +273,23 @@ describe('functionName', () => {
 });
 \`\`\`
 
-Would you like me to create this test?
-- [ ] Yes, create the test
-- [ ] No, skip for now
+AskUserQuestion: Would you like me to create this test?
+
+Options:
+1. Yes, create the test
+2. No, skip for now
 ```
+
+**Handling the user's response:**
+
+- **If "Yes, create the test":**
+  1. Create the test file in the appropriate test directory (follow project conventions)
+  2. Include the suggested test case and any additional edge cases related to the fix
+  3. Run the test to verify it passes
+  4. Then proceed to **Step 6: Create Self-Improvement Patch**
+
+- **If "No, skip for now":**
+  - Proceed directly to **Step 6: Create Self-Improvement Patch**
 
 ## Logging Requirements
 
@@ -353,6 +366,8 @@ function fixedFunction(input) {
 
 ## After Fixing
 
+**Use this output template in Step 5** (before the AskUserQuestion about tests):
+
 ```
 ## Fix Applied ✅
 
@@ -364,13 +379,6 @@ function fixedFunction(input) {
 - path/to/file.ts (line X)
 
 **Logging added:** Yes, prefix `[FIX]`
-**Test suggested:** Yes
-
-Please test the fix and share logs if any issues.
-
-To add the suggested test:
-- [ ] Yes, create test
-- [ ] No, skip
 ```
 
 ### Step 6: Create Self-Improvement Patch
@@ -470,16 +478,7 @@ default avatar URL. Also added a null check in the Avatar sub-component.
 
 ### Context Cleanup
 
-Context is heavy after investigation, fix, and patch generation. All results are saved — suggest freeing space:
-
-```
-AskUserQuestion: Free up context before continuing?
-
-Options:
-1. /clear — Full reset (recommended)
-2. /compact — Compress history
-3. Continue as is
-```
+Suggest the user to free up context space if needed: `/clear` (full reset) or `/compact` (compress history).
 
 ---
 

--- a/skills/aif-fix/SKILL.md
+++ b/skills/aif-fix/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aif-fix
 description: Fix a specific bug or problem in the codebase. Supports two modes - immediate fix or plan-first. Without arguments executes existing FIX_PLAN.md. Always suggests test coverage and adds logging. Use when user says "fix bug", "debug this", "something is broken", or pastes an error message.
-argument-hint: "<bug description or error message>"
+argument-hint: <bug description or error message>
 allowed-tools: Read Write Edit Glob Grep Bash AskUserQuestion Questions Task
 disable-model-invocation: false
 ---

--- a/skills/aif-fix/SKILL.md
+++ b/skills/aif-fix/SKILL.md
@@ -97,11 +97,9 @@ Options:
 1. **Fix now** — Investigate and apply the fix immediately
 2. **Plan first** — Create a fix plan for review, then fix later
 
-**If user chooses "Plan first":**
-- Proceed to **Step 1.1: Create Fix Plan**
-
-**If user chooses "Fix now":**
-- Skip Step 1.1, proceed directly to **Step 2: Investigate the Codebase**
+**Based on choice:**
+- "Plan first" → Proceed to **Step 1.1: Create Fix Plan**
+- "Fix now" → Skip Step 1.1, proceed directly to **Step 2: Investigate the Codebase**
 
 ### Step 1.1: Create Fix Plan
 

--- a/skills/aif-implement/SKILL.md
+++ b/skills/aif-implement/SKILL.md
@@ -338,7 +338,7 @@ Options:
 **Based on choice:**
 - Yes, commit now → invoke `/aif-commit` with the suggested message, then continue to next task
 - No, continue to next task → proceed to the next task without committing
-- Skip all commit checkpoints → remember this choice for the remainder of the session. For all subsequent commit checkpoints in this session, skip the `AskUserQuestion` prompt and proceed directly to the next task (as if user selected "No, continue to next task" each time)
+- Skip all commit checkpoints → for all subsequent checkpoints within this `/aif-implement` run, skip the prompt automatically and proceed directly to the next task (as if user selected "No, continue to next task" each time). This is in-context memory — resets on `/clear` or new session
 
 **3.9: Move to next task or pause**
 

--- a/skills/aif-implement/SKILL.md
+++ b/skills/aif-implement/SKILL.md
@@ -70,11 +70,18 @@ Then reconcile plan/task state:
 
 **If uncommitted changes exist:**
 ```
-You have uncommitted changes. Commit them first?
-- [ ] Yes, commit now (/aif-commit)
-- [ ] No, stash and continue
-- [ ] Cancel
+AskUserQuestion: You have uncommitted changes. Commit them first?
+
+Options:
+1. Yes, commit now (/aif-commit)
+2. No, stash and continue
+3. Cancel
 ```
+
+**Based on choice:**
+- Yes → run `/aif-commit`, then continue to plan discovery
+- No → `git stash push -m "aif-implement: stash before plan execution"`, then continue
+- Cancel → inform the user: "Implementation cancelled." → **STOP**
 
 **If NO plan file exists but `.ai-factory/FIX_PLAN.md` exists:**
 
@@ -95,21 +102,21 @@ Running /aif-fix to execute the plan...
 **If NO plan file exists AND no FIX_PLAN.md (all tasks completed or fresh start):**
 
 ```
-No active plan found.
-
-Current branch: feature/user-auth
-
+AskUserQuestion: No active plan found. Current branch: <current-branch>.
 What would you like to do?
-- [ ] Start new feature from current branch
-- [ ] Return to main/master and start new feature
-- [ ] Create quick task plan (no branch)
-- [ ] Nothing, just checking status
+
+Options:
+1. Start new feature from current branch
+2. Return to main/master and start new feature
+3. Create quick task plan (no branch)
+4. Nothing, just checking status
 ```
 
 Based on choice:
 - New feature from current → `/aif-plan full <description>`
 - Return to main → `git checkout main`, then `git pull` → `/aif-plan full <description>`
 - Quick task → `/aif-plan fast <description>`
+- Nothing, just checking status → display branch info and recent commits summary → **STOP**
 
 **If plan file exists → continue to Step 0.1**
 
@@ -167,7 +174,7 @@ If any rule is violated — fix the output before presenting it to the user.
 - Apply proper error handling and logging as specified
 - Avoid pitfalls documented in skill-context rules and relevant fallback patches
 
-### Step 0.1: Find Plan File
+### Step 0.2: Find Plan File
 
 **If `$ARGUMENTS` contains `@<path>`:**
 
@@ -320,15 +327,18 @@ If during implementation:
 
 If the plan has commit checkpoints and current task is at a checkpoint:
 ```
-✅ Tasks 1-4 completed.
+AskUserQuestion: ✅ Tasks <first>-<last> completed. This is a commit checkpoint. Ready to commit? Suggested message: "<conventional commit message>"
 
-This is a commit checkpoint. Ready to commit?
-Suggested message: "feat: add base models and types"
-
-- [ ] Yes, commit now (/aif-commit)
-- [ ] No, continue to next task
-- [ ] Skip all commit checkpoints
+Options:
+1. Yes, commit now (/aif-commit)
+2. No, continue to next task
+3. Skip all commit checkpoints
 ```
+
+**Based on choice:**
+- Yes, commit now → invoke `/aif-commit` with the suggested message, then continue to next task
+- No, continue to next task → proceed to the next task without committing
+- Skip all commit checkpoints → remember this choice for the remainder of the session. For all subsequent commit checkpoints in this session, skip the `AskUserQuestion` prompt and proceed directly to the next task (as if user selected "No, continue to next task" each time)
 
 **3.9: Move to next task or pause**
 
@@ -418,32 +428,6 @@ Options:
 2. No — skip
 ```
 
-### Context Cleanup
-
-Context is heavy after implementation. All code changes are saved — suggest freeing space:
-
-```
-AskUserQuestion: Free up context before continuing?
-
-Options:
-1. /clear — Full reset (recommended)
-2. /compact — Compress history
-3. Continue as is
-```
-
-**Suggest verification:**
-
-```
-AskUserQuestion: All tasks complete. Run verification?
-
-Options:
-1. Verify first — Run /aif-verify to check completeness (recommended)
-2. Skip to commit — Go straight to /aif-commit
-```
-
-If user chooses "Verify first" → suggest invoking `/aif-verify`.
-If user chooses "Skip to commit" → suggest invoking `/aif-commit`.
-
 **Documentation policy checkpoint (after completion, before plan cleanup):**
 
 Read the plan file setting `Docs: yes/no`.
@@ -478,10 +462,19 @@ If plan setting is `Docs: no` or setting is unset:
 
 - **If `.ai-factory/PLAN.md`** (from `/aif-plan fast`):
   ```
-  Would you like to delete .ai-factory/PLAN.md? (It's no longer needed)
-  - [ ] Yes, delete it
-  - [ ] No, keep it
+  AskUserQuestion: Would you like to delete .ai-factory/PLAN.md? (It's no longer needed)
+
+  Options:
+  1. Yes, delete it
+  2. No, keep it
   ```
+
+  **Based on choice:**
+  - "Yes, delete it" → delete the file:
+    ```bash
+    rm .ai-factory/PLAN.md
+    ```
+  - "No, keep it" → leave the file as is, continue to the next step
 
 - **If branch-named file** (e.g., `.ai-factory/plans/feature-user-auth.md`):
   - Keep it - documents what was done
@@ -504,9 +497,11 @@ You're working in a parallel worktree.
   Worktree:  <current-directory>
   Main repo: <main-repo-path>
 
-Would you like to merge this branch into main and clean up?
-- [ ] Yes, merge and clean up (recommended)
-- [ ] No, I'll handle it manually
+AskUserQuestion: Would you like to merge this branch into main and clean up?
+
+Options:
+1. Yes, merge and clean up (recommended)
+2. No, I'll handle it manually
 ```
 
 If user chooses **"Yes, merge and clean up"**:
@@ -556,6 +551,8 @@ If user chooses **"Yes, merge and clean up"**:
    You're now in: <main-repo-path> (main)
    ```
 
+→ **STOP** — worktree merged and removed, no further steps needed.
+
 If user chooses **"No, I'll handle it manually"**, show a reminder:
 ```
 To merge and clean up later:
@@ -563,6 +560,24 @@ To merge and clean up later:
   git merge <branch>
   /aif-plan --cleanup <branch>
 ```
+
+### Final Step — Verify or Commit
+
+```
+AskUserQuestion: All tasks complete. What's next?
+
+Options:
+1. Verify first — Run /aif-verify to check completeness (recommended)
+2. Skip to commit — Go straight to /aif-commit
+```
+
+**Based on choice:**
+- "Verify first" → invoke `/aif-verify` → after it completes, continue to context cleanup below
+- "Skip to commit" → invoke `/aif-commit` → after it completes, continue to context cleanup below
+
+**Context cleanup (after verify or commit):**
+
+Suggest the user to free up context space if needed: `/clear` (full reset) or `/compact` (compress history).
 
 **IMPORTANT: NO summary reports, NO analysis documents, NO wrap-up tasks.**
 

--- a/skills/aif-implement/SKILL.md
+++ b/skills/aif-implement/SKILL.md
@@ -112,7 +112,7 @@ Options:
 4. Nothing, just checking status
 ```
 
-Based on choice:
+**Based on choice:**
 - New feature from current → `/aif-plan full <description>`
 - Return to main → `git checkout main`, then `git pull` → `/aif-plan full <description>`
 - Quick task → `/aif-plan fast <description>`
@@ -504,7 +504,17 @@ Options:
 2. No, I'll handle it manually
 ```
 
-If user chooses **"Yes, merge and clean up"**:
+**Based on choice:**
+- "Yes, merge and clean up" → follow the Worktree Merge procedure below
+- "No, I'll handle it manually" → show a reminder:
+  ```
+  To merge and clean up later:
+    cd <main-repo-path>
+    git merge <branch>
+    /aif-plan --cleanup <branch>
+  ```
+
+#### Worktree Merge
 
 1. **Ensure everything is committed** — check `git status`. If uncommitted changes exist, suggest `/aif-commit` first and wait.
 
@@ -552,14 +562,6 @@ If user chooses **"Yes, merge and clean up"**:
    ```
 
 → **STOP** — worktree merged and removed, no further steps needed.
-
-If user chooses **"No, I'll handle it manually"**, show a reminder:
-```
-To merge and clean up later:
-  cd <main-repo-path>
-  git merge <branch>
-  /aif-plan --cleanup <branch>
-```
 
 ### Final Step — Verify or Commit
 

--- a/skills/aif-improve/SKILL.md
+++ b/skills/aif-improve/SKILL.md
@@ -349,16 +349,7 @@ Ready to implement:
 
 ### Context Cleanup
 
-Context is heavy after deep codebase analysis. Plan is updated in file — suggest freeing space:
-
-```
-AskUserQuestion: Free up context before continuing?
-
-Options:
-1. /clear — Full reset (recommended)
-2. /compact — Compress history
-3. Continue as is
-```
+Suggest the user to free up context space if needed: `/clear` (full reset) or `/compact` (compress history).
 
 ## Important Rules
 

--- a/skills/aif-improve/SKILL.md
+++ b/skills/aif-improve/SKILL.md
@@ -264,11 +264,18 @@ Tasks analyzed: N
 - Dependencies to fix: N
 - Tasks to remove: N
 
-Apply these improvements?
-- [ ] Yes, apply all
-- [ ] Let me pick which ones
-- [ ] No, keep the plan as is
+AskUserQuestion: Apply these improvements?
+
+Options:
+1. Yes, apply all
+2. Let me pick which ones
+3. No, keep the plan as is
 ```
+
+**Based on choice:**
+- Yes, apply all → apply all improvements to the plan file
+- Let me pick which ones → present each improvement individually for approval
+- No, keep the plan as is → exit without modifications
 
 **If no improvements found:**
 

--- a/skills/aif-plan/SKILL.md
+++ b/skills/aif-plan/SKILL.md
@@ -166,21 +166,21 @@ Examples:
 AskUserQuestion: Before we start, a few questions:
 
 1. Should I write tests for this feature?
-   - [ ] Yes, write tests
-   - [ ] No, skip tests
+   a. Yes, write tests
+   b. No, skip tests
 
 2. Logging level for implementation:
-   - [ ] Verbose (recommended) - detailed DEBUG logs for development
-   - [ ] Standard - INFO level, key events only
-   - [ ] Minimal - only WARN/ERROR
+   a. Verbose (recommended) - detailed DEBUG logs for development
+   b. Standard - INFO level, key events only
+   c. Minimal - only WARN/ERROR
 
 3. Documentation policy after implementation?
-   - [ ] Yes — mandatory docs checkpoint at completion (recommended)
-   - [ ] No — warn-only (`WARN [docs]`), no mandatory checkpoint
+   a. Yes — mandatory docs checkpoint at completion (recommended)
+   b. No — warn-only (`WARN [docs]`), no mandatory checkpoint
 
 4. Roadmap milestone linkage (only if `.ai-factory/ROADMAP.md` exists):
-   - [ ] Link this plan to a milestone
-   - [ ] Skip — no linkage (allowed; `/aif-verify --strict` should report WARN, not fail, for missing linkage alone)
+   a. Link this plan to a milestone
+   b. Skip — no linkage (allowed; `/aif-verify --strict` should report WARN, not fail, for missing linkage alone)
 
 5. Any specific requirements or constraints?
 ```
@@ -305,14 +305,14 @@ Ask a shorter set of questions:
 AskUserQuestion: Before we start:
 
 1. Should I include tests in the plan?
-   - [ ] Yes, include tests
-   - [ ] No, skip tests
+   a. Yes, include tests
+   b. No, skip tests
 
 2. Any specific requirements or constraints?
 
 3. Roadmap milestone linkage (only if `.ai-factory/ROADMAP.md` exists):
-   - [ ] Link this plan to a milestone
-   - [ ] Skip — no linkage (allowed; `/aif-verify --strict` should report WARN, not fail, for missing linkage alone)
+   a. Link this plan to a milestone
+   b. Skip — no linkage (allowed; `/aif-verify --strict` should report WARN, not fail, for missing linkage alone)
 ```
 
 **Plan file:** Always `.ai-factory/PLAN.md` (no branch, no branch-named file).

--- a/skills/aif-plan/SKILL.md
+++ b/skills/aif-plan/SKILL.md
@@ -464,16 +464,7 @@ To view tasks:
 
 ### Context Cleanup
 
-Context is heavy after planning. All results are saved to the plan file — suggest freeing space:
-
-```
-AskUserQuestion: Free up context before continuing?
-
-Options:
-1. /clear — Full reset (recommended)
-2. /compact — Compress history
-3. Continue as is
-```
+Suggest the user to free up context space if needed: `/clear` (full reset) or `/compact` (compress history).
 
 ---
 

--- a/skills/aif-roadmap/SKILL.md
+++ b/skills/aif-roadmap/SKILL.md
@@ -72,7 +72,9 @@ Options:
 3. Both — I'll describe, you'll add what's missing
 ```
 
-If user chooses to describe → ask follow-up:
+**Based on choice:**
+- "Analyze codebase and suggest milestones" → proceed to Step 1.2
+- "Let me describe the vision" or "Both" → collect user description (if "Both", also add codebase analysis in Step 1.2), then ask follow-up:
 
 ```
 AskUserQuestion: Any priorities or deadlines?

--- a/skills/aif-verify/SKILL.md
+++ b/skills/aif-verify/SKILL.md
@@ -408,16 +408,7 @@ Options:
 
 ### Context Cleanup
 
-Context is heavy after verification. All results are saved — suggest freeing space:
-
-```
-AskUserQuestion: Free up context before continuing?
-
-Options:
-1. /clear — Full reset (recommended)
-2. /compact — Compress history
-3. Continue as is
-```
+Suggest the user to free up context space if needed: `/clear` (full reset) or `/compact` (compress history).
 
 ---
 

--- a/skills/aif-verify/SKILL.md
+++ b/skills/aif-verify/SKILL.md
@@ -43,7 +43,7 @@ Same logic as `/aif-implement`:
    → Look for .ai-factory/plans/<branch-name>.md
 ```
 
-If no plan file found:
+**If no plan file found:**
 ```
 AskUserQuestion: No plan file found. What should I verify?
 

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -32,7 +32,10 @@ PYTHON=$(command -v python3 || command -v python || echo "")
   2. Skip security scan (at your own risk — external skills won't be scanned for prompt injection)
   3. Install Python first and re-run `/aif`
 
-**If user chooses to skip** — show a clear warning: "External skills will NOT be scanned. Malicious prompt injections may go undetected." Then skip all Level 1 automated scans, but still perform Level 2 (manual semantic review).
+**Based on choice:**
+- "Provide path to Python" → use the provided path for all `python3` commands below
+- "Skip security scan" → show a clear warning: "External skills will NOT be scanned. Malicious prompt injections may go undetected." Then skip all Level 1 automated scans, but still perform Level 2 (manual semantic review).
+- "Install Python first" → **STOP**, user will re-run `/aif` after installing
 
 **Two-level check for every external skill:**
 


### PR DESCRIPTION
## Summary

Interactive prompts in skills used inconsistent formats — some had markdown checkboxes (`- [ ]`), others plain text. This made it unclear to the AI agent that it should use the `AskUserQuestion` tool to pause and wait for user input.

### Changes

- **Standardized prompt format**: replaced markdown checkboxes with explicit `AskUserQuestion:` blocks and numbered options across 6 skills
- **Added response handling**: each prompt now has a "Based on choice" section with clear branching logic, so the agent knows exactly what to do after the user responds
- **Simplified context cleanup**: replaced verbose AskUserQuestion blocks at the end of skills with a simple one-line suggestion (`/clear` or `/compact`), since forcing a 3-option prompt for this is overkill
- **Minor fixes**: quoted `argument-hint` in aif-fix frontmatter, fixed step numbering in aif-implement, added `→ STOP` markers where flow should end

### Affected skills

- `aif-docs` — context cleanup
- `aif-fix` — test suggestion prompt, context cleanup
- `aif-implement` — uncommitted changes, no plan, commit checkpoints, plan deletion, worktree merge, verify/commit final step, context cleanup
- `aif-improve` — context cleanup
- `aif-plan` — context cleanup
- `aif-verify` — context cleanup