### PR TITLE
feat(kilocode): update workflow handling and installation process

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ AI Factory works with any AI coding agent. During `ai-factory init`, you choose 
 | Cursor | `.cursor/` | `.cursor/skills/` |
 | Windsurf | `.windsurf/` | `.windsurf/skills/` |
 | Roo Code | `.roo/` | `.roo/skills/` |
-| Kilo Code | `.kilocode/` | `.kilocode/skills/` |
+| Kilo Code | `.kilocode/` | `.kilocode/skills/`, `.kilocode/workflows/` |
 | Antigravity | `.agent/` | `.agent/skills/`, `.agent/workflows/` |
 | OpenCode | `.opencode/` | `.opencode/skills/` |
 | Warp | `.warp/` | `.warp/skills/` |

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -181,6 +181,51 @@ assert_not_exists "$AG_PROJECT_DIR/.agent/skills/aif-docs/references/stale.md" "
 echo "antigravity force smoke tests passed"
 
 # -------------------------------------------------------------------
+# Kilo Code workflow smoke: action skills should install as workflows
+# and no longer remain under .kilocode/skills/.
+# -------------------------------------------------------------------
+
+KILO_PROJECT_DIR="$TMPDIR/update-smoke-kilocode"
+mkdir -p "$KILO_PROJECT_DIR"
+
+cat > "$KILO_PROJECT_DIR/.ai-factory.json" << 'EOF'
+{
+  "version": "2.4.0",
+  "agents": [
+    {
+      "id": "kilocode",
+      "skillsDir": ".kilocode/skills",
+      "installedSkills": ["aif", "aif-plan", "aif-commit", "aif-docs"],
+      "mcp": {
+        "github": false,
+        "filesystem": false,
+        "postgres": false,
+        "chromeDevtools": false,
+        "playwright": false
+      }
+    }
+  ],
+  "extensions": []
+}
+EOF
+
+KILO_OUTPUT="$TMPDIR/update-kilocode.log"
+
+(cd "$KILO_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update > "$KILO_OUTPUT" 2>&1)
+
+assert_contains "$KILO_OUTPUT" "\[kilocode\] Status:" "kilocode status section must be printed"
+assert_exists "$KILO_PROJECT_DIR/.kilocode/workflows/aif.md" "aif workflow must be installed for Kilo Code"
+assert_exists "$KILO_PROJECT_DIR/.kilocode/workflows/aif-plan.md" "aif-plan workflow must be installed for Kilo Code"
+assert_exists "$KILO_PROJECT_DIR/.kilocode/workflows/aif-commit.md" "aif-commit workflow must be installed for Kilo Code"
+assert_contains "$KILO_PROJECT_DIR/.kilocode/workflows/aif-plan.md" "/aif:commit" "Kilo workflow content must use Kilo invocation syntax"
+assert_exists "$KILO_PROJECT_DIR/.kilocode/skills/aif-docs/SKILL.md" "non-workflow Kilo skills must remain in skills/"
+assert_not_exists "$KILO_PROJECT_DIR/.kilocode/skills/aif" "workflow skill should not remain in skills/"
+assert_not_exists "$KILO_PROJECT_DIR/.kilocode/skills/aif-plan" "workflow skill should not remain in skills/"
+assert_not_exists "$KILO_PROJECT_DIR/.kilocode/skills/aif-commit" "workflow skill should not remain in skills/"
+
+echo "kilocode workflow smoke tests passed"
+
+# -------------------------------------------------------------------
 # Claude subagents smoke: update should install bundled subagents,
 # persist subagent state in config, and heal local drift.
 # -------------------------------------------------------------------

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -217,7 +217,7 @@ assert_contains "$KILO_OUTPUT" "\[kilocode\] Status:" "kilocode status section m
 assert_exists "$KILO_PROJECT_DIR/.kilocode/workflows/aif.md" "aif workflow must be installed for Kilo Code"
 assert_exists "$KILO_PROJECT_DIR/.kilocode/workflows/aif-plan.md" "aif-plan workflow must be installed for Kilo Code"
 assert_exists "$KILO_PROJECT_DIR/.kilocode/workflows/aif-commit.md" "aif-commit workflow must be installed for Kilo Code"
-assert_contains "$KILO_PROJECT_DIR/.kilocode/workflows/aif-plan.md" "/aif:commit" "Kilo workflow content must use Kilo invocation syntax"
+assert_contains "$KILO_PROJECT_DIR/.kilocode/workflows/aif-plan.md" "/aif:[a-z-]+" "Kilo workflow content must use Kilo invocation syntax"
 assert_exists "$KILO_PROJECT_DIR/.kilocode/skills/aif-docs/SKILL.md" "non-workflow Kilo skills must remain in skills/"
 assert_not_exists "$KILO_PROJECT_DIR/.kilocode/skills/aif" "workflow skill should not remain in skills/"
 assert_not_exists "$KILO_PROJECT_DIR/.kilocode/skills/aif-plan" "workflow skill should not remain in skills/"

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -254,7 +254,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
       .filter(Boolean)
       .join('; ');
 
-    console.log(chalk.dim(`  ${installedAgents.length + 1}. Use the agent-specific AI Factory workflow commands${invocationHints ? ` (${invocationHints})` : ''}`));
+    console.log(chalk.dim(`  ${installedAgents.length + 1}. Use /aif-plan and /aif-commit for daily workflow${invocationHints ? ` (${invocationHints})` : ''}`));
     console.log('');
 
   } catch (error) {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -254,7 +254,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
       .filter(Boolean)
       .join('; ');
 
-    console.log(chalk.dim(`  ${installedAgents.length + 1}. Use /aif-plan and /aif-commit for daily workflow${invocationHints ? ` (${invocationHints})` : ''}`));
+    console.log(chalk.dim(`  ${installedAgents.length + 1}. Use the agent-specific AI Factory workflow commands${invocationHints ? ` (${invocationHints})` : ''}`));
     console.log('');
 
   } catch (error) {

--- a/src/core/transformer.ts
+++ b/src/core/transformer.ts
@@ -61,6 +61,10 @@ export function simplifyFrontmatter(content: string): string {
   return content.replace(/^---\n[\s\S]*?\n---/, newFrontmatter);
 }
 
+export function removeFrontmatter(content: string): string {
+  return content.replace(/^---\n[\s\S]*?\n---\n?/, '');
+}
+
 const INVOCATION_PATTERN = /(^|[^A-Za-z0-9_-])\/(aif(?:-[a-z0-9-]+)?)/g;
 
 export function rewriteInvocationPrefix(

--- a/src/core/transformers/kilocode.ts
+++ b/src/core/transformers/kilocode.ts
@@ -1,8 +1,38 @@
+import path from 'path';
 import type { AgentTransformer, TransformResult } from '../transformer.js';
-import { sanitizeName, extractFrontmatterName, replaceFrontmatterName } from '../transformer.js';
+import {
+  WORKFLOW_SKILLS,
+  sanitizeName,
+  extractFrontmatterName,
+  replaceFrontmatterName,
+  rewriteInvocationPrefix,
+  removeFrontmatter,
+} from '../transformer.js';
+import { fileExists, removeDirectory, removeFile } from '../../utils/fs.js';
+
+function toKiloWorkflowInvocation(invocation: string): string {
+  if (invocation === 'aif') {
+    return '/aif';
+  }
+
+  return `/aif:${invocation.slice('aif-'.length)}`;
+}
+
+function toKiloWorkflowContent(content: string): string {
+  return rewriteInvocationPrefix(removeFrontmatter(content), toKiloWorkflowInvocation);
+}
 
 export class KiloCodeTransformer implements AgentTransformer {
   transform(skillName: string, content: string): TransformResult {
+    if (WORKFLOW_SKILLS.has(skillName)) {
+      return {
+        targetDir: 'workflows',
+        targetName: `${skillName}.md`,
+        content: toKiloWorkflowContent(content),
+        flat: true,
+      };
+    }
+
     const name = extractFrontmatterName(content);
     const sanitized = name ? sanitizeName(name) : skillName;
     const newContent = name ? replaceFrontmatterName(content, sanitized) : content;
@@ -15,12 +45,37 @@ export class KiloCodeTransformer implements AgentTransformer {
     };
   }
 
+  async postInstall(projectDir: string): Promise<void> {
+    const skillsDir = path.join(projectDir, '.kilocode', 'skills');
+    for (const skillName of WORKFLOW_SKILLS) {
+      const legacySkillDir = path.join(skillsDir, skillName);
+      if (await fileExists(legacySkillDir)) {
+        await removeDirectory(legacySkillDir);
+      }
+    }
+  }
+
+  async cleanup(projectDir: string): Promise<void> {
+    const workflowsDir = path.join(projectDir, '.kilocode', 'workflows');
+    for (const skillName of WORKFLOW_SKILLS) {
+      const workflowFile = path.join(workflowsDir, `${skillName}.md`);
+      if (await fileExists(workflowFile)) {
+        await removeFile(workflowFile);
+      }
+    }
+  }
+
   getWelcomeMessage(): string[] {
     return [
       '1. Open Kilo Code in this directory',
-      '2. Skills installed to .kilocode/skills/ (directory names use hyphens, not dots)',
-      '3. MCP servers configured in .kilocode/mcp.json (if selected)',
-      '4. Run /aif to analyze project and generate project-relevant skills',
+      '2. Workflow skills installed to .kilocode/workflows/ and display as Kilo commands',
+      '3. Knowledge skills installed to .kilocode/skills/ (directory names use hyphens, not dots)',
+      '4. MCP servers configured in .kilocode/mcp.json (if selected)',
+      '5. Run /aif to analyze project and use /aif:plan, /aif:commit for daily workflow',
     ];
+  }
+
+  getInvocationHint(): string {
+    return 'Kilo Code: /aif, /aif:plan, /aif:commit';
   }
 }


### PR DESCRIPTION
Fix Kilo Code workflow command installation

AI Factory was installing `aif` action skills for Kilo Code only under `.kilocode/skills/`, while Kilo exposes slash-like command entries from `.kilocode/workflows/`. This change installs AI Factory workflow skills (`aif`, `aif-plan`, `aif-commit`, `aif-explore`, `aif-fix`, `aif-implement`, `aif-improve`, `aif-verify`) as flat workflow files for Kilo Code, rewrites internal command references to Kilo syntax such as `/aif:plan`, and removes legacy workflow skill directories during install/update.

Also updates Kilo onboarding/docs and adds coverage for the new workflow layout.

Closes #18
