### PR TITLE
Feature/review commits mode

### DIFF
--- a/skills/aif-review/SKILL.md
+++ b/skills/aif-review/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: aif-review
 description: Perform code review on staged changes or a pull request. Checks for bugs, security issues, performance problems, and best practices. Use when user says "review code", "check my code", "review PR", or "is this code okay".
-argument-hint: "[PR number or --commits [base] or empty]"
-allowed-tools: Bash(git *) Bash(gh *) Read Glob Grep
+argument-hint: "[PR number | branch/commit/tag | empty]"
+allowed-tools: Bash(git *) Bash(gh *) Read Glob Grep AskUserQuestion
 disable-model-invocation: false
 ---
 
@@ -24,29 +24,72 @@ Perform thorough code reviews focusing on correctness, security, performance, an
 2. Use `gh pr diff <number>` to get the diff
 3. Review all changes in the PR
 
-### With --commits (Review by Commits)
+### With Git Ref (Commits Mode)
 
-Review changes on the current branch commit-by-commit relative to a base branch.
+Argument routing chain:
+1. **Empty** → staged review (see above)
+2. **Digits or `#N`** → PR mode (see above)
+3. **Everything else** → validate via `git rev-parse --verify` → commits mode or ask user
 
-1. Determine base branch:
-   - If `$ARGUMENTS` contains `--commits <base>`, use `<base>` as the base branch
-   - If only `--commits` without explicit base, auto-detect:
-     - Run `git remote show origin | grep 'HEAD branch'` to find default branch
-     - Fallback to `main`, then `master`
-2. Get the list of commits:
+Validation:
+```bash
+git rev-parse --verify <argument> 2>/dev/null
+```
+
+- **Valid ref** → enter commits mode (steps below)
+- **Invalid ref** → do NOT fall back to staged review silently. Ask the user to clarify:
+
+  ```
+  AskUserQuestion: `<argument>` is not a valid git ref. What did you mean?
+
+  Options:
+  1. Review staged changes instead
+  2. Cancel
+  ```
+
+  **Based on choice:**
+  - "Review staged changes" → run staged review (default mode)
+  - "Cancel" → inform the user that review was cancelled → **STOP**
+  - "Other" → user provides corrected ref → re-validate via `rev-parse`
+
+> Edge case: a branch with a purely numeric name (e.g. `123`) will be interpreted as a PR number — acceptable compromise.
+
+**Steps:**
+
+1. **Get commit list** between the ref and HEAD:
    ```bash
-   git log --oneline --reverse <base>..HEAD
+   git log --oneline --reverse <ref>..HEAD
    ```
-3. For each commit, get the diff:
+   If no commits found (HEAD is at or behind `<ref>`), inform the user and **stop**.
+
+2. **Check commit count:**
+   If more than 20 commits, ask the user before proceeding:
+
+   ```
+   AskUserQuestion: Found <N> commits to review. Reviewing all of them will be slow and consume significant context. How to proceed?
+
+   Options:
+   1. Review all <N> commits
+   2. Review only the last 20
+   3. Cancel
+   ```
+
+   **Based on choice:**
+   - "Review all" → continue with the full commit list
+   - "Review only the last 20" → truncate the list to the 20 most recent commits (keep chronological order)
+   - "Cancel" → inform the user that review was cancelled → **STOP**
+
+3. **Review each commit:**
    ```bash
    git show <commit-hash> --stat
    git show <commit-hash>
    ```
-4. Review each commit individually, checking:
+   For each commit check:
    - Does the commit message match the actual changes?
    - Are changes atomic (single logical unit per commit)?
    - Are there any issues introduced in this specific commit?
-5. After reviewing all commits, provide a combined summary with per-commit notes
+
+4. **Provide combined summary** with per-commit notes
 
 ## Context Gates (Read-Only)
 
@@ -167,11 +210,14 @@ Review PR #123 using GitHub CLI.
 **User:** `/aif-review https://github.com/org/repo/pull/123`
 Review PR from URL.
 
-**User:** `/aif-review --commits`
-Review all commits on the current branch vs auto-detected base branch.
+**User:** `/aif-review 2.x`
+Review all commits on the current branch compared to branch `2.x`.
 
-**User:** `/aif-review --commits develop`
-Review all commits on the current branch vs `develop`.
+**User:** `/aif-review main`
+Review all commits on the current branch compared to `main`.
+
+**User:** `/aif-review v1.0.0`
+Review all commits on the current branch compared to tag `v1.0.0`.
 
 ## Integration
 

--- a/skills/aif-review/SKILL.md
+++ b/skills/aif-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aif-review
 description: Perform code review on staged changes or a pull request. Checks for bugs, security issues, performance problems, and best practices. Use when user says "review code", "check my code", "review PR", or "is this code okay".
-argument-hint: "[PR number or empty]"
+argument-hint: "[PR number or --commits [base] or empty]"
 allowed-tools: Bash(git *) Bash(gh *) Read Glob Grep
 disable-model-invocation: false
 ---
@@ -23,6 +23,30 @@ Perform thorough code reviews focusing on correctness, security, performance, an
 1. Use `gh pr view <number> --json` to get PR details
 2. Use `gh pr diff <number>` to get the diff
 3. Review all changes in the PR
+
+### With --commits (Review by Commits)
+
+Review changes on the current branch commit-by-commit relative to a base branch.
+
+1. Determine base branch:
+   - If `$ARGUMENTS` contains `--commits <base>`, use `<base>` as the base branch
+   - If only `--commits` without explicit base, auto-detect:
+     - Run `git remote show origin | grep 'HEAD branch'` to find default branch
+     - Fallback to `main`, then `master`
+2. Get the list of commits:
+   ```bash
+   git log --oneline --reverse <base>..HEAD
+   ```
+3. For each commit, get the diff:
+   ```bash
+   git show <commit-hash> --stat
+   git show <commit-hash>
+   ```
+4. Review each commit individually, checking:
+   - Does the commit message match the actual changes?
+   - Are changes atomic (single logical unit per commit)?
+   - Are there any issues introduced in this specific commit?
+5. After reviewing all commits, provide a combined summary with per-commit notes
 
 ## Context Gates (Read-Only)
 
@@ -142,6 +166,12 @@ Review PR #123 using GitHub CLI.
 
 **User:** `/aif-review https://github.com/org/repo/pull/123`
 Review PR from URL.
+
+**User:** `/aif-review --commits`
+Review all commits on the current branch vs auto-detected base branch.
+
+**User:** `/aif-review --commits develop`
+Review all commits on the current branch vs `develop`.
 
 ## Integration
 


### PR DESCRIPTION
Summary

- Add new --commits mode to /aif-review skill for reviewing changes commit-by-commit relative to a base branch
- Supports auto-detection of the base branch (--commits) and explicit specification (--commits develop)