### PR TITLE
feat: автообновление extension-ов и команда extension update

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,7 +45,15 @@
 
 The `agents` array can include any supported agent IDs: `claude`, `cursor`, `windsurf`, `roocode`, `kilocode`, `antigravity`, `opencode`, `warp`, `zencoder`, `codex`, `copilot`, `gemini`, `junie`, or `universal`. Each agent keeps its own `skillsDir`, installed skills list, and MCP preferences.
 
-The optional `extensions` array tracks installed extensions by name, original source, and version.
+The optional `extensions` array tracks installed extensions by name, original source, and version. `ai-factory update` now refreshes these extensions from their saved sources before base-skill updates, and `ai-factory extension update [name] --force` refreshes them without running the full base-skill update flow.
+
+Extension refresh uses the saved `source` field:
+
+- npm sources are checked against the npm registry and skipped when the published version is unchanged
+- GitHub sources fetch `extension.json` through the GitHub API before cloning
+- local paths and non-GitHub git sources require `--force` for refresh
+
+When GitHub-backed extension refreshes are frequent, set `GITHUB_TOKEN` to raise the GitHub API rate limit used by these checks.
 
 ## MCP Configuration
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -25,6 +25,15 @@ ai-factory extension add aif-ext-example
 # List installed extensions
 ai-factory extension list
 
+# Update extensions from their sources
+ai-factory extension update
+
+# Update a specific extension
+ai-factory extension update aif-ext-example
+
+# Force refresh even if version unchanged
+ai-factory extension update --force
+
 # Remove an extension (cleans up injections, MCP servers, and files)
 ai-factory extension remove aif-ext-example
 ```
@@ -40,9 +49,66 @@ ai-factory extension remove aif-ext-example
 
 ### What Happens on Update
 
-Running `ai-factory update` updates previously installed base skills, reports per-agent status (`changed`, `unchanged`, `skipped`, `removed`), skips base skills replaced by extensions, re-installs replacement skills, then **re-applies all extension injections** automatically. MCP server configs and custom commands are not affected by updates.
+Running `ai-factory update`:
 
-`ai-factory update --force` performs a clean reinstall of currently installed base skills before extension replacement and injection re-apply. Replaced skills are still handled by extension manifests, and custom extension commands/MCP config remain intact.
+1. **Self-update check** — prompts to update the CLI if a newer version exists
+2. **Extension refresh** — checks installed extensions for updates from their sources:
+   - npm packages: queries registry for latest version
+   - GitHub repos: fetches `extension.json` via GitHub API (faster than cloning)
+   - Local paths: requires `--force` to refresh
+   - Extensions with unchanged versions are skipped
+3. **Base skill update** — updates installed base skills, reports per-agent status (`changed`, `unchanged`, `skipped`, `removed`)
+4. **Reinstall replacement skills** — re-installs skills from extension manifests
+5. **Re-apply injections** — re-applies all extension injections automatically
+
+`ai-factory update --force` forces a clean reinstall of base skills AND forces extension refresh regardless of version changes.
+
+#### Extension Update Behavior
+
+| Source Type | Version Check | `--force` Behavior |
+|-------------|---------------|-------------------|
+| npm | Registry lookup, skip if unchanged | Always re-download |
+| GitHub | API fetch of `extension.json`, skip if unchanged | Always re-clone |
+| GitLab / other git | Requires `--force` | Always re-clone |
+| Local path | Requires `--force` | Re-copy from source |
+
+#### GitHub API Rate Limits
+
+GitHub API requests use `GITHUB_TOKEN` if present (5000 req/hr). Without a token, you're limited to 60 req/hr. If rate-limited, the extension refresh is skipped with a warning — the broader `update` continues.
+
+```bash
+# Set GITHUB_TOKEN for higher rate limits
+export GITHUB_TOKEN=ghp_xxxx
+ai-factory update
+```
+
+### Updating Extensions Separately
+
+Use `ai-factory extension update` to refresh extensions without updating base skills:
+
+```bash
+# Update all extensions
+ai-factory extension update
+
+# Update a specific extension
+ai-factory extension update aif-ext-example
+
+# Force refresh regardless of version
+ai-factory extension update --force
+```
+
+The command outputs per-extension status:
+
+```
+✓ aif-ext-example: v1.0.0 → v1.1.0
+- aif-ext-other: v1.0.0 (unchanged)
+⚠ aif-ext-local: source type requires --force
+
+Summary:
+  Updated: 1
+  Unchanged: 1
+  Skipped: 1
+```
 
 ### What Happens on Remove
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,13 +80,22 @@ ai-factory extension add ./my-extension
 # List installed extensions
 ai-factory extension list
 
+# Update extensions from their sources
+ai-factory extension update
+
+# Update a specific extension (use --force to refresh unchanged versions)
+ai-factory extension update my-extension --force
+
 # Remove extension
 ai-factory extension remove my-extension
 ```
 
 For v1 -> v2 migration, run `ai-factory upgrade` to rename old skills to the new `aif-*` prefix.
 
-`ai-factory update` now prints per-agent status buckets for base skills (`changed`, `unchanged`, `skipped`, `removed`). Skills newly available in the package but not previously installed are shown as `skipped` (not auto-installed).
+`ai-factory update` now:
+- Checks for extension updates from their sources (npm, GitHub, etc.) before updating base skills
+- Prints per-agent status buckets for base skills (`changed`, `unchanged`, `skipped`, `removed`)
+- Skills newly available in the package but not previously installed are shown as `skipped` (not auto-installed)
 
 ## Next Steps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "ai-factory",
-  "version": "2.1.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-factory",
-      "version": "2.1.0",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "fs-extra": "^11.2.0",
-        "inquirer": "^9.2.15"
+        "inquirer": "^9.2.15",
+        "semver": "^7.7.4"
       },
       "bin": {
         "ai-factory": "bin/ai-factory.js"
@@ -21,6 +22,7 @@
         "@types/fs-extra": "^11.0.4",
         "@types/inquirer": "^9.0.7",
         "@types/node": "^20.11.0",
+        "@types/semver": "^7.7.1",
         "knip": "^5.85.0",
         "typescript": "^5.3.3"
       },
@@ -482,6 +484,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/through": {
       "version": "0.0.33",
@@ -1354,6 +1363,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,12 @@
   ],
   "knip": {
     "ignoreExportsUsedInFile": true,
-    "exclude": ["types"],
-    "ignore": ["examples/**"]
+    "exclude": [
+      "types"
+    ],
+    "ignore": [
+      "examples/**"
+    ]
   },
   "engines": {
     "node": ">=18.0.0"
@@ -62,12 +66,14 @@
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "fs-extra": "^11.2.0",
-    "inquirer": "^9.2.15"
+    "inquirer": "^9.2.15",
+    "semver": "^7.7.4"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
     "@types/inquirer": "^9.0.7",
     "@types/node": "^20.11.0",
+    "@types/semver": "^7.7.1",
     "knip": "^5.85.0",
     "typescript": "^5.3.3"
   }

--- a/src/cli/commands/extension.ts
+++ b/src/cli/commands/extension.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import path from 'path';
-import { loadConfig, saveConfig } from '../../core/config.js';
+import { loadConfig, saveConfig, type AiFactoryConfig, type ExtensionRecord } from '../../core/config.js';
 import {
   resolveExtension,
   commitExtensionInstall,
@@ -8,22 +8,111 @@ import {
   getExtensionsDir,
   loadExtensionManifest,
   type ExtensionManifest,
+  type ResolvedExtension,
 } from '../../core/extensions.js';
+import { removeExtensionMcpServers } from '../../core/mcp.js';
 import {
-  applySingleExtensionInjections,
-} from '../../core/injections.js';
-import { configureExtensionMcpServers, removeExtensionMcpServers, validateMcpTemplate, type McpServerConfig } from '../../core/mcp.js';
-import { installExtensionSkills } from '../../core/installer.js';
-import { readJsonFile } from '../../utils/fs.js';
-import { getAgentConfig } from '../../core/agents.js';
-import {
+  assertNoReplacementConflicts,
+  installExtensionAssetsForAllAgents,
   removeSkillsForAllAgents,
-  installExtensionSkillsForAllAgents,
   collectReplacedSkills,
+  removePreviousExtensionState,
   restoreBaseSkills,
   stripInjectionsForAllAgents,
   removeCustomSkillsForAllAgents,
+  refreshExtensions,
 } from '../../core/extension-ops.js';
+
+interface CommitResolvedExtensionOptions {
+  config: AiFactoryConfig;
+  source: string;
+  resolved: ResolvedExtension;
+}
+
+async function commitResolvedExtension(
+  projectDir: string,
+  options: CommitResolvedExtensionOptions,
+): Promise<{ manifest: ExtensionManifest; extensionDir: string; record: ExtensionRecord }> {
+  const { config, source, resolved } = options;
+  const manifest = resolved.manifest;
+  const extensions = config.extensions ?? [];
+  const existIdx = extensions.findIndex(ext => ext.name === manifest.name);
+  const oldRecord = existIdx >= 0 ? { ...extensions[existIdx] } : null;
+  const oldManifest = existIdx >= 0
+    ? await loadExtensionManifest(path.join(getExtensionsDir(projectDir), manifest.name))
+    : null;
+
+  assertNoReplacementConflicts(extensions, manifest, manifest.name);
+
+  await commitExtensionInstall(projectDir, resolved);
+
+  if (existIdx >= 0) {
+    await removePreviousExtensionState(projectDir, config.agents, manifest.name, oldRecord, oldManifest);
+  }
+
+  console.log(chalk.green(`✓ Extension "${manifest.name}" v${manifest.version} installed`));
+
+  const extensionDir = path.join(getExtensionsDir(projectDir), manifest.name);
+  const assetInstall = await installExtensionAssetsForAllAgents(projectDir, config.agents, extensionDir, manifest);
+
+  for (const outcome of assetInstall.replacementOutcomes) {
+    if (outcome.status === 'installed') {
+      console.log(chalk.green(`✓ Replaced skill "${outcome.baseSkillName}" with "${path.basename(outcome.extensionSkillPath)}"`));
+    } else if (outcome.status === 'rolled-back') {
+      console.log(chalk.yellow(`⚠ Replacement "${outcome.baseSkillName}" only installed on ${outcome.successCount}/${outcome.agentCount} agents — rolled back, base skill restored`));
+    } else {
+      console.log(chalk.yellow(`⚠ Failed to replace skill "${outcome.baseSkillName}" — base skill preserved`));
+    }
+  }
+
+  for (const [agentId, installed] of assetInstall.customSkillInstalls) {
+    if (installed.length > 0) {
+      console.log(chalk.green(`✓ Skills installed for ${agentId}: ${installed.join(', ')}`));
+    }
+  }
+
+  if (assetInstall.injectionCount > 0) {
+    console.log(chalk.green(`✓ Applied ${assetInstall.injectionCount} injection(s)`));
+  }
+
+  if (assetInstall.configuredMcpServers.length > 0) {
+    console.log(chalk.green(`✓ MCP servers configured: ${assetInstall.configuredMcpServers.join(', ')}`));
+    for (const srv of manifest.mcpServers ?? []) {
+      if (srv.instruction) {
+        console.log(chalk.dim(`    ${srv.instruction}`));
+      }
+    }
+  }
+
+  const record: ExtensionRecord = {
+    name: manifest.name,
+    source,
+    version: manifest.version,
+    replacedSkills: assetInstall.replacedSkills.length > 0 ? assetInstall.replacedSkills : undefined,
+  };
+
+  if (existIdx >= 0) {
+    extensions[existIdx] = record;
+  } else {
+    extensions.push(record);
+  }
+
+  config.extensions = extensions;
+  await saveConfig(projectDir, config);
+
+  if (manifest.agents?.length) {
+    console.log(chalk.dim(`  Agents provided: ${manifest.agents.map(agent => agent.displayName).join(', ')}`));
+  }
+  if (manifest.commands?.length) {
+    console.log(chalk.dim(`  Commands provided: ${manifest.commands.map(command => command.name).join(', ')}`));
+  }
+  if (manifest.skills?.length) {
+    console.log(chalk.dim(`  Skills provided: ${manifest.skills.join(', ')}`));
+  }
+  console.log('');
+
+  return { manifest, extensionDir, record };
+}
 
 export async function extensionAddCommand(source: string): Promise<void> {
   const projectDir = process.cwd();
@@ -40,151 +129,10 @@ export async function extensionAddCommand(source: string): Promise<void> {
   console.log(chalk.dim(`Installing from: ${source}\n`));
 
   try {
-    const extensions = config.extensions ?? [];
-
-    // Phase 1: Resolve source — download/clone and validate manifest WITHOUT writing to project
     const resolved = await resolveExtension(projectDir, source);
-    const manifest = resolved.manifest;
 
     try {
-      const existIdx = extensions.findIndex(e => e.name === manifest.name);
-      const oldRecord = existIdx >= 0 ? { ...extensions[existIdx] } : null;
-
-      // Load old manifest from installed dir (still intact — we haven't overwritten yet)
-      const oldManifest = existIdx >= 0
-        ? await loadExtensionManifest(path.join(getExtensionsDir(projectDir), manifest.name))
-        : null;
-
-      // Block conflicting replacements BEFORE copying any files
-      if (manifest.replaces) {
-        for (const [, baseSkillName] of Object.entries(manifest.replaces)) {
-          for (const other of extensions) {
-            if (other.name === manifest.name) continue;
-            if (other.replacedSkills?.includes(baseSkillName)) {
-              throw new Error(`Conflict: skill "${baseSkillName}" is already replaced by extension "${other.name}". Remove it first.`);
-            }
-          }
-        }
-      }
-
-      // Phase 2: Commit — copy resolved files to .ai-factory/extensions/<name>/
-      await commitExtensionInstall(projectDir, resolved);
-
-      // Clean up old state on re-install
-      if (existIdx >= 0) {
-        await stripInjectionsForAllAgents(projectDir, config.agents, manifest.name);
-
-        // Remove old replacement skills (installed under base names)
-        if (oldRecord?.replacedSkills?.length) {
-          await removeSkillsForAllAgents(projectDir, config.agents, oldRecord.replacedSkills);
-          await restoreBaseSkills(projectDir, config.agents, oldRecord.replacedSkills, new Set());
-        }
-
-        // Remove old extension custom skills using the OLD manifest (not the new one)
-        if (oldManifest) {
-          await removeCustomSkillsForAllAgents(projectDir, config.agents, oldManifest);
-        }
-      }
-
-      console.log(chalk.green(`✓ Extension "${manifest.name}" v${manifest.version} installed`));
-
-      const extensionDir = path.join(getExtensionsDir(projectDir), manifest.name);
-
-      // Install replacement skills — only track successfully installed ones
-      const replacedSkills: string[] = [];
-      const replacesPaths = new Set<string>();
-      if (manifest.replaces && Object.keys(manifest.replaces).length > 0) {
-        const nameOverrides: Record<string, string> = { ...manifest.replaces };
-        const replacePaths = Object.keys(manifest.replaces);
-
-        // Track per-agent success: only count as replaced if installed on ALL agents
-        const perAgentResults = new Map<string, number>(); // baseName → success count
-        for (const agent of config.agents) {
-          const installed = await installExtensionSkills(projectDir, agent, extensionDir, replacePaths, nameOverrides);
-          for (const name of installed) {
-            perAgentResults.set(name, (perAgentResults.get(name) ?? 0) + 1);
-          }
-        }
-
-        const agentCount = config.agents.length;
-        for (const [extSkillPath, baseSkillName] of Object.entries(manifest.replaces)) {
-          replacesPaths.add(extSkillPath);
-          const successCount = perAgentResults.get(baseSkillName) ?? 0;
-          if (successCount === agentCount) {
-            replacedSkills.push(baseSkillName);
-            console.log(chalk.green(`✓ Replaced skill "${baseSkillName}" with "${path.basename(extSkillPath)}"`));
-          } else if (successCount > 0) {
-            // Rollback: remove the replacement from agents where it did install, restore base skill
-            await removeSkillsForAllAgents(projectDir, config.agents, [baseSkillName]);
-            await restoreBaseSkills(projectDir, config.agents, [baseSkillName], new Set());
-            console.log(chalk.yellow(`⚠ Replacement "${baseSkillName}" only installed on ${successCount}/${agentCount} agents — rolled back, base skill restored`));
-          } else {
-            console.log(chalk.yellow(`⚠ Failed to replace skill "${baseSkillName}" — base skill preserved`));
-          }
-        }
-      }
-
-      // Install extension custom skills (excluding replacements)
-      if (manifest.skills?.length) {
-        const nonReplacementSkills = manifest.skills.filter(s => !replacesPaths.has(s));
-        if (nonReplacementSkills.length > 0) {
-          const results = await installExtensionSkillsForAllAgents(projectDir, config.agents, extensionDir, nonReplacementSkills);
-          for (const [agentId, installed] of results) {
-            if (installed.length > 0) {
-              console.log(chalk.green(`✓ Skills installed for ${agentId}: ${installed.join(', ')}`));
-            }
-          }
-        }
-      }
-
-      // Save config AFTER all installations succeed
-      const record = { name: manifest.name, source, version: manifest.version, replacedSkills: replacedSkills.length > 0 ? replacedSkills : undefined };
-      if (existIdx >= 0) {
-        extensions[existIdx] = record;
-      } else {
-        extensions.push(record);
-      }
-      config.extensions = extensions;
-      await saveConfig(projectDir, config);
-
-      // Apply injections for all agents
-      if (manifest.injections?.length) {
-        let totalInjections = 0;
-
-        for (const agent of config.agents) {
-          const count = await applySingleExtensionInjections(projectDir, agent, extensionDir, manifest);
-          totalInjections += count;
-        }
-
-        if (totalInjections > 0) {
-          console.log(chalk.green(`✓ Applied ${totalInjections} injection(s)`));
-        }
-      }
-
-      // Configure MCP servers for all agents that support it
-      if (manifest.mcpServers?.length) {
-        const mcpConfigured = await applyExtensionMcp(projectDir, config.agents.map(a => a.id), extensionDir, manifest);
-        if (mcpConfigured.length > 0) {
-          console.log(chalk.green(`✓ MCP servers configured: ${mcpConfigured.join(', ')}`));
-          for (const srv of manifest.mcpServers) {
-            if (srv.instruction) {
-              console.log(chalk.dim(`    ${srv.instruction}`));
-            }
-          }
-        }
-      }
-
-      if (manifest.agents?.length) {
-        console.log(chalk.dim(`  Agents provided: ${manifest.agents.map(a => a.displayName).join(', ')}`));
-      }
-      if (manifest.commands?.length) {
-        console.log(chalk.dim(`  Commands provided: ${manifest.commands.map(c => c.name).join(', ')}`));
-      }
-      if (manifest.skills?.length) {
-        console.log(chalk.dim(`  Skills provided: ${manifest.skills.join(', ')}`));
-      }
-
-      console.log('');
+      await commitResolvedExtension(projectDir, { config, source, resolved });
     } finally {
       await resolved.cleanup();
     }
@@ -314,39 +262,90 @@ export async function extensionListCommand(): Promise<void> {
   console.log('');
 }
 
-async function applyExtensionMcp(
-  projectDir: string,
-  agentIds: string[],
-  extensionDir: string,
-  manifest: ExtensionManifest,
-): Promise<string[]> {
-  if (!manifest.mcpServers?.length) return [];
+export async function extensionUpdateCommand(name?: string, options?: { force?: boolean }): Promise<void> {
+  const projectDir = process.cwd();
+  const force = options?.force ?? false;
 
-  const allConfigured: string[] = [];
+  console.log(chalk.bold.blue('\n🏭 AI Factory - Update Extensions\n'));
 
-  for (const srv of manifest.mcpServers) {
-    let template: unknown;
-    if (typeof srv.template === 'string') {
-      const templatePath = path.join(extensionDir, srv.template);
-      template = await readJsonFile<McpServerConfig>(templatePath);
-    } else {
-      template = srv.template;
-    }
-    if (!template) continue;
-    validateMcpTemplate(template, srv.key);
+  if (force) {
+    console.log(chalk.dim('Force mode: refreshing all extensions regardless of version\n'));
+  }
 
-    for (const agentId of agentIds) {
-      const agentConfig = getAgentConfig(agentId);
-      if (!agentConfig.supportsMcp) continue;
+  const config = await loadConfig(projectDir);
+  if (!config) {
+    console.log(chalk.red('Error: No .ai-factory.json found.'));
+    console.log(chalk.dim('Run "ai-factory init" to set up your project first.'));
+    process.exit(1);
+  }
 
-      const configured = await configureExtensionMcpServers(projectDir, agentId, [
-        { key: srv.key, template },
-      ]);
-      if (configured.length > 0 && !allConfigured.includes(srv.key)) {
-        allConfigured.push(srv.key);
+  const extensions = config.extensions ?? [];
+
+  if (extensions.length === 0) {
+    console.log(chalk.dim('No extensions installed.\n'));
+    return;
+  }
+
+  if (name && !extensions.find((e) => e.name === name)) {
+    console.log(chalk.red(`Extension "${name}" is not installed.`));
+    console.log(chalk.dim(`Installed extensions: ${extensions.map((e) => e.name).join(', ')}`));
+    process.exit(1);
+  }
+
+  const targetNames = name ? [name] : undefined;
+
+  const summary = await refreshExtensions(projectDir, config, {
+    targetNames,
+    force,
+    log: (level, message) => {
+      if (level === 'warn') {
+        console.log(chalk.yellow(message));
+      } else {
+        console.log(chalk.dim(message));
       }
+    },
+  });
+
+  if (summary.updated.length > 0) {
+    for (const r of summary.updated) {
+      console.log(chalk.green(`  ✓ ${r.name}: v${r.oldVersion} → v${r.newVersion}`));
     }
   }
 
-  return allConfigured;
+  for (const r of summary.unchanged) {
+    console.log(chalk.dim(`  - ${r.name}: v${r.oldVersion} (unchanged)`));
+  }
+
+  for (const r of summary.skipped) {
+    if (r.failureReason === 'rate-limited') {
+      console.log(chalk.yellow(`  ⚠ ${r.name}: GitHub API rate limited, skipping`));
+    } else if (r.failureReason === 'source-type-requires-force') {
+      console.log(
+        chalk.yellow(`  ⚠ ${r.name}: source type requires --force to refresh`),
+      );
+    } else {
+      console.log(chalk.dim(`  - ${r.name}: ${r.failureReason}`));
+    }
+  }
+
+  for (const r of summary.failed) {
+    console.log(chalk.red(`  ✗ ${r.name}: ${r.failureReason}`));
+  }
+
+  await saveConfig(projectDir, config);
+
+  console.log('');
+  console.log(chalk.bold('Summary:'));
+  console.log(chalk.green(`  Updated: ${summary.updated.length}`));
+  console.log(chalk.dim(`  Unchanged: ${summary.unchanged.length}`));
+  console.log(chalk.dim(`  Skipped: ${summary.skipped.length}`));
+  if (summary.failed.length > 0) {
+    console.log(chalk.red(`  Failed: ${summary.failed.length}`));
+  }
+  console.log('');
+
+  if (summary.failed.length > 0) {
+    process.exit(1);
+  }
 }
+

--- a/src/cli/commands/extension.ts
+++ b/src/cli/commands/extension.ts
@@ -1,118 +1,22 @@
 import chalk from 'chalk';
 import path from 'path';
-import { loadConfig, saveConfig, type AiFactoryConfig, type ExtensionRecord } from '../../core/config.js';
+import { loadConfig, saveConfig } from '../../core/config.js';
 import {
   resolveExtension,
-  commitExtensionInstall,
   removeExtensionFiles,
   getExtensionsDir,
   loadExtensionManifest,
-  type ExtensionManifest,
-  type ResolvedExtension,
 } from '../../core/extensions.js';
 import { removeExtensionMcpServers } from '../../core/mcp.js';
 import {
-  assertNoReplacementConflicts,
-  installExtensionAssetsForAllAgents,
   removeSkillsForAllAgents,
   collectReplacedSkills,
-  removePreviousExtensionState,
   restoreBaseSkills,
   stripInjectionsForAllAgents,
   removeCustomSkillsForAllAgents,
+  commitResolvedExtension,
   refreshExtensions,
 } from '../../core/extension-ops.js';
-
-interface CommitResolvedExtensionOptions {
-  config: AiFactoryConfig;
-  source: string;
-  resolved: ResolvedExtension;
-}
-
-async function commitResolvedExtension(
-  projectDir: string,
-  options: CommitResolvedExtensionOptions,
-): Promise<{ manifest: ExtensionManifest; extensionDir: string; record: ExtensionRecord }> {
-  const { config, source, resolved } = options;
-  const manifest = resolved.manifest;
-  const extensions = config.extensions ?? [];
-  const existIdx = extensions.findIndex(ext => ext.name === manifest.name);
-  const oldRecord = existIdx >= 0 ? { ...extensions[existIdx] } : null;
-  const oldManifest = existIdx >= 0
-    ? await loadExtensionManifest(path.join(getExtensionsDir(projectDir), manifest.name))
-    : null;
-
-  assertNoReplacementConflicts(extensions, manifest, manifest.name);
-
-  await commitExtensionInstall(projectDir, resolved);
-
-  if (existIdx >= 0) {
-    await removePreviousExtensionState(projectDir, config.agents, manifest.name, oldRecord, oldManifest);
-  }
-
-  console.log(chalk.green(`✓ Extension "${manifest.name}" v${manifest.version} installed`));
-
-  const extensionDir = path.join(getExtensionsDir(projectDir), manifest.name);
-  const assetInstall = await installExtensionAssetsForAllAgents(projectDir, config.agents, extensionDir, manifest);
-
-  for (const outcome of assetInstall.replacementOutcomes) {
-    if (outcome.status === 'installed') {
-      console.log(chalk.green(`✓ Replaced skill "${outcome.baseSkillName}" with "${path.basename(outcome.extensionSkillPath)}"`));
-    } else if (outcome.status === 'rolled-back') {
-      console.log(chalk.yellow(`⚠ Replacement "${outcome.baseSkillName}" only installed on ${outcome.successCount}/${outcome.agentCount} agents — rolled back, base skill restored`));
-    } else {
-      console.log(chalk.yellow(`⚠ Failed to replace skill "${outcome.baseSkillName}" — base skill preserved`));
-    }
-  }
-
-  for (const [agentId, installed] of assetInstall.customSkillInstalls) {
-    if (installed.length > 0) {
-      console.log(chalk.green(`✓ Skills installed for ${agentId}: ${installed.join(', ')}`));
-    }
-  }
-
-  if (assetInstall.injectionCount > 0) {
-    console.log(chalk.green(`✓ Applied ${assetInstall.injectionCount} injection(s)`));
-  }
-
-  if (assetInstall.configuredMcpServers.length > 0) {
-    console.log(chalk.green(`✓ MCP servers configured: ${assetInstall.configuredMcpServers.join(', ')}`));
-    for (const srv of manifest.mcpServers ?? []) {
-      if (srv.instruction) {
-        console.log(chalk.dim(`    ${srv.instruction}`));
-      }
-    }
-  }
-
-  const record: ExtensionRecord = {
-    name: manifest.name,
-    source,
-    version: manifest.version,
-    replacedSkills: assetInstall.replacedSkills.length > 0 ? assetInstall.replacedSkills : undefined,
-  };
-
-  if (existIdx >= 0) {
-    extensions[existIdx] = record;
-  } else {
-    extensions.push(record);
-  }
-
-  config.extensions = extensions;
-  await saveConfig(projectDir, config);
-
-  if (manifest.agents?.length) {
-    console.log(chalk.dim(`  Agents provided: ${manifest.agents.map(agent => agent.displayName).join(', ')}`));
-  }
-  if (manifest.commands?.length) {
-    console.log(chalk.dim(`  Commands provided: ${manifest.commands.map(command => command.name).join(', ')}`));
-  }
-  if (manifest.skills?.length) {
-    console.log(chalk.dim(`  Skills provided: ${manifest.skills.join(', ')}`));
-  }
-  console.log('');
-
-  return { manifest, extensionDir, record };
-}
 
 export async function extensionAddCommand(source: string): Promise<void> {
   const projectDir = process.cwd();
@@ -132,7 +36,31 @@ export async function extensionAddCommand(source: string): Promise<void> {
     const resolved = await resolveExtension(projectDir, source);
 
     try {
-      await commitResolvedExtension(projectDir, { config, source, resolved });
+      const { manifest } = await commitResolvedExtension(projectDir, {
+        config,
+        source,
+        resolved,
+        log: (level, message) => {
+          if (level === 'warn') {
+            console.log(chalk.yellow(`⚠ ${message}`));
+          } else {
+            console.log(chalk.green(`✓ ${message}`));
+          }
+        },
+      });
+      await saveConfig(projectDir, config);
+
+      console.log(chalk.green(`✓ Extension "${manifest.name}" v${manifest.version} installed`));
+      if (manifest.agents?.length) {
+        console.log(chalk.dim(`  Agents provided: ${manifest.agents.map(agent => agent.displayName).join(', ')}`));
+      }
+      if (manifest.commands?.length) {
+        console.log(chalk.dim(`  Commands provided: ${manifest.commands.map(command => command.name).join(', ')}`));
+      }
+      if (manifest.skills?.length) {
+        console.log(chalk.dim(`  Skills provided: ${manifest.skills.join(', ')}`));
+      }
+      console.log('');
     } finally {
       await resolved.cleanup();
     }
@@ -319,6 +247,8 @@ export async function extensionUpdateCommand(name?: string, options?: { force?: 
   for (const r of summary.skipped) {
     if (r.failureReason === 'rate-limited') {
       console.log(chalk.yellow(`  ⚠ ${r.name}: GitHub API rate limited, skipping`));
+    } else if (r.failureReason === 'lookup-failed') {
+      console.log(chalk.yellow(`  ⚠ ${r.name}: version check failed, retry or use --force`));
     } else if (r.failureReason === 'source-type-requires-force') {
       console.log(
         chalk.yellow(`  ⚠ ${r.name}: source type requires --force to refresh`),

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -4,13 +4,14 @@ import {realpathSync} from 'fs';
 import {execSync} from 'child_process';
 import inquirer from 'inquirer';
 import {getCurrentVersion, loadConfig, saveConfig} from '../../core/config.js';
+import {compareExtensionVersions, getExtensionsDir, getNpmVersionCheckResult, loadExtensionManifest} from '../../core/extensions.js';
 import {buildManagedSkillsState, getAvailableSkills, partitionSkills, type SkillUpdateEntry, updateSkills} from '../../core/installer.js';
 import {applyExtensionInjections} from '../../core/injections.js';
-import {getExtensionsDir, loadExtensionManifest} from '../../core/extensions.js';
 import {
   installExtensionSkillsForAllAgents,
   installSkillsForAllAgents,
   collectReplacedSkills,
+  refreshExtensions,
 } from '../../core/extension-ops.js';
 import {fileExists} from '../../utils/fs.js';
 
@@ -54,39 +55,13 @@ function groupEntriesByStatus(entries: SkillUpdateEntry[]): Record<'changed' | '
   };
 }
 
-function parseVersion(v: string): { parts: number[]; prerelease: string | null } {
-  const [core, ...rest] = v.split('-');
-  return {
-    parts: core.split('.').map(Number),
-    prerelease: rest.length > 0 ? rest.join('-') : null,
-  };
-}
-
 function isNewerVersion(latest: string, current: string): boolean {
-  const l = parseVersion(latest);
-  const c = parseVersion(current);
-  for (let i = 0; i < 3; i++) {
-    if ((l.parts[i] ?? 0) > (c.parts[i] ?? 0)) return true;
-    if ((l.parts[i] ?? 0) < (c.parts[i] ?? 0)) return false;
-  }
-  // Equal major.minor.patch: prerelease is older than stable (semver §11)
-  if (c.prerelease && !l.prerelease) return true;
-  if (!c.prerelease && l.prerelease) return false;
-  return false;
+  return compareExtensionVersions(latest, current) > 0;
 }
 
 async function getLatestVersion(): Promise<string | null> {
-  try {
-    const response = await fetch('https://registry.npmjs.org/ai-factory/latest', {
-      signal: AbortSignal.timeout(5000),
-    });
-    if (!response.ok) return null;
-    const data = await response.json() as {version: string};
-    if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(data.version)) return null;
-    return data.version;
-  } catch {
-    return null;
-  }
+  const versionCheck = await getNpmVersionCheckResult('ai-factory', getCurrentVersion());
+  return versionCheck.latestVersion;
 }
 
 function getInstallCommand(version: string): string {
@@ -177,8 +152,40 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
   const selfUpdated = await selfUpdate(currentVersion);
   if (selfUpdated) return;
 
+  const extensions = config.extensions ?? [];
+
   if (force) {
     console.log(chalk.yellow('⚠ Force mode enabled: clean reinstall of installed base skills\n'));
+  }
+
+  if (extensions.length > 0) {
+    console.log(chalk.dim('Refreshing extensions...\n'));
+
+    const extensionSummary = await refreshExtensions(projectDir, config, { force });
+
+    if (extensionSummary.updated.length > 0) {
+      for (const r of extensionSummary.updated) {
+        console.log(chalk.green(`  ✓ ${r.name}: v${r.oldVersion} → v${r.newVersion}`));
+      }
+    }
+
+    for (const r of extensionSummary.skipped) {
+      if (r.failureReason === 'rate-limited') {
+        console.log(chalk.yellow(`  ⚠ ${r.name}: GitHub API rate limited`));
+      } else if (r.failureReason === 'source-type-requires-force') {
+        console.log(chalk.dim(`  - ${r.name}: source type requires --force`));
+      }
+    }
+
+    for (const r of extensionSummary.failed) {
+      console.log(chalk.yellow(`  ⚠ ${r.name}: ${r.failureReason}`));
+    }
+
+    console.log(
+      chalk.dim(
+        `Extensions: ${extensionSummary.updated.length} updated, ${extensionSummary.unchanged.length} unchanged, ${extensionSummary.failed.length} failed\n`,
+      ),
+    );
   }
 
   console.log(chalk.dim('Updating skills...\n'));
@@ -187,7 +194,6 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
     const availableSkills = await getAvailableSkills();
     const entriesByAgent = new Map<string, SkillUpdateEntry[]>();
 
-    const extensions = config.extensions ?? [];
     const allReplacedSkills = collectReplacedSkills(extensions);
 
     if (allReplacedSkills.size > 0) {

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -161,7 +161,16 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
   if (extensions.length > 0) {
     console.log(chalk.dim('Refreshing extensions...\n'));
 
-    const extensionSummary = await refreshExtensions(projectDir, config, { force });
+    const extensionSummary = await refreshExtensions(projectDir, config, {
+      force,
+      log: (level, message) => {
+        if (level === 'warn') {
+          console.log(chalk.yellow(`  ⚠ ${message}`));
+        } else {
+          console.log(chalk.dim(`  ${message}`));
+        }
+      },
+    });
 
     if (extensionSummary.updated.length > 0) {
       for (const r of extensionSummary.updated) {
@@ -172,6 +181,8 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
     for (const r of extensionSummary.skipped) {
       if (r.failureReason === 'rate-limited') {
         console.log(chalk.yellow(`  ⚠ ${r.name}: GitHub API rate limited`));
+      } else if (r.failureReason === 'lookup-failed') {
+        console.log(chalk.yellow(`  ⚠ ${r.name}: extension version check failed`));
       } else if (r.failureReason === 'source-type-requires-force') {
         console.log(chalk.dim(`  - ${r.name}: source type requires --force`));
       }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { initCommand } from './commands/init.js';
 import { updateCommand } from './commands/update.js';
 import { upgradeCommand } from './commands/upgrade.js';
-import { extensionAddCommand, extensionRemoveCommand, extensionListCommand } from './commands/extension.js';
+import { extensionAddCommand, extensionRemoveCommand, extensionListCommand, extensionUpdateCommand } from './commands/extension.js';
 import { getCurrentVersion, loadConfig } from '../core/config.js';
 import { loadAllExtensions } from '../core/extensions.js';
 
@@ -47,6 +47,12 @@ ext
   .command('list')
   .description('List installed extensions')
   .action(extensionListCommand);
+
+ext
+  .command('update [name]')
+  .description('Update extension(s) from their sources')
+  .option('--force', 'Force refresh even if version unchanged')
+  .action(extensionUpdateCommand);
 
 async function loadExtensionCommands(): Promise<void> {
   try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,7 +21,7 @@ program
 program
   .command('update')
   .description('Update installed skills to latest version')
-  .option('--force', 'Force clean reinstall of currently installed base skills')
+  .option('--force', 'Force extension refresh and clean reinstall of currently installed base skills')
   .action(updateCommand);
 
 program

--- a/src/core/extension-ops.ts
+++ b/src/core/extension-ops.ts
@@ -13,8 +13,8 @@ import {
 } from './extensions.js';
 import { installSkills, getAvailableSkills, installExtensionSkills, removeExtensionSkills } from './installer.js';
 import { applySingleExtensionInjections, stripAllExtensionInjections, stripInjectionsByExtensionName } from './injections.js';
-import { configureExtensionMcpServers, validateMcpTemplate, type McpServerConfig } from './mcp.js';
-import { readJsonFile } from '../utils/fs.js';
+import { configureExtensionMcpServers, removeExtensionMcpServers, validateMcpTemplate, type McpServerConfig } from './mcp.js';
+import { copyDirectory, ensureDir, fileExists, readJsonFile, removeDirectory } from '../utils/fs.js';
 
 export interface ExtensionAssetInstallResult {
   replacedSkills: string[];
@@ -35,6 +35,14 @@ export interface CommitResolvedExtensionOptions {
   source: string;
   resolved: ResolvedExtension;
   log?: (level: 'info' | 'warn', message: string) => void;
+}
+
+interface ExtensionInstallRollbackContext {
+  extensionDir: string;
+  backupDir: string | null;
+  oldRecord: ExtensionRecord | null;
+  oldManifest: ExtensionManifest | null;
+  newManifest: ExtensionManifest;
 }
 
 /**
@@ -149,6 +157,13 @@ export async function removePreviousExtensionState(
 ): Promise<void> {
   await stripInjectionsForAllAgents(projectDir, agents, extensionName, oldManifest);
 
+  if (oldManifest?.mcpServers?.length) {
+    const mcpKeys = oldManifest.mcpServers.map(server => server.key);
+    for (const agent of agents) {
+      await removeExtensionMcpServers(projectDir, agent.id, mcpKeys);
+    }
+  }
+
   if (oldRecord?.replacedSkills?.length) {
     await removeSkillsForAllAgents(projectDir, agents, oldRecord.replacedSkills);
     await restoreBaseSkills(projectDir, agents, oldRecord.replacedSkills, new Set());
@@ -157,6 +172,43 @@ export async function removePreviousExtensionState(
   if (oldManifest) {
     await removeCustomSkillsForAllAgents(projectDir, agents, oldManifest);
   }
+}
+
+async function cleanupPartialExtensionState(
+  projectDir: string,
+  agents: AgentInstallation[],
+  extensionName: string,
+  manifest: ExtensionManifest,
+): Promise<void> {
+  const partialRecord: ExtensionRecord = {
+    name: extensionName,
+    source: '',
+    version: manifest.version,
+    replacedSkills: manifest.replaces ? Object.values(manifest.replaces) : undefined,
+  };
+
+  await removePreviousExtensionState(projectDir, agents, extensionName, partialRecord, manifest);
+}
+
+async function rollbackFailedExtensionInstall(
+  projectDir: string,
+  agents: AgentInstallation[],
+  context: ExtensionInstallRollbackContext,
+): Promise<void> {
+  await cleanupPartialExtensionState(projectDir, agents, context.newManifest.name, context.newManifest);
+
+  if (context.backupDir) {
+    await removeDirectory(context.extensionDir);
+    await ensureDir(path.dirname(context.extensionDir));
+    await copyDirectory(context.backupDir, context.extensionDir);
+
+    if (context.oldManifest) {
+      await installExtensionAssetsForAllAgents(projectDir, agents, context.extensionDir, context.oldManifest);
+    }
+    return;
+  }
+
+  await removeDirectory(context.extensionDir);
 }
 
 /**
@@ -320,21 +372,48 @@ export async function commitResolvedExtension(
   const manifest = resolved.manifest;
   const extensions = config.extensions ?? [];
   const existIdx = extensions.findIndex(ext => ext.name === manifest.name);
+  const extensionDir = path.join(getExtensionsDir(projectDir), manifest.name);
+  const backupCandidateDir = existIdx >= 0
+    ? path.join(getExtensionsDir(projectDir), `.backup-${manifest.name}-${Date.now()}`)
+    : null;
   const oldRecord = existIdx >= 0 ? { ...extensions[existIdx] } : null;
   const oldManifest = existIdx >= 0
-    ? await loadExtensionManifest(path.join(getExtensionsDir(projectDir), manifest.name))
+    ? await loadExtensionManifest(extensionDir)
     : null;
 
   assertNoReplacementConflicts(extensions, manifest, manifest.name);
 
-  await commitExtensionInstall(projectDir, resolved);
-
-  if (existIdx >= 0) {
-    await removePreviousExtensionState(projectDir, config.agents, manifest.name, oldRecord, oldManifest);
+  let backupDir: string | null = null;
+  if (backupCandidateDir && await fileExists(extensionDir)) {
+    await removeDirectory(backupCandidateDir);
+    await copyDirectory(extensionDir, backupCandidateDir);
+    backupDir = backupCandidateDir;
   }
 
-  const extensionDir = path.join(getExtensionsDir(projectDir), manifest.name);
-  const assetInstall = await installExtensionAssetsForAllAgents(projectDir, config.agents, extensionDir, manifest);
+  let assetInstall: ExtensionAssetInstallResult;
+
+  try {
+    await commitExtensionInstall(projectDir, resolved);
+
+    if (existIdx >= 0) {
+      await removePreviousExtensionState(projectDir, config.agents, manifest.name, oldRecord, oldManifest);
+    }
+
+    assetInstall = await installExtensionAssetsForAllAgents(projectDir, config.agents, extensionDir, manifest);
+  } catch (error) {
+    await rollbackFailedExtensionInstall(projectDir, config.agents, {
+      extensionDir,
+      backupDir,
+      oldRecord,
+      oldManifest,
+      newManifest: manifest,
+    });
+    throw error;
+  } finally {
+    if (backupDir) {
+      await removeDirectory(backupDir);
+    }
+  }
 
   for (const outcome of assetInstall.replacementOutcomes) {
     if (outcome.status === 'installed') {

--- a/src/core/extension-ops.ts
+++ b/src/core/extension-ops.ts
@@ -43,6 +43,17 @@ interface ExtensionInstallRollbackContext {
   oldRecord: ExtensionRecord | null;
   oldManifest: ExtensionManifest | null;
   newManifest: ExtensionManifest;
+  partialAssetInstall?: ExtensionAssetInstallResult | null;
+}
+
+class ExtensionAssetInstallError extends Error {
+  partialResult: ExtensionAssetInstallResult;
+
+  constructor(message: string, partialResult: ExtensionAssetInstallResult) {
+    super(message);
+    this.name = 'ExtensionAssetInstallError';
+    this.partialResult = partialResult;
+  }
 }
 
 /**
@@ -179,15 +190,32 @@ async function cleanupPartialExtensionState(
   agents: AgentInstallation[],
   extensionName: string,
   manifest: ExtensionManifest,
+  partialAssetInstall?: ExtensionAssetInstallResult | null,
 ): Promise<void> {
-  const partialRecord: ExtensionRecord = {
-    name: extensionName,
-    source: '',
-    version: manifest.version,
-    replacedSkills: manifest.replaces ? Object.values(manifest.replaces) : undefined,
-  };
+  await stripInjectionsForAllAgents(projectDir, agents, extensionName, manifest);
 
-  await removePreviousExtensionState(projectDir, agents, extensionName, partialRecord, manifest);
+  if (manifest.mcpServers?.length) {
+    const mcpKeys = manifest.mcpServers.map(server => server.key);
+    for (const agent of agents) {
+      await removeExtensionMcpServers(projectDir, agent.id, mcpKeys);
+    }
+  }
+
+  const replacedSkills = partialAssetInstall?.replacedSkills ?? [];
+  if (replacedSkills.length > 0) {
+    await removeSkillsForAllAgents(projectDir, agents, replacedSkills);
+  }
+
+  const customSkills = new Set<string>();
+  for (const installed of partialAssetInstall?.customSkillInstalls.values() ?? []) {
+    for (const skill of installed) {
+      customSkills.add(skill);
+    }
+  }
+
+  if (customSkills.size > 0) {
+    await removeSkillsForAllAgents(projectDir, agents, [...customSkills]);
+  }
 }
 
 async function rollbackFailedExtensionInstall(
@@ -195,7 +223,13 @@ async function rollbackFailedExtensionInstall(
   agents: AgentInstallation[],
   context: ExtensionInstallRollbackContext,
 ): Promise<void> {
-  await cleanupPartialExtensionState(projectDir, agents, context.newManifest.name, context.newManifest);
+  await cleanupPartialExtensionState(
+    projectDir,
+    agents,
+    context.newManifest.name,
+    context.newManifest,
+    context.partialAssetInstall,
+  );
 
   if (context.backupDir) {
     await removeDirectory(context.extensionDir);
@@ -253,114 +287,115 @@ export async function installExtensionAssetsForAllAgents(
   extensionDir: string,
   manifest: ExtensionManifest,
 ): Promise<ExtensionAssetInstallResult> {
-  const replacedSkills: string[] = [];
-  const replacementOutcomes: ExtensionAssetInstallResult['replacementOutcomes'] = [];
-  const replacesPaths = new Set<string>();
+  const partialResult: ExtensionAssetInstallResult = {
+    replacedSkills: [],
+    replacementOutcomes: [],
+    customSkillInstalls: new Map<string, string[]>(),
+    injectionCount: 0,
+    configuredMcpServers: [],
+  };
 
-  if (manifest.replaces && Object.keys(manifest.replaces).length > 0) {
-    const nameOverrides: Record<string, string> = { ...manifest.replaces };
-    const replacePaths = Object.keys(manifest.replaces);
-    const perAgentResults = new Map<string, number>();
+  try {
+    const replacesPaths = new Set<string>();
 
-    for (const agent of agents) {
-      const installed = await installExtensionSkills(projectDir, agent, extensionDir, replacePaths, nameOverrides);
-      for (const name of installed) {
-        perAgentResults.set(name, (perAgentResults.get(name) ?? 0) + 1);
-      }
-    }
-
-    const agentCount = agents.length;
-    for (const [extSkillPath, baseSkillName] of Object.entries(manifest.replaces)) {
-      replacesPaths.add(extSkillPath);
-      const successCount = perAgentResults.get(baseSkillName) ?? 0;
-
-      if (successCount === agentCount) {
-        replacedSkills.push(baseSkillName);
-        replacementOutcomes.push({
-          baseSkillName,
-          extensionSkillPath: extSkillPath,
-          status: 'installed',
-          successCount,
-          agentCount,
-        });
-        continue;
-      }
-
-      if (successCount > 0) {
-        await removeSkillsForAllAgents(projectDir, agents, [baseSkillName]);
-        await restoreBaseSkills(projectDir, agents, [baseSkillName], new Set());
-        replacementOutcomes.push({
-          baseSkillName,
-          extensionSkillPath: extSkillPath,
-          status: 'rolled-back',
-          successCount,
-          agentCount,
-        });
-        continue;
-      }
-
-      replacementOutcomes.push({
-        baseSkillName,
-        extensionSkillPath: extSkillPath,
-        status: 'preserved-base',
-        successCount,
-        agentCount,
-      });
-    }
-  }
-
-  const customSkillInstalls = new Map<string, string[]>();
-  if (manifest.skills?.length) {
-    const nonReplacementSkills = manifest.skills.filter(skillPath => !replacesPaths.has(skillPath));
-    if (nonReplacementSkills.length > 0) {
-      const results = await installExtensionSkillsForAllAgents(projectDir, agents, extensionDir, nonReplacementSkills);
-      for (const [agentId, installed] of results) {
-        customSkillInstalls.set(agentId, installed);
-      }
-    }
-  }
-
-  let injectionCount = 0;
-  if (manifest.injections?.length) {
-    for (const agent of agents) {
-      injectionCount += await applySingleExtensionInjections(projectDir, agent, extensionDir, manifest);
-    }
-  }
-
-  const configuredMcpServers: string[] = [];
-  if (manifest.mcpServers?.length) {
-    for (const server of manifest.mcpServers) {
-      let template: unknown;
-      if (typeof server.template === 'string') {
-        template = await readJsonFile<McpServerConfig>(path.join(extensionDir, server.template));
-      } else {
-        template = server.template;
-      }
-
-      if (!template) {
-        continue;
-      }
-
-      validateMcpTemplate(template, server.key);
+    if (manifest.replaces && Object.keys(manifest.replaces).length > 0) {
+      const nameOverrides: Record<string, string> = { ...manifest.replaces };
+      const replacePaths = Object.keys(manifest.replaces);
+      const perAgentResults = new Map<string, number>();
 
       for (const agent of agents) {
-        const configured = await configureExtensionMcpServers(projectDir, agent.id, [
-          { key: server.key, template },
-        ]);
-        if (configured.length > 0 && !configuredMcpServers.includes(server.key)) {
-          configuredMcpServers.push(server.key);
+        const installed = await installExtensionSkills(projectDir, agent, extensionDir, replacePaths, nameOverrides);
+        for (const name of installed) {
+          perAgentResults.set(name, (perAgentResults.get(name) ?? 0) + 1);
+        }
+      }
+
+      const agentCount = agents.length;
+      for (const [extSkillPath, baseSkillName] of Object.entries(manifest.replaces)) {
+        replacesPaths.add(extSkillPath);
+        const successCount = perAgentResults.get(baseSkillName) ?? 0;
+
+        if (successCount === agentCount) {
+          partialResult.replacedSkills.push(baseSkillName);
+          partialResult.replacementOutcomes.push({
+            baseSkillName,
+            extensionSkillPath: extSkillPath,
+            status: 'installed',
+            successCount,
+            agentCount,
+          });
+          continue;
+        }
+
+        if (successCount > 0) {
+          await removeSkillsForAllAgents(projectDir, agents, [baseSkillName]);
+          await restoreBaseSkills(projectDir, agents, [baseSkillName], new Set());
+          partialResult.replacementOutcomes.push({
+            baseSkillName,
+            extensionSkillPath: extSkillPath,
+            status: 'rolled-back',
+            successCount,
+            agentCount,
+          });
+          continue;
+        }
+
+        partialResult.replacementOutcomes.push({
+          baseSkillName,
+          extensionSkillPath: extSkillPath,
+          status: 'preserved-base',
+          successCount,
+          agentCount,
+        });
+      }
+    }
+
+    if (manifest.skills?.length) {
+      const nonReplacementSkills = manifest.skills.filter(skillPath => !replacesPaths.has(skillPath));
+      if (nonReplacementSkills.length > 0) {
+        const results = await installExtensionSkillsForAllAgents(projectDir, agents, extensionDir, nonReplacementSkills);
+        for (const [agentId, installed] of results) {
+          partialResult.customSkillInstalls.set(agentId, installed);
         }
       }
     }
-  }
 
-  return {
-    replacedSkills,
-    replacementOutcomes,
-    customSkillInstalls,
-    injectionCount,
-    configuredMcpServers,
-  };
+    if (manifest.injections?.length) {
+      for (const agent of agents) {
+        partialResult.injectionCount += await applySingleExtensionInjections(projectDir, agent, extensionDir, manifest);
+      }
+    }
+
+    if (manifest.mcpServers?.length) {
+      for (const server of manifest.mcpServers) {
+        let template: unknown;
+        if (typeof server.template === 'string') {
+          template = await readJsonFile<McpServerConfig>(path.join(extensionDir, server.template));
+        } else {
+          template = server.template;
+        }
+
+        if (!template) {
+          continue;
+        }
+
+        validateMcpTemplate(template, server.key);
+
+        for (const agent of agents) {
+          const configured = await configureExtensionMcpServers(projectDir, agent.id, [
+            { key: server.key, template },
+          ]);
+          if (configured.length > 0 && !partialResult.configuredMcpServers.includes(server.key)) {
+            partialResult.configuredMcpServers.push(server.key);
+          }
+        }
+      }
+    }
+
+    return partialResult;
+  } catch (error) {
+    throw new ExtensionAssetInstallError((error as Error).message, partialResult);
+  }
 }
 
 export async function commitResolvedExtension(
@@ -401,12 +436,16 @@ export async function commitResolvedExtension(
 
     assetInstall = await installExtensionAssetsForAllAgents(projectDir, config.agents, extensionDir, manifest);
   } catch (error) {
+    const partialAssetInstall = error instanceof ExtensionAssetInstallError
+      ? error.partialResult
+      : null;
     await rollbackFailedExtensionInstall(projectDir, config.agents, {
       extensionDir,
       backupDir,
       oldRecord,
       oldManifest,
       newManifest: manifest,
+      partialAssetInstall,
     });
     throw error;
   } finally {

--- a/src/core/extension-ops.ts
+++ b/src/core/extension-ops.ts
@@ -1,7 +1,33 @@
-import type { AgentInstallation, ExtensionRecord } from './config.js';
-import type { ExtensionManifest } from './extensions.js';
+import path from 'path';
+import type { AgentInstallation, AiFactoryConfig, ExtensionRecord } from './config.js';
+import {
+  type ExtensionManifest,
+  classifyExtensionSource,
+  compareExtensionVersions,
+  getNpmVersionCheckResult,
+  parseGitSource,
+  resolveExtension,
+  getExtensionsDir,
+  loadExtensionManifest,
+} from './extensions.js';
 import { installSkills, getAvailableSkills, installExtensionSkills, removeExtensionSkills } from './installer.js';
-import { stripAllExtensionInjections, stripInjectionsByExtensionName } from './injections.js';
+import { applySingleExtensionInjections, stripAllExtensionInjections, stripInjectionsByExtensionName } from './injections.js';
+import { configureExtensionMcpServers, validateMcpTemplate, type McpServerConfig } from './mcp.js';
+import { readJsonFile } from '../utils/fs.js';
+
+export interface ExtensionAssetInstallResult {
+  replacedSkills: string[];
+  replacementOutcomes: Array<{
+    baseSkillName: string;
+    extensionSkillPath: string;
+    status: 'installed' | 'rolled-back' | 'preserved-base';
+    successCount: number;
+    agentCount: number;
+  }>;
+  customSkillInstalls: Map<string, string[]>;
+  injectionCount: number;
+  configuredMcpServers: string[];
+}
 
 /**
  * Install base skills on all agents.
@@ -65,6 +91,28 @@ export function collectReplacedSkills(extensions: ExtensionRecord[], excludeName
 }
 
 /**
+ * Ensure a new/updated extension does not claim a base skill already replaced by another extension.
+ */
+export function assertNoReplacementConflicts(
+  extensions: ExtensionRecord[],
+  manifest: ExtensionManifest,
+  currentExtensionName?: string,
+): void {
+  if (!manifest.replaces) {
+    return;
+  }
+
+  for (const [, baseSkillName] of Object.entries(manifest.replaces)) {
+    for (const other of extensions) {
+      if (other.name === currentExtensionName) continue;
+      if (other.replacedSkills?.includes(baseSkillName)) {
+        throw new Error(`Conflict: skill "${baseSkillName}" is already replaced by extension "${other.name}". Remove it first.`);
+      }
+    }
+  }
+}
+
+/**
  * Restore base skills that were previously replaced, filtering out skills still replaced by other extensions.
  */
 export async function restoreBaseSkills(
@@ -79,6 +127,28 @@ export async function restoreBaseSkills(
     await installSkillsForAllAgents(projectDir, agents, toRestore);
   }
   return toRestore;
+}
+
+/**
+ * Remove the previously installed state for an extension before reapplying its refreshed manifest.
+ */
+export async function removePreviousExtensionState(
+  projectDir: string,
+  agents: AgentInstallation[],
+  extensionName: string,
+  oldRecord?: ExtensionRecord | null,
+  oldManifest?: ExtensionManifest | null,
+): Promise<void> {
+  await stripInjectionsForAllAgents(projectDir, agents, extensionName, oldManifest);
+
+  if (oldRecord?.replacedSkills?.length) {
+    await removeSkillsForAllAgents(projectDir, agents, oldRecord.replacedSkills);
+    await restoreBaseSkills(projectDir, agents, oldRecord.replacedSkills, new Set());
+  }
+
+  if (oldManifest) {
+    await removeCustomSkillsForAllAgents(projectDir, agents, oldManifest);
+  }
 }
 
 /**
@@ -112,4 +182,329 @@ export async function removeCustomSkillsForAllAgents(
   const customSkills = (manifest.skills ?? []).filter(s => !replacesPaths.has(s));
   if (customSkills.length === 0) return new Map();
   return removeSkillsForAllAgents(projectDir, agents, customSkills);
+}
+
+/**
+ * Install replacement skills, custom skills, injections, and MCP config for an extension.
+ */
+export async function installExtensionAssetsForAllAgents(
+  projectDir: string,
+  agents: AgentInstallation[],
+  extensionDir: string,
+  manifest: ExtensionManifest,
+): Promise<ExtensionAssetInstallResult> {
+  const replacedSkills: string[] = [];
+  const replacementOutcomes: ExtensionAssetInstallResult['replacementOutcomes'] = [];
+  const replacesPaths = new Set<string>();
+
+  if (manifest.replaces && Object.keys(manifest.replaces).length > 0) {
+    const nameOverrides: Record<string, string> = { ...manifest.replaces };
+    const replacePaths = Object.keys(manifest.replaces);
+    const perAgentResults = new Map<string, number>();
+
+    for (const agent of agents) {
+      const installed = await installExtensionSkills(projectDir, agent, extensionDir, replacePaths, nameOverrides);
+      for (const name of installed) {
+        perAgentResults.set(name, (perAgentResults.get(name) ?? 0) + 1);
+      }
+    }
+
+    const agentCount = agents.length;
+    for (const [extSkillPath, baseSkillName] of Object.entries(manifest.replaces)) {
+      replacesPaths.add(extSkillPath);
+      const successCount = perAgentResults.get(baseSkillName) ?? 0;
+
+      if (successCount === agentCount) {
+        replacedSkills.push(baseSkillName);
+        replacementOutcomes.push({
+          baseSkillName,
+          extensionSkillPath: extSkillPath,
+          status: 'installed',
+          successCount,
+          agentCount,
+        });
+        continue;
+      }
+
+      if (successCount > 0) {
+        await removeSkillsForAllAgents(projectDir, agents, [baseSkillName]);
+        await restoreBaseSkills(projectDir, agents, [baseSkillName], new Set());
+        replacementOutcomes.push({
+          baseSkillName,
+          extensionSkillPath: extSkillPath,
+          status: 'rolled-back',
+          successCount,
+          agentCount,
+        });
+        continue;
+      }
+
+      replacementOutcomes.push({
+        baseSkillName,
+        extensionSkillPath: extSkillPath,
+        status: 'preserved-base',
+        successCount,
+        agentCount,
+      });
+    }
+  }
+
+  const customSkillInstalls = new Map<string, string[]>();
+  if (manifest.skills?.length) {
+    const nonReplacementSkills = manifest.skills.filter(skillPath => !replacesPaths.has(skillPath));
+    if (nonReplacementSkills.length > 0) {
+      const results = await installExtensionSkillsForAllAgents(projectDir, agents, extensionDir, nonReplacementSkills);
+      for (const [agentId, installed] of results) {
+        customSkillInstalls.set(agentId, installed);
+      }
+    }
+  }
+
+  let injectionCount = 0;
+  if (manifest.injections?.length) {
+    for (const agent of agents) {
+      injectionCount += await applySingleExtensionInjections(projectDir, agent, extensionDir, manifest);
+    }
+  }
+
+  const configuredMcpServers: string[] = [];
+  if (manifest.mcpServers?.length) {
+    for (const server of manifest.mcpServers) {
+      let template: unknown;
+      if (typeof server.template === 'string') {
+        template = await readJsonFile<McpServerConfig>(path.join(extensionDir, server.template));
+      } else {
+        template = server.template;
+      }
+
+      if (!template) {
+        continue;
+      }
+
+      validateMcpTemplate(template, server.key);
+
+      for (const agent of agents) {
+        const configured = await configureExtensionMcpServers(projectDir, agent.id, [
+          { key: server.key, template },
+        ]);
+        if (configured.length > 0 && !configuredMcpServers.includes(server.key)) {
+          configuredMcpServers.push(server.key);
+        }
+      }
+    }
+  }
+
+  return {
+    replacedSkills,
+    replacementOutcomes,
+    customSkillInstalls,
+    injectionCount,
+    configuredMcpServers,
+  };
+}
+
+export interface ExtensionRefreshResult {
+  name: string;
+  status: 'updated' | 'unchanged' | 'failed' | 'skipped';
+  oldVersion: string;
+  newVersion: string | null;
+  failureReason?: string;
+}
+
+export interface ExtensionRefreshSummary {
+  updated: ExtensionRefreshResult[];
+  unchanged: ExtensionRefreshResult[];
+  failed: ExtensionRefreshResult[];
+  skipped: ExtensionRefreshResult[];
+}
+
+async function checkExtensionNeedsRefresh(
+  source: string,
+  currentVersion: string,
+  force: boolean,
+): Promise<{ shouldRefresh: boolean; latestVersion: string | null; reason: string }> {
+  const sourceType = classifyExtensionSource(source);
+
+  if (force) {
+    return { shouldRefresh: true, latestVersion: null, reason: 'force' };
+  }
+
+  if (sourceType === 'npm') {
+    const packageName = source.replace(/^npm:/, '');
+    const check = await getNpmVersionCheckResult(packageName, currentVersion, false);
+    return {
+      shouldRefresh: check.shouldDownload,
+      latestVersion: check.latestVersion,
+      reason: check.reason,
+    };
+  }
+
+  if (sourceType === 'github') {
+    const gitSource = parseGitSource(source);
+    if (gitSource.isGitHub && gitSource.owner && gitSource.repo) {
+      const token = process.env.GITHUB_TOKEN?.trim();
+      const contentsUrl = new URL(
+        `https://api.github.com/repos/${gitSource.owner}/${gitSource.repo}/contents/extension.json`,
+      );
+      if (gitSource.ref) {
+        contentsUrl.searchParams.set('ref', gitSource.ref);
+      }
+
+      try {
+        const response = await fetch(contentsUrl.toString(), {
+          headers: {
+            Accept: 'application/vnd.github+json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          signal: AbortSignal.timeout(5000),
+        });
+
+        if (response.status === 403 && response.headers.get('x-ratelimit-remaining') === '0') {
+          return { shouldRefresh: false, latestVersion: null, reason: 'rate-limited' };
+        }
+
+        if (response.ok) {
+          const payload = (await response.json()) as { content?: string; encoding?: string };
+          if (payload.encoding === 'base64' && payload.content) {
+            const manifest = JSON.parse(
+              Buffer.from(payload.content.replace(/\n/g, ''), 'base64').toString('utf8'),
+            ) as ExtensionManifest;
+            if (manifest.version) {
+              const needsUpdate = compareExtensionVersions(manifest.version, currentVersion) > 0;
+              return {
+                shouldRefresh: needsUpdate,
+                latestVersion: manifest.version,
+                reason: needsUpdate ? 'version-changed' : 'unchanged',
+              };
+            }
+          }
+        }
+      } catch {
+        return { shouldRefresh: false, latestVersion: null, reason: 'github-api-failed' };
+      }
+    }
+  }
+
+  return { shouldRefresh: false, latestVersion: null, reason: 'source-type-requires-force' };
+}
+
+export async function refreshExtensions(
+  projectDir: string,
+  config: AiFactoryConfig,
+  options?: {
+    targetNames?: string[];
+    force?: boolean;
+    log?: (level: 'info' | 'warn', message: string) => void;
+  },
+): Promise<ExtensionRefreshSummary> {
+  const force = options?.force ?? false;
+  const log = options?.log ?? (() => {});
+  const extensions = config.extensions ?? [];
+
+  if (extensions.length === 0) {
+    return { updated: [], unchanged: [], failed: [], skipped: [] };
+  }
+
+  const targetExtensions = options?.targetNames
+    ? extensions.filter((e) => options.targetNames!.includes(e.name))
+    : extensions;
+
+  const results: ExtensionRefreshResult[] = [];
+
+  for (const extRecord of targetExtensions) {
+    const { name: extName, source, version: currentVersion } = extRecord;
+
+    log('info', `Checking ${extName} (v${currentVersion})...`);
+
+    const check = await checkExtensionNeedsRefresh(source, currentVersion, force);
+
+    if (!check.shouldRefresh) {
+      const status: ExtensionRefreshResult['status'] =
+        check.reason === 'unchanged' ? 'unchanged' : 'skipped';
+      results.push({
+        name: extName,
+        status,
+        oldVersion: currentVersion,
+        newVersion: check.latestVersion ?? currentVersion,
+        failureReason: check.reason !== 'unchanged' ? check.reason : undefined,
+      });
+      continue;
+    }
+
+    log('info', `Refreshing ${extName} from ${source}...`);
+
+    try {
+      const resolved = await resolveExtension(projectDir, source);
+
+      try {
+        const manifest = resolved.manifest;
+        const extensionsList = config.extensions ?? [];
+        const existIdx = extensionsList.findIndex((ext) => ext.name === extName);
+        const oldRecord = existIdx >= 0 ? { ...extensionsList[existIdx] } : null;
+        const oldManifest = existIdx >= 0
+          ? await loadExtensionManifest(path.join(getExtensionsDir(projectDir), extName))
+          : null;
+
+        assertNoReplacementConflicts(extensionsList, manifest, extName);
+
+        const { commitExtensionInstall } = await import('./extensions.js');
+        await commitExtensionInstall(projectDir, resolved);
+
+        if (existIdx >= 0) {
+          await removePreviousExtensionState(projectDir, config.agents, extName, oldRecord, oldManifest);
+        }
+
+        const extensionDir = path.join(getExtensionsDir(projectDir), manifest.name);
+        const assetInstall = await installExtensionAssetsForAllAgents(
+          projectDir,
+          config.agents,
+          extensionDir,
+          manifest,
+        );
+
+        const record: ExtensionRecord = {
+          name: manifest.name,
+          source,
+          version: manifest.version,
+          replacedSkills: assetInstall.replacedSkills.length > 0 ? assetInstall.replacedSkills : undefined,
+        };
+
+        if (existIdx >= 0) {
+          extensionsList[existIdx] = record;
+        } else {
+          extensionsList.push(record);
+        }
+
+        config.extensions = extensionsList;
+
+        results.push({
+          name: extName,
+          status: 'updated',
+          oldVersion: currentVersion,
+          newVersion: manifest.version,
+        });
+
+        log('info', `Updated ${extName}: v${currentVersion} → v${manifest.version}`);
+      } finally {
+        await resolved.cleanup();
+      }
+    } catch (error) {
+      const message = (error as Error).message;
+      results.push({
+        name: extName,
+        status: 'failed',
+        oldVersion: currentVersion,
+        newVersion: null,
+        failureReason: message,
+      });
+      log('warn', `Failed to refresh ${extName}: ${message}`);
+    }
+  }
+
+  return {
+    updated: results.filter((r) => r.status === 'updated'),
+    unchanged: results.filter((r) => r.status === 'unchanged'),
+    failed: results.filter((r) => r.status === 'failed'),
+    skipped: results.filter((r) => r.status === 'skipped'),
+  };
 }

--- a/src/core/extension-ops.ts
+++ b/src/core/extension-ops.ts
@@ -4,11 +4,12 @@ import {
   type ExtensionManifest,
   classifyExtensionSource,
   compareExtensionVersions,
-  getNpmVersionCheckResult,
-  parseGitSource,
+  commitExtensionInstall,
+  resolveExtensionVersion,
   resolveExtension,
   getExtensionsDir,
   loadExtensionManifest,
+  type ResolvedExtension,
 } from './extensions.js';
 import { installSkills, getAvailableSkills, installExtensionSkills, removeExtensionSkills } from './installer.js';
 import { applySingleExtensionInjections, stripAllExtensionInjections, stripInjectionsByExtensionName } from './injections.js';
@@ -27,6 +28,13 @@ export interface ExtensionAssetInstallResult {
   customSkillInstalls: Map<string, string[]>;
   injectionCount: number;
   configuredMcpServers: string[];
+}
+
+export interface CommitResolvedExtensionOptions {
+  config: AiFactoryConfig;
+  source: string;
+  resolved: ResolvedExtension;
+  log?: (level: 'info' | 'warn', message: string) => void;
 }
 
 /**
@@ -303,6 +311,78 @@ export async function installExtensionAssetsForAllAgents(
   };
 }
 
+export async function commitResolvedExtension(
+  projectDir: string,
+  options: CommitResolvedExtensionOptions,
+): Promise<{ manifest: ExtensionManifest; extensionDir: string; record: ExtensionRecord }> {
+  const { config, source, resolved } = options;
+  const log = options.log ?? (() => {});
+  const manifest = resolved.manifest;
+  const extensions = config.extensions ?? [];
+  const existIdx = extensions.findIndex(ext => ext.name === manifest.name);
+  const oldRecord = existIdx >= 0 ? { ...extensions[existIdx] } : null;
+  const oldManifest = existIdx >= 0
+    ? await loadExtensionManifest(path.join(getExtensionsDir(projectDir), manifest.name))
+    : null;
+
+  assertNoReplacementConflicts(extensions, manifest, manifest.name);
+
+  await commitExtensionInstall(projectDir, resolved);
+
+  if (existIdx >= 0) {
+    await removePreviousExtensionState(projectDir, config.agents, manifest.name, oldRecord, oldManifest);
+  }
+
+  const extensionDir = path.join(getExtensionsDir(projectDir), manifest.name);
+  const assetInstall = await installExtensionAssetsForAllAgents(projectDir, config.agents, extensionDir, manifest);
+
+  for (const outcome of assetInstall.replacementOutcomes) {
+    if (outcome.status === 'installed') {
+      log('info', `Replaced skill "${outcome.baseSkillName}" with "${path.basename(outcome.extensionSkillPath)}"`);
+    } else if (outcome.status === 'rolled-back') {
+      log('warn', `Replacement "${outcome.baseSkillName}" only installed on ${outcome.successCount}/${outcome.agentCount} agents - rolled back, base skill restored`);
+    } else {
+      log('warn', `Failed to replace skill "${outcome.baseSkillName}" - base skill preserved`);
+    }
+  }
+
+  for (const [agentId, installed] of assetInstall.customSkillInstalls) {
+    if (installed.length > 0) {
+      log('info', `Skills installed for ${agentId}: ${installed.join(', ')}`);
+    }
+  }
+
+  if (assetInstall.injectionCount > 0) {
+    log('info', `Applied ${assetInstall.injectionCount} injection(s)`);
+  }
+
+  if (assetInstall.configuredMcpServers.length > 0) {
+    log('info', `MCP servers configured: ${assetInstall.configuredMcpServers.join(', ')}`);
+    for (const srv of manifest.mcpServers ?? []) {
+      if (srv.instruction) {
+        log('info', `  ${srv.instruction}`);
+      }
+    }
+  }
+
+  const record: ExtensionRecord = {
+    name: manifest.name,
+    source,
+    version: manifest.version,
+    replacedSkills: assetInstall.replacedSkills.length > 0 ? assetInstall.replacedSkills : undefined,
+  };
+
+  if (existIdx >= 0) {
+    extensions[existIdx] = record;
+  } else {
+    extensions.push(record);
+  }
+
+  config.extensions = extensions;
+
+  return { manifest, extensionDir, record };
+}
+
 export interface ExtensionRefreshResult {
   name: string;
   status: 'updated' | 'unchanged' | 'failed' | 'skipped';
@@ -319,6 +399,7 @@ export interface ExtensionRefreshSummary {
 }
 
 async function checkExtensionNeedsRefresh(
+  projectDir: string,
   source: string,
   currentVersion: string,
   force: boolean,
@@ -329,63 +410,25 @@ async function checkExtensionNeedsRefresh(
     return { shouldRefresh: true, latestVersion: null, reason: 'force' };
   }
 
-  if (sourceType === 'npm') {
-    const packageName = source.replace(/^npm:/, '');
-    const check = await getNpmVersionCheckResult(packageName, currentVersion, false);
+  if (sourceType === 'local') {
+    return { shouldRefresh: false, latestVersion: null, reason: 'source-type-requires-force' };
+  }
+
+  const resolution = await resolveExtensionVersion(projectDir, source);
+  if (resolution.status === 'failed' || !resolution.latestVersion) {
     return {
-      shouldRefresh: check.shouldDownload,
-      latestVersion: check.latestVersion,
-      reason: check.reason,
+      shouldRefresh: false,
+      latestVersion: null,
+      reason: 'lookup-failed',
     };
   }
 
-  if (sourceType === 'github') {
-    const gitSource = parseGitSource(source);
-    if (gitSource.isGitHub && gitSource.owner && gitSource.repo) {
-      const token = process.env.GITHUB_TOKEN?.trim();
-      const contentsUrl = new URL(
-        `https://api.github.com/repos/${gitSource.owner}/${gitSource.repo}/contents/extension.json`,
-      );
-      if (gitSource.ref) {
-        contentsUrl.searchParams.set('ref', gitSource.ref);
-      }
-
-      try {
-        const response = await fetch(contentsUrl.toString(), {
-          headers: {
-            Accept: 'application/vnd.github+json',
-            ...(token ? { Authorization: `Bearer ${token}` } : {}),
-          },
-          signal: AbortSignal.timeout(5000),
-        });
-
-        if (response.status === 403 && response.headers.get('x-ratelimit-remaining') === '0') {
-          return { shouldRefresh: false, latestVersion: null, reason: 'rate-limited' };
-        }
-
-        if (response.ok) {
-          const payload = (await response.json()) as { content?: string; encoding?: string };
-          if (payload.encoding === 'base64' && payload.content) {
-            const manifest = JSON.parse(
-              Buffer.from(payload.content.replace(/\n/g, ''), 'base64').toString('utf8'),
-            ) as ExtensionManifest;
-            if (manifest.version) {
-              const needsUpdate = compareExtensionVersions(manifest.version, currentVersion) > 0;
-              return {
-                shouldRefresh: needsUpdate,
-                latestVersion: manifest.version,
-                reason: needsUpdate ? 'version-changed' : 'unchanged',
-              };
-            }
-          }
-        }
-      } catch {
-        return { shouldRefresh: false, latestVersion: null, reason: 'github-api-failed' };
-      }
-    }
-  }
-
-  return { shouldRefresh: false, latestVersion: null, reason: 'source-type-requires-force' };
+  const needsUpdate = compareExtensionVersions(resolution.latestVersion, currentVersion) > 0;
+  return {
+    shouldRefresh: needsUpdate,
+    latestVersion: resolution.latestVersion,
+    reason: needsUpdate ? 'version-changed' : 'unchanged',
+  };
 }
 
 export async function refreshExtensions(
@@ -410,13 +453,24 @@ export async function refreshExtensions(
     : extensions;
 
   const results: ExtensionRefreshResult[] = [];
+  const hasGitHubSource = targetExtensions.some(ext => classifyExtensionSource(ext.source) === 'github');
+
+  if (hasGitHubSource) {
+    const hasToken = Boolean(process.env.GITHUB_TOKEN?.trim());
+    log(
+      'info',
+      hasToken
+        ? 'GitHub extension checks: authenticated via GITHUB_TOKEN'
+        : 'GitHub extension checks: unauthenticated; set GITHUB_TOKEN to raise rate limits',
+    );
+  }
 
   for (const extRecord of targetExtensions) {
     const { name: extName, source, version: currentVersion } = extRecord;
 
     log('info', `Checking ${extName} (v${currentVersion})...`);
 
-    const check = await checkExtensionNeedsRefresh(source, currentVersion, force);
+    const check = await checkExtensionNeedsRefresh(projectDir, source, currentVersion, force);
 
     if (!check.shouldRefresh) {
       const status: ExtensionRefreshResult['status'] =
@@ -437,45 +491,12 @@ export async function refreshExtensions(
       const resolved = await resolveExtension(projectDir, source);
 
       try {
-        const manifest = resolved.manifest;
-        const extensionsList = config.extensions ?? [];
-        const existIdx = extensionsList.findIndex((ext) => ext.name === extName);
-        const oldRecord = existIdx >= 0 ? { ...extensionsList[existIdx] } : null;
-        const oldManifest = existIdx >= 0
-          ? await loadExtensionManifest(path.join(getExtensionsDir(projectDir), extName))
-          : null;
-
-        assertNoReplacementConflicts(extensionsList, manifest, extName);
-
-        const { commitExtensionInstall } = await import('./extensions.js');
-        await commitExtensionInstall(projectDir, resolved);
-
-        if (existIdx >= 0) {
-          await removePreviousExtensionState(projectDir, config.agents, extName, oldRecord, oldManifest);
-        }
-
-        const extensionDir = path.join(getExtensionsDir(projectDir), manifest.name);
-        const assetInstall = await installExtensionAssetsForAllAgents(
-          projectDir,
-          config.agents,
-          extensionDir,
-          manifest,
-        );
-
-        const record: ExtensionRecord = {
-          name: manifest.name,
+        const { manifest } = await commitResolvedExtension(projectDir, {
+          config,
           source,
-          version: manifest.version,
-          replacedSkills: assetInstall.replacedSkills.length > 0 ? assetInstall.replacedSkills : undefined,
-        };
-
-        if (existIdx >= 0) {
-          extensionsList[existIdx] = record;
-        } else {
-          extensionsList.push(record);
-        }
-
-        config.extensions = extensionsList;
+          resolved,
+          log,
+        });
 
         results.push({
           name: extName,

--- a/src/core/extension-ops.ts
+++ b/src/core/extension-ops.ts
@@ -236,8 +236,9 @@ async function rollbackFailedExtensionInstall(
     await ensureDir(path.dirname(context.extensionDir));
     await copyDirectory(context.backupDir, context.extensionDir);
 
-    if (context.oldManifest) {
-      await installExtensionAssetsForAllAgents(projectDir, agents, context.extensionDir, context.oldManifest);
+    const restoredManifest = context.oldManifest ?? await loadExtensionManifest(context.extensionDir);
+    if (restoredManifest) {
+      await installExtensionAssetsForAllAgents(projectDir, agents, context.extensionDir, restoredManifest);
     }
     return;
   }
@@ -537,7 +538,7 @@ async function checkExtensionNeedsRefresh(
     return {
       shouldRefresh: false,
       latestVersion: null,
-      reason: 'lookup-failed',
+      reason: resolution.failureReason === 'rate-limited' ? 'rate-limited' : 'lookup-failed',
     };
   }
 
@@ -609,6 +610,13 @@ export async function refreshExtensions(
       const resolved = await resolveExtension(projectDir, source);
 
       try {
+        if (resolved.manifest.name !== extName) {
+          throw new Error(
+            `Extension identity mismatch: expected "${extName}" but source returned "${resolved.manifest.name}". ` +
+            `The extension may have been renamed or the source URL may be incorrect.`,
+          );
+        }
+
         const { manifest } = await commitResolvedExtension(projectDir, {
           config,
           source,

--- a/src/core/extensions.ts
+++ b/src/core/extensions.ts
@@ -320,7 +320,12 @@ function isGitUrl(source: string): boolean {
 }
 
 function isLocalPath(source: string): boolean {
-  return source.startsWith('./') || source.startsWith('/') || source.startsWith('../') || path.isAbsolute(source);
+  return source.startsWith('./')
+    || source.startsWith('.\\')
+    || source.startsWith('/')
+    || source.startsWith('../')
+    || source.startsWith('..\\')
+    || path.isAbsolute(source);
 }
 
 export function classifyExtensionSource(source: string): ExtensionSourceType {
@@ -574,12 +579,13 @@ export async function resolveExtensionVersion(
     if (sourceType === 'github') {
       const gitSource = parseGitSource(source);
       const manifest = await fetchGitHubExtensionManifest(source);
-      if (!manifest) {
+      if (manifest) {
         return {
-          status: 'failed',
+          status: 'resolved',
           sourceType,
           source,
-          failureReason: 'Could not fetch GitHub extension manifest metadata',
+          latestVersion: manifest.version,
+          manifest,
           metadata: {
             host: gitSource.host ?? undefined,
             owner: gitSource.owner ?? undefined,
@@ -589,19 +595,32 @@ export async function resolveExtensionVersion(
         };
       }
 
-      return {
-        status: 'resolved',
+      logExtension('warn', 'GitHub metadata unavailable, falling back to git clone for version resolution', {
         sourceType,
-        source,
-        latestVersion: manifest.version,
-        manifest,
-        metadata: {
-          host: gitSource.host ?? undefined,
-          owner: gitSource.owner ?? undefined,
-          repo: gitSource.repo ?? undefined,
-          ref: gitSource.ref ?? undefined,
-        },
-      };
+        host: gitSource.host,
+        owner: gitSource.owner,
+        repo: gitSource.repo,
+        ref: gitSource.ref,
+      });
+
+      const resolved = await resolveFromGit(projectDir, source);
+      try {
+        return {
+          status: 'resolved',
+          sourceType,
+          source,
+          latestVersion: resolved.manifest.version,
+          manifest: resolved.manifest,
+          metadata: {
+            host: gitSource.host ?? undefined,
+            owner: gitSource.owner ?? undefined,
+            repo: gitSource.repo ?? undefined,
+            ref: gitSource.ref ?? undefined,
+          },
+        };
+      } finally {
+        await resolved.cleanup();
+      }
     }
 
     return {

--- a/src/core/extensions.ts
+++ b/src/core/extensions.ts
@@ -425,7 +425,7 @@ export function parseGitSource(source: string): ParsedGitSource {
   };
 }
 
-async function fetchGitHubExtensionManifest(source: string): Promise<ExtensionManifest | null> {
+export async function fetchGitHubExtensionManifest(source: string): Promise<ExtensionManifest | null> {
   const gitSource = parseGitSource(source);
 
   if (!gitSource.isGitHub || !gitSource.owner || !gitSource.repo) {
@@ -511,6 +511,112 @@ async function fetchGitHubExtensionManifest(source: string): Promise<ExtensionMa
       failureReason: (error as Error).message,
     });
     return null;
+  }
+}
+
+export async function resolveExtensionVersion(
+  projectDir: string,
+  source: string,
+): Promise<ExtensionVersionResolution> {
+  const sourceType = classifyExtensionSource(source);
+
+  logExtension('debug', 'Resolving extension version metadata', {
+    source,
+    sourceType,
+  });
+
+  try {
+    if (sourceType === 'local') {
+      const localPath = path.resolve(projectDir, source);
+      const manifest = await loadExtensionManifest(localPath);
+      if (!manifest) {
+        return {
+          status: 'failed',
+          sourceType,
+          source,
+          failureReason: `No valid extension.json found in ${localPath}`,
+          metadata: { path: localPath },
+        };
+      }
+
+      return {
+        status: 'resolved',
+        sourceType,
+        source,
+        latestVersion: manifest.version,
+        manifest,
+        metadata: { path: localPath },
+      };
+    }
+
+    if (sourceType === 'npm') {
+      const packageName = source.replace(/^npm:/, '');
+      const latestVersion = await fetchLatestNpmPackageVersion(packageName);
+      if (!latestVersion) {
+        return {
+          status: 'failed',
+          sourceType,
+          source,
+          failureReason: `Could not fetch npm metadata for ${packageName}`,
+          metadata: { packageName },
+        };
+      }
+
+      return {
+        status: 'resolved',
+        sourceType,
+        source,
+        latestVersion,
+        metadata: { packageName },
+      };
+    }
+
+    if (sourceType === 'github') {
+      const gitSource = parseGitSource(source);
+      const manifest = await fetchGitHubExtensionManifest(source);
+      if (!manifest) {
+        return {
+          status: 'failed',
+          sourceType,
+          source,
+          failureReason: 'Could not fetch GitHub extension manifest metadata',
+          metadata: {
+            host: gitSource.host ?? undefined,
+            owner: gitSource.owner ?? undefined,
+            repo: gitSource.repo ?? undefined,
+            ref: gitSource.ref ?? undefined,
+          },
+        };
+      }
+
+      return {
+        status: 'resolved',
+        sourceType,
+        source,
+        latestVersion: manifest.version,
+        manifest,
+        metadata: {
+          host: gitSource.host ?? undefined,
+          owner: gitSource.owner ?? undefined,
+          repo: gitSource.repo ?? undefined,
+          ref: gitSource.ref ?? undefined,
+        },
+      };
+    }
+
+    return {
+      status: 'failed',
+      sourceType,
+      source,
+      failureReason: `Lightweight version checks are not available for ${sourceType} sources`,
+    };
+  } catch (error) {
+    return {
+      status: 'failed',
+      sourceType,
+      source,
+      failureReason: (error as Error).message,
+    };
   }
 }
 

--- a/src/core/extensions.ts
+++ b/src/core/extensions.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
+import * as semver from 'semver';
 import { readJsonFile, removeDirectory, ensureDir } from '../utils/fs.js';
 import type { McpServerConfig } from './mcp.js';
 
@@ -58,8 +59,6 @@ export interface NpmVersionCheckResult {
   reason: 'force' | 'version-changed' | 'unchanged' | 'lookup-failed';
 }
 
-const SEMVER_PATTERN = /^\d+\.\d+\.\d+(-[\w.]+)?$/;
-
 let githubAuthModeLogged = false;
 
 function shouldLog(level: ExtensionLogLevel): boolean {
@@ -93,7 +92,7 @@ function logExtension(level: ExtensionLogLevel, message: string, context?: Recor
 }
 
 function isValidVersionString(version: string): boolean {
-  return SEMVER_PATTERN.test(version);
+  return semver.valid(version) !== null;
 }
 
 function logGitHubAuthModeOnce(hasToken: boolean): void {
@@ -348,108 +347,47 @@ export function classifyExtensionSource(source: string): ExtensionSourceType {
   return 'npm';
 }
 
-export function parseExtensionVersion(version: string): { parts: number[]; prerelease: string | null } {
-  const [core, ...rest] = version.split('-');
-
-  return {
-    parts: core.split('.').map(part => Number(part)),
-    prerelease: rest.length > 0 ? rest.join('-') : null,
-  };
-}
-
 export function compareExtensionVersions(left: string, right: string): number {
-  const parsedLeft = parseExtensionVersion(left);
-  const parsedRight = parseExtensionVersion(right);
+  logExtension('debug', 'Comparing extension versions', {
+    left,
+    right,
+  });
 
-  for (let index = 0; index < 3; index++) {
-    const leftPart = parsedLeft.parts[index] ?? 0;
-    const rightPart = parsedRight.parts[index] ?? 0;
+  const leftValid = semver.valid(left);
+  const rightValid = semver.valid(right);
 
-    if (leftPart > rightPart) {
-      return 1;
-    }
-
-    if (leftPart < rightPart) {
-      return -1;
-    }
-  }
-
-  if (parsedLeft.prerelease && !parsedRight.prerelease) {
-    return -1;
-  }
-
-  if (!parsedLeft.prerelease && parsedRight.prerelease) {
-    return 1;
-  }
-
-  if (parsedLeft.prerelease === parsedRight.prerelease) {
+  if (!leftValid && !rightValid) {
+    logExtension('warn', 'Both extension versions are invalid for comparison', {
+      left,
+      right,
+    });
     return 0;
   }
 
-  if (parsedLeft.prerelease && parsedRight.prerelease) {
-    return comparePrereleaseStrings(parsedLeft.prerelease, parsedRight.prerelease);
+  if (!leftValid) {
+    logExtension('warn', 'Left extension version is invalid for comparison', {
+      left,
+      right,
+    });
+    return -1;
   }
 
-  return 0;
-}
-
-function comparePrereleaseStrings(left: string, right: string): number {
-  const leftParts = splitPrereleaseParts(left);
-  const rightParts = splitPrereleaseParts(right);
-
-  const maxLen = Math.max(leftParts.length, rightParts.length);
-
-  for (let index = 0; index < maxLen; index++) {
-    const leftPart = leftParts[index];
-    const rightPart = rightParts[index];
-
-    if (leftPart === undefined) {
-      return -1;
-    }
-
-    if (rightPart === undefined) {
-      return 1;
-    }
-
-    const leftIsNum = typeof leftPart === 'number';
-    const rightIsNum = typeof rightPart === 'number';
-
-    if (leftIsNum && rightIsNum) {
-      if (leftPart > rightPart) {
-        return 1;
-      }
-
-      if (leftPart < rightPart) {
-        return -1;
-      }
-
-      continue;
-    }
-
-    if (leftIsNum) {
-      return 1;
-    }
-
-    if (rightIsNum) {
-      return -1;
-    }
-
-    const cmp = String(leftPart).localeCompare(String(rightPart));
-
-    if (cmp !== 0) {
-      return cmp;
-    }
+  if (!rightValid) {
+    logExtension('warn', 'Right extension version is invalid for comparison', {
+      left,
+      right,
+    });
+    return 1;
   }
 
-  return 0;
-}
-
-function splitPrereleaseParts(prerelease: string): Array<string | number> {
-  return prerelease.split('.').map((part) => {
-    const num = Number(part);
-
-    return Number.isInteger(num) ? num : part;
+  const result = semver.compare(leftValid, rightValid);
+  logExtension('debug', 'Extension version comparison result', {
+    left: leftValid,
+    right: rightValid,
+    result,
   });
+
+  return result;
 }
 
 export function parseGitSource(source: string): ParsedGitSource {
@@ -799,7 +737,7 @@ async function resolveFromGit(projectDir: string, url: string): Promise<Resolved
   await removeDirectory(tmpDir);
 
   const manifestFromApi = await fetchGitHubExtensionManifest(url);
-  if (!manifestFromApi && !gitSource.isGitHub) {
+  if (!manifestFromApi.manifest && !gitSource.isGitHub) {
     logExtension('debug', 'Using git clone fallback for non-GitHub extension metadata', {
       sourceType,
       host: gitSource.host,
@@ -828,7 +766,7 @@ async function resolveFromGit(projectDir: string, url: string): Promise<Resolved
     repo: gitSource.repo,
     ref: gitSource.ref,
     latestVersion: manifest.version,
-    metadataSource: manifestFromApi ? 'github-api+clone' : 'clone',
+    metadataSource: manifestFromApi.manifest ? 'github-api+clone' : 'clone',
   });
 
   return { manifest, sourceDir: tmpDir, tempDir: tmpDir, cleanup: () => removeDirectory(tmpDir) };

--- a/src/core/extensions.ts
+++ b/src/core/extensions.ts
@@ -3,6 +3,207 @@ import fs from 'fs-extra';
 import { readJsonFile, removeDirectory, ensureDir } from '../utils/fs.js';
 import type { McpServerConfig } from './mcp.js';
 
+type ExtensionLogLevel = 'debug' | 'info' | 'warn';
+
+export type ExtensionSourceType = 'local' | 'npm' | 'github' | 'gitlab' | 'git';
+
+export interface ParsedGitSource {
+  host: string | null;
+  owner: string | null;
+  repo: string | null;
+  ref: string | null;
+  cloneUrl: string;
+  isGitHub: boolean;
+  isGitLab: boolean;
+}
+
+export interface ExtensionVersionMetadata {
+  sourceType: ExtensionSourceType;
+  latestVersion: string;
+  manifest: ExtensionManifest;
+  source: string;
+  metadata?: {
+    path?: string;
+    packageName?: string;
+    host?: string;
+    owner?: string;
+    repo?: string;
+    ref?: string;
+  };
+}
+
+export interface ExtensionVersionResolution {
+  status: 'resolved' | 'failed';
+  sourceType: ExtensionSourceType;
+  source: string;
+  latestVersion?: string;
+  manifest?: ExtensionManifest;
+  metadata?: ExtensionVersionMetadata['metadata'];
+  failureReason?: string;
+}
+
+interface NpmRegistryVersionResponse {
+  version: string;
+}
+
+interface GitHubContentsResponse {
+  content?: string;
+  encoding?: string;
+}
+
+export interface NpmVersionCheckResult {
+  packageName: string;
+  latestVersion: string | null;
+  shouldDownload: boolean;
+  reason: 'force' | 'version-changed' | 'unchanged' | 'lookup-failed';
+}
+
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+(-[\w.]+)?$/;
+
+let githubAuthModeLogged = false;
+
+function shouldLog(level: ExtensionLogLevel): boolean {
+  const envLevel = process.env.LOG_LEVEL?.toLowerCase();
+
+  if (envLevel === 'debug') {
+    return true;
+  }
+
+  if (envLevel === 'info') {
+    return level !== 'debug';
+  }
+
+  return level === 'warn';
+}
+
+function logExtension(level: ExtensionLogLevel, message: string, context?: Record<string, unknown>): void {
+  if (!shouldLog(level)) {
+    return;
+  }
+
+  const suffix = context ? ` ${JSON.stringify(context)}` : '';
+  const line = `[extensions] ${message}${suffix}`;
+
+  if (level === 'warn') {
+    console.warn(line);
+    return;
+  }
+
+  console.log(line);
+}
+
+function isValidVersionString(version: string): boolean {
+  return SEMVER_PATTERN.test(version);
+}
+
+function logGitHubAuthModeOnce(hasToken: boolean): void {
+  if (githubAuthModeLogged) {
+    return;
+  }
+
+  githubAuthModeLogged = true;
+  logExtension('info', hasToken ? 'Using authenticated GitHub API requests' : 'Using unauthenticated GitHub API requests', {
+    sourceType: 'github',
+    authMode: hasToken ? 'token' : 'anonymous',
+  });
+}
+
+function isGitHubRateLimited(response: Response): boolean {
+  return response.status === 403 && response.headers.get('x-ratelimit-remaining') === '0';
+}
+
+export async function fetchLatestNpmPackageVersion(packageName: string): Promise<string | null> {
+  const registryUrl = `https://registry.npmjs.org/${encodeURIComponent(packageName)}/latest`;
+
+  logExtension('debug', 'Fetching latest npm package version', {
+    sourceType: 'npm',
+    packageName,
+    registryUrl,
+  });
+
+  try {
+    const response = await fetch(registryUrl, {
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!response.ok) {
+      logExtension('warn', 'Failed to fetch npm package metadata', {
+        sourceType: 'npm',
+        packageName,
+        status: response.status,
+      });
+      return null;
+    }
+
+    const data = await response.json() as NpmRegistryVersionResponse;
+    if (typeof data.version !== 'string' || !isValidVersionString(data.version)) {
+      logExtension('warn', 'npm package metadata missing version', {
+        sourceType: 'npm',
+        packageName,
+        latestVersion: data.version,
+      });
+      return null;
+    }
+
+    logExtension('info', 'Fetched latest npm package version', {
+      sourceType: 'npm',
+      packageName,
+      latestVersion: data.version,
+    });
+
+    return data.version;
+  } catch (error) {
+    logExtension('warn', 'npm package version lookup failed', {
+      sourceType: 'npm',
+      packageName,
+      failureReason: (error as Error).message,
+    });
+    return null;
+  }
+}
+
+export async function getNpmVersionCheckResult(
+  packageName: string,
+  currentVersion: string,
+  force = false,
+): Promise<NpmVersionCheckResult> {
+  const latestVersion = await fetchLatestNpmPackageVersion(packageName);
+
+  if (!latestVersion) {
+    return {
+      packageName,
+      latestVersion: null,
+      shouldDownload: force,
+      reason: 'lookup-failed',
+    };
+  }
+
+  if (force) {
+    return {
+      packageName,
+      latestVersion,
+      shouldDownload: true,
+      reason: 'force',
+    };
+  }
+
+  if (compareExtensionVersions(latestVersion, currentVersion) > 0) {
+    return {
+      packageName,
+      latestVersion,
+      shouldDownload: true,
+      reason: 'version-changed',
+    };
+  }
+
+  return {
+    packageName,
+    latestVersion,
+    shouldDownload: false,
+    reason: 'unchanged',
+  };
+}
+
 export interface ExtensionInjection {
   target: string;
   position: 'append' | 'prepend';
@@ -43,6 +244,20 @@ export interface ExtensionManifest {
   mcpServers?: ExtensionMcpServer[];
 }
 
+function validateExtensionManifest(manifest: ExtensionManifest): void {
+  validateExtensionName(manifest.name);
+
+  if (!isValidVersionString(manifest.version)) {
+    throw new Error(`Invalid extension version: "${manifest.version}". Versions must use SemVer format.`);
+  }
+
+  if (manifest.replaces) {
+    for (const baseSkillName of Object.values(manifest.replaces)) {
+      validateSkillName(baseSkillName);
+    }
+  }
+}
+
 const EXTENSIONS_DIR = 'extensions';
 const SAFE_NAME_PATTERN = /^[a-zA-Z0-9_@][\w.@/-]*$/;
 const SAFE_SKILL_NAME_PATTERN = /^[a-zA-Z0-9][\w.-]*$/;
@@ -69,12 +284,7 @@ export async function loadExtensionManifest(extensionDir: string): Promise<Exten
   if (!manifest || !manifest.name || !manifest.version) {
     return null;
   }
-  validateExtensionName(manifest.name);
-  if (manifest.replaces) {
-    for (const baseSkillName of Object.values(manifest.replaces)) {
-      validateSkillName(baseSkillName);
-    }
-  }
+  validateExtensionManifest(manifest);
   return manifest;
 }
 
@@ -113,6 +323,197 @@ function isLocalPath(source: string): boolean {
   return source.startsWith('./') || source.startsWith('/') || source.startsWith('../') || path.isAbsolute(source);
 }
 
+export function classifyExtensionSource(source: string): ExtensionSourceType {
+  if (isLocalPath(source)) {
+    return 'local';
+  }
+
+  if (source.includes('github.com/')) {
+    return 'github';
+  }
+
+  if (source.includes('gitlab.com/')) {
+    return 'gitlab';
+  }
+
+  if (isGitUrl(source)) {
+    return 'git';
+  }
+
+  return 'npm';
+}
+
+export function parseExtensionVersion(version: string): { parts: number[]; prerelease: string | null } {
+  const [core, ...rest] = version.split('-');
+
+  return {
+    parts: core.split('.').map(part => Number(part)),
+    prerelease: rest.length > 0 ? rest.join('-') : null,
+  };
+}
+
+export function compareExtensionVersions(left: string, right: string): number {
+  const parsedLeft = parseExtensionVersion(left);
+  const parsedRight = parseExtensionVersion(right);
+
+  for (let index = 0; index < 3; index++) {
+    const leftPart = parsedLeft.parts[index] ?? 0;
+    const rightPart = parsedRight.parts[index] ?? 0;
+
+    if (leftPart > rightPart) {
+      return 1;
+    }
+
+    if (leftPart < rightPart) {
+      return -1;
+    }
+  }
+
+  if (parsedLeft.prerelease && !parsedRight.prerelease) {
+    return -1;
+  }
+
+  if (!parsedLeft.prerelease && parsedRight.prerelease) {
+    return 1;
+  }
+
+  if (parsedLeft.prerelease === parsedRight.prerelease) {
+    return 0;
+  }
+
+  return parsedLeft.prerelease && parsedRight.prerelease
+    ? parsedLeft.prerelease.localeCompare(parsedRight.prerelease)
+    : 0;
+}
+
+export function parseGitSource(source: string): ParsedGitSource {
+  const withoutPrefix = source.replace(/^git\+/, '');
+  const [cloneCandidate, refCandidate] = withoutPrefix.split('#', 2);
+  const cloneUrl = cloneCandidate.replace(/^git@github\.com:/, 'https://github.com/');
+  const normalizedUrl = cloneUrl.replace(/^git@gitlab\.com:/, 'https://gitlab.com/');
+
+  let host: string | null = null;
+  let owner: string | null = null;
+  let repo: string | null = null;
+
+  try {
+    const url = new URL(normalizedUrl);
+    host = url.hostname;
+    const segments = url.pathname.replace(/^\//, '').replace(/\.git$/, '').split('/').filter(Boolean);
+    owner = segments[0] ?? null;
+    repo = segments[1] ?? null;
+  } catch {
+    const sshMatch = normalizedUrl.match(/^(?:ssh:\/\/)?git@([^/:]+)[:/]([^/]+)\/([^/]+?)(?:\.git)?$/);
+    if (sshMatch) {
+      host = sshMatch[1] ?? null;
+      owner = sshMatch[2] ?? null;
+      repo = sshMatch[3] ?? null;
+    }
+  }
+
+  const isGitHub = host === 'github.com';
+  const isGitLab = host === 'gitlab.com';
+
+  return {
+    host,
+    owner,
+    repo,
+    ref: refCandidate ?? null,
+    cloneUrl: cloneCandidate,
+    isGitHub,
+    isGitLab,
+  };
+}
+
+async function fetchGitHubExtensionManifest(source: string): Promise<ExtensionManifest | null> {
+  const gitSource = parseGitSource(source);
+
+  if (!gitSource.isGitHub || !gitSource.owner || !gitSource.repo) {
+    return null;
+  }
+
+  const token = process.env.GITHUB_TOKEN?.trim();
+  logGitHubAuthModeOnce(Boolean(token));
+
+  const contentsUrl = new URL(`https://api.github.com/repos/${gitSource.owner}/${gitSource.repo}/contents/extension.json`);
+  if (gitSource.ref) {
+    contentsUrl.searchParams.set('ref', gitSource.ref);
+  }
+
+  logExtension('debug', 'Fetching extension manifest via GitHub API', {
+    sourceType: 'github',
+    owner: gitSource.owner,
+    repo: gitSource.repo,
+    ref: gitSource.ref,
+    contentsUrl: contentsUrl.toString(),
+  });
+
+  try {
+    const response = await fetch(contentsUrl, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (isGitHubRateLimited(response)) {
+      logExtension('warn', 'GitHub API rate limit reached while fetching extension metadata', {
+        sourceType: 'github',
+        owner: gitSource.owner,
+        repo: gitSource.repo,
+        ref: gitSource.ref,
+        hint: token ? 'retry later or investigate token scope' : 'set GITHUB_TOKEN with repo read access',
+      });
+      return null;
+    }
+
+    if (!response.ok) {
+      logExtension('warn', 'Failed to fetch extension manifest via GitHub API', {
+        sourceType: 'github',
+        owner: gitSource.owner,
+        repo: gitSource.repo,
+        ref: gitSource.ref,
+        status: response.status,
+      });
+      return null;
+    }
+
+    const payload = await response.json() as GitHubContentsResponse;
+    if (payload.encoding !== 'base64' || typeof payload.content !== 'string') {
+      logExtension('warn', 'GitHub API payload missing base64 extension manifest content', {
+        sourceType: 'github',
+        owner: gitSource.owner,
+        repo: gitSource.repo,
+        ref: gitSource.ref,
+      });
+      return null;
+    }
+
+    const manifest = JSON.parse(Buffer.from(payload.content.replace(/\n/g, ''), 'base64').toString('utf8')) as ExtensionManifest;
+    validateExtensionManifest(manifest);
+
+    logExtension('info', 'Fetched extension manifest via GitHub API', {
+      sourceType: 'github',
+      owner: gitSource.owner,
+      repo: gitSource.repo,
+      ref: gitSource.ref,
+      latestVersion: manifest.version,
+    });
+
+    return manifest;
+  } catch (error) {
+    logExtension('warn', 'GitHub API manifest lookup failed', {
+      sourceType: 'github',
+      owner: gitSource.owner,
+      repo: gitSource.repo,
+      ref: gitSource.ref,
+      failureReason: (error as Error).message,
+    });
+    return null;
+  }
+}
+
 // Two-phase install: resolve (download/validate) then commit (copy to project).
 // This allows callers to inspect the manifest and check constraints before any files are written.
 
@@ -125,16 +526,23 @@ export interface ResolvedExtension {
 
 async function resolveFromLocal(sourcePath: string): Promise<ResolvedExtension> {
   const resolvedSource = path.resolve(sourcePath);
+  logExtension('debug', 'Resolving local extension source', { sourcePath, resolvedSource });
   const manifest = await loadExtensionManifest(resolvedSource);
   if (!manifest) {
     throw new Error(`Invalid extension: no valid extension.json found in ${resolvedSource}`);
   }
+  logExtension('info', 'Resolved local extension manifest', {
+    sourceType: 'local',
+    path: resolvedSource,
+    latestVersion: manifest.version,
+  });
   return { manifest, sourceDir: resolvedSource, cleanup: async () => {} };
 }
 
 async function resolveFromNpm(projectDir: string, packageName: string): Promise<ResolvedExtension> {
   const { execFileSync } = await import('child_process');
   const tmpDir = path.join(getExtensionsDir(projectDir), '.tmp-install');
+  logExtension('debug', 'Resolving npm extension source', { packageName, tmpDir });
   await removeDirectory(tmpDir);
   await ensureDir(tmpDir);
 
@@ -158,16 +566,47 @@ async function resolveFromNpm(projectDir: string, packageName: string): Promise<
     throw new Error(`Invalid extension: no valid extension.json in ${packageName}`);
   }
 
+  logExtension('info', 'Resolved npm extension manifest', {
+    sourceType: 'npm',
+    packageName,
+    latestVersion: manifest.version,
+  });
+
   return { manifest, sourceDir: packageDir, tempDir: tmpDir, cleanup: () => removeDirectory(tmpDir) };
 }
 
 async function resolveFromGit(projectDir: string, url: string): Promise<ResolvedExtension> {
   const { execFileSync } = await import('child_process');
   const tmpDir = path.join(getExtensionsDir(projectDir), '.tmp-clone');
+  const gitSource = parseGitSource(url);
+  const sourceType = classifyExtensionSource(url);
+  logExtension('debug', 'Resolving git extension source', {
+    sourceType,
+    url,
+    host: gitSource.host,
+    owner: gitSource.owner,
+    repo: gitSource.repo,
+    ref: gitSource.ref,
+    tmpDir,
+  });
   await removeDirectory(tmpDir);
 
-  const cleanUrl = url.replace(/^git\+/, '');
-  execFileSync('git', ['clone', '--depth', '1', cleanUrl, tmpDir], { stdio: 'pipe' });
+  const manifestFromApi = await fetchGitHubExtensionManifest(url);
+  if (!manifestFromApi && !gitSource.isGitHub) {
+    logExtension('debug', 'Using git clone fallback for non-GitHub extension metadata', {
+      sourceType,
+      host: gitSource.host,
+      ref: gitSource.ref,
+      url,
+    });
+  }
+
+  const cloneArgs = ['clone', '--depth', '1'];
+  if (gitSource.ref) {
+    cloneArgs.push('--branch', gitSource.ref, '--single-branch');
+  }
+  cloneArgs.push(gitSource.cloneUrl, tmpDir);
+  execFileSync('git', cloneArgs, { stdio: 'pipe' });
 
   const manifest = await loadExtensionManifest(tmpDir);
   if (!manifest) {
@@ -175,8 +614,19 @@ async function resolveFromGit(projectDir: string, url: string): Promise<Resolved
     throw new Error(`Invalid extension: no valid extension.json in ${url}`);
   }
 
+  logExtension('info', 'Resolved git extension manifest', {
+    sourceType,
+    host: gitSource.host,
+    owner: gitSource.owner,
+    repo: gitSource.repo,
+    ref: gitSource.ref,
+    latestVersion: manifest.version,
+    metadataSource: manifestFromApi ? 'github-api+clone' : 'clone',
+  });
+
   return { manifest, sourceDir: tmpDir, tempDir: tmpDir, cleanup: () => removeDirectory(tmpDir) };
 }
+
 
 export async function resolveExtension(projectDir: string, source: string): Promise<ResolvedExtension> {
   if (isLocalPath(source)) {

--- a/src/core/extensions.ts
+++ b/src/core/extensions.ts
@@ -386,9 +386,70 @@ export function compareExtensionVersions(left: string, right: string): number {
     return 0;
   }
 
-  return parsedLeft.prerelease && parsedRight.prerelease
-    ? parsedLeft.prerelease.localeCompare(parsedRight.prerelease)
-    : 0;
+  if (parsedLeft.prerelease && parsedRight.prerelease) {
+    return comparePrereleaseStrings(parsedLeft.prerelease, parsedRight.prerelease);
+  }
+
+  return 0;
+}
+
+function comparePrereleaseStrings(left: string, right: string): number {
+  const leftParts = splitPrereleaseParts(left);
+  const rightParts = splitPrereleaseParts(right);
+
+  const maxLen = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < maxLen; index++) {
+    const leftPart = leftParts[index];
+    const rightPart = rightParts[index];
+
+    if (leftPart === undefined) {
+      return -1;
+    }
+
+    if (rightPart === undefined) {
+      return 1;
+    }
+
+    const leftIsNum = typeof leftPart === 'number';
+    const rightIsNum = typeof rightPart === 'number';
+
+    if (leftIsNum && rightIsNum) {
+      if (leftPart > rightPart) {
+        return 1;
+      }
+
+      if (leftPart < rightPart) {
+        return -1;
+      }
+
+      continue;
+    }
+
+    if (leftIsNum) {
+      return 1;
+    }
+
+    if (rightIsNum) {
+      return -1;
+    }
+
+    const cmp = String(leftPart).localeCompare(String(rightPart));
+
+    if (cmp !== 0) {
+      return cmp;
+    }
+  }
+
+  return 0;
+}
+
+function splitPrereleaseParts(prerelease: string): Array<string | number> {
+  return prerelease.split('.').map((part) => {
+    const num = Number(part);
+
+    return Number.isInteger(num) ? num : part;
+  });
 }
 
 export function parseGitSource(source: string): ParsedGitSource {
@@ -430,11 +491,16 @@ export function parseGitSource(source: string): ParsedGitSource {
   };
 }
 
-export async function fetchGitHubExtensionManifest(source: string): Promise<ExtensionManifest | null> {
+export interface GitHubManifestResult {
+  manifest: ExtensionManifest | null;
+  rateLimited: boolean;
+}
+
+export async function fetchGitHubExtensionManifest(source: string): Promise<GitHubManifestResult> {
   const gitSource = parseGitSource(source);
 
   if (!gitSource.isGitHub || !gitSource.owner || !gitSource.repo) {
-    return null;
+    return { manifest: null, rateLimited: false };
   }
 
   const token = process.env.GITHUB_TOKEN?.trim();
@@ -470,7 +536,7 @@ export async function fetchGitHubExtensionManifest(source: string): Promise<Exte
         ref: gitSource.ref,
         hint: token ? 'retry later or investigate token scope' : 'set GITHUB_TOKEN with repo read access',
       });
-      return null;
+      return { manifest: null, rateLimited: true };
     }
 
     if (!response.ok) {
@@ -481,7 +547,7 @@ export async function fetchGitHubExtensionManifest(source: string): Promise<Exte
         ref: gitSource.ref,
         status: response.status,
       });
-      return null;
+      return { manifest: null, rateLimited: false };
     }
 
     const payload = await response.json() as GitHubContentsResponse;
@@ -492,7 +558,7 @@ export async function fetchGitHubExtensionManifest(source: string): Promise<Exte
         repo: gitSource.repo,
         ref: gitSource.ref,
       });
-      return null;
+      return { manifest: null, rateLimited: false };
     }
 
     const manifest = JSON.parse(Buffer.from(payload.content.replace(/\n/g, ''), 'base64').toString('utf8')) as ExtensionManifest;
@@ -506,7 +572,7 @@ export async function fetchGitHubExtensionManifest(source: string): Promise<Exte
       latestVersion: manifest.version,
     });
 
-    return manifest;
+    return { manifest, rateLimited: false };
   } catch (error) {
     logExtension('warn', 'GitHub API manifest lookup failed', {
       sourceType: 'github',
@@ -515,7 +581,7 @@ export async function fetchGitHubExtensionManifest(source: string): Promise<Exte
       ref: gitSource.ref,
       failureReason: (error as Error).message,
     });
-    return null;
+    return { manifest: null, rateLimited: false };
   }
 }
 
@@ -578,14 +644,30 @@ export async function resolveExtensionVersion(
 
     if (sourceType === 'github') {
       const gitSource = parseGitSource(source);
-      const manifest = await fetchGitHubExtensionManifest(source);
-      if (manifest) {
+      const result = await fetchGitHubExtensionManifest(source);
+
+      if (result.rateLimited) {
+        return {
+          status: 'failed',
+          sourceType,
+          source,
+          failureReason: 'rate-limited',
+          metadata: {
+            host: gitSource.host ?? undefined,
+            owner: gitSource.owner ?? undefined,
+            repo: gitSource.repo ?? undefined,
+            ref: gitSource.ref ?? undefined,
+          },
+        };
+      }
+
+      if (result.manifest) {
         return {
           status: 'resolved',
           sourceType,
           source,
-          latestVersion: manifest.version,
-          manifest,
+          latestVersion: result.manifest.version,
+          manifest: result.manifest,
           metadata: {
             host: gitSource.host ?? undefined,
             owner: gitSource.owner ?? undefined,


### PR DESCRIPTION
## Что сделано

Реализовано автообновление extension-ов по версии в рамках `ai-factory update` и добавлена отдельная команда для их ручного обновления.

Работа относится к issue #58 .

## Основные изменения

- добавлена версия-ориентированная проверка источников extension-ов
- вынесен общий pipeline refresh/reinstall extension-а в shared core-логику
- добавлена отдельная CLI-команда для обновления extension-ов
- `ai-factory update` теперь сначала проверяет и обновляет extension-ы, а уже потом обновляет базовые skills
- обновлена документация по extension-ам и новому поведению update

## Новые команды

### `ai-factory extension update`
Обновляет все установленные extension-ы из сохраненных источников.

Поведение:
- для `npm`-источников проверяет последнюю версию в registry
- для `GitHub`-источников пытается получить `extension.json` через GitHub API
- для private/SSH GitHub sources при недоступности API использует fallback через `git clone`
- для local path и non-GitHub git sources обновление выполняется через `--force`

### `ai-factory extension update [name]`
Обновляет только один конкретный extension.

Пример:
```bash
ai-factory extension update my-extension
```

### `ai-factory extension update --force`
Принудительно refresh-ит extension-ы даже если версия не изменилась.

Пример:
```bash
ai-factory extension update --force
```

## Изменение поведения `ai-factory update`

Теперь `ai-factory update` работает так:

1. проверяет self-update CLI
2. refresh-ит установленные extension-ы из их source
3. обновляет базовые skills
4. повторно применяет replacement skills
5. повторно применяет injections

### Что делает `--force`
Флаг `--force` теперь:
- принудительно обновляет extension-ы
- выполняет clean reinstall базовых skills

## Технические детали

В рамках задачи добавлено:
- определение типа source (`local`, `npm`, `github`, `gitlab`, `git`)
- сравнение версий extension-ов
- lightweight version check для npm
- GitHub manifest lookup для `extension.json`
- shared refresh/apply pipeline для extension lifecycle
- безопасный rollback при неуспешном refresh
- cleanup устаревших MCP entries при reinstall
- поддержка Windows-style local paths (`.\\`, `..\\`)

## Надежность и edge cases

Дополнительно исправлены важные сценарии:
- refresh extension-а теперь безопасно откатывается при ошибке частичной установки
- при переустановке удаляются устаревшие MCP server keys
- private/SSH GitHub extension-ы не теряют возможность обновляться без обязательного `--force`

## Документация

Обновлены:
- `docs/extensions.md`
- `docs/getting-started.md`
- `docs/configuration.md`

## Проверка

Проверено командами:
```bash
npm run lint
npm run build
```

## Связанные задачи

- closes #58
