### PR TITLE
feat: aif-qa

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ ai-factory/
 │   ├── aif-review/             # Code review
 │   ├── aif-roadmap/            # Strategic project roadmap
 │   ├── aif-rules/              # Project rules and conventions
+│   ├── aif-qa/                 # QA workflow: change summary → test plan → test cases
 │   ├── aif-security-checklist/ # Security audit
 │   ├── aif-skill-generator/    # Generate new skills
 │   └── aif-verify/             # Verify implementation against plan
@@ -73,6 +74,9 @@ artifacts, but the paths below remain the default layout:
 - `.ai-factory/skill-context/<skill>/SKILL.md` — project-specific overrides for skills (from /aif-evolve)
 - `.ai-factory/evolutions/*.md` — evolution logs (from /aif-evolve)
 - `.ai-factory/evolutions/patch-cursor.json` — incremental evolve cursor (latest processed patch)
+- `.ai-factory/qa/<branch>/change-summary.md` — QA change summary (from /aif-qa)
+- `.ai-factory/qa/<branch>/test-plan.md` — QA test plan (from /aif-qa)
+- `.ai-factory/qa/<branch>/test-cases.md` — QA test cases (from /aif-qa)
 - `.ai-factory/evolution/current.json` — active loop pointer (from /aif-loop)
 - `.ai-factory/evolution/<alias>/run.json` — current loop state
 - `.ai-factory/evolution/<alias>/history.jsonl` — loop event history (append-only)
@@ -82,19 +86,20 @@ artifacts, but the paths below remain the default layout:
 
 Artifact writers are command-scoped to prevent ownership conflicts:
 
-| Artifact                                                         | Primary writer command | Notes                                                                                            |
-|------------------------------------------------------------------|------------------------|--------------------------------------------------------------------------------------------------|
-| `.ai-factory/DESCRIPTION.md`                                     | `/aif`                 | `/aif-implement` may update only when implementation materially changed context facts            |
-| `paths.architecture` (default: `.ai-factory/ARCHITECTURE.md`)    | `/aif-architecture`    | `/aif-implement` may update structure notes when structure changes                               |
-| `paths.roadmap` (default: `.ai-factory/ROADMAP.md`)              | `/aif-roadmap`         | `/aif-implement` may mark completed milestones with evidence                                     |
-| `paths.rules_file` (default: `.ai-factory/RULES.md`), `paths.rules/<area>.md`, `rules.<area>` | `/aif-rules`           | top-level conventions plus area-rule files and registration                                     |
-| `paths.research` (default: `.ai-factory/RESEARCH.md`)            | `/aif-explore`         | explore-mode writable artifact                                                                   |
-| `paths.plan` / `paths.plans/<branch-or-slug>.md`                 | `/aif-plan`            | defaults shown; `/aif-improve` refines existing plans                                            |
-| `paths.fix_plan` and `paths.patches/*.md`                        | `/aif-fix`             | fix workflow ownership; context artifacts (including `DESCRIPTION.md`) stay read-only by default |
-| `README.md` and `paths.docs/*`                                   | `/aif-docs`            | README stays the landing page; detailed docs directory is configurable via `paths.docs`          |
-| `.ai-factory/skill-context/*`                                    | `/aif-evolve`          | skill-context overrides for built-in skills                                                      |
-| `paths.evolutions/*.md` and `paths.evolutions/patch-cursor.json` | `/aif-evolve`          | evolution logs and incremental patch cursor                                                      |
-| `.ai-factory/evolution/*` artifacts                              | `/aif-loop`            | loop state ownership                                                                             |
+| Artifact                                                                                      | Primary writer command | Notes                                                                                            |
+|-----------------------------------------------------------------------------------------------|------------------------|--------------------------------------------------------------------------------------------------|
+| `.ai-factory/DESCRIPTION.md`                                                                  | `/aif`                 | `/aif-implement` may update only when implementation materially changed context facts            |
+| `paths.architecture` (default: `.ai-factory/ARCHITECTURE.md`)                                 | `/aif-architecture`    | `/aif-implement` may update structure notes when structure changes                               |
+| `paths.roadmap` (default: `.ai-factory/ROADMAP.md`)                                           | `/aif-roadmap`         | `/aif-implement` may mark completed milestones with evidence                                     |
+| `paths.rules_file` (default: `.ai-factory/RULES.md`), `paths.rules/<area>.md`, `rules.<area>` | `/aif-rules`           | top-level conventions plus area-rule files and registration                                      |
+| `paths.research` (default: `.ai-factory/RESEARCH.md`)                                         | `/aif-explore`         | explore-mode writable artifact                                                                   |
+| `paths.plan` / `paths.plans/<branch-or-slug>.md`                                              | `/aif-plan`            | defaults shown; `/aif-improve` refines existing plans                                            |
+| `paths.fix_plan` and `paths.patches/*.md`                                                     | `/aif-fix`             | fix workflow ownership; context artifacts (including `DESCRIPTION.md`) stay read-only by default |
+| `README.md` and `paths.docs/*`                                                                | `/aif-docs`            | README stays the landing page; detailed docs directory is configurable via `paths.docs`          |
+| `.ai-factory/skill-context/*`                                                                 | `/aif-evolve`          | skill-context overrides for built-in skills                                                      |
+| `paths.evolutions/*.md` and `paths.evolutions/patch-cursor.json`                              | `/aif-evolve`          | evolution logs and incremental patch cursor                                                      |
+| `.ai-factory/evolution/*` artifacts                                                           | `/aif-loop`            | loop state ownership                                                                             |
+| `paths.qa` (default: `.ai-factory/qa/<branch>/`)                                              | `/aif-qa`              | change-summary, test-plan, test-cases artifacts; branch slug used as subdirectory                |
 
 Quality commands (`/aif-commit`, `/aif-review`, `/aif-verify`) are read-only for context artifacts by default.
 
@@ -115,7 +120,7 @@ Context gate policy for quality commands:
 - Core workflow and quality: `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`,
   `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`
 - Additional utility: `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`,
-  `/aif-security-checklist`
+  `/aif-security-checklist`, `/aif-qa`
 
 Current config-agnostic built-ins:
 
@@ -124,7 +129,7 @@ Current config-agnostic built-ins:
 
 Current config keys in active use:
 
-- `paths.*` - artifact discovery for description, architecture, roadmap, research, RULES.md, plan files, fix plans,
+- `paths.*` - artifact discovery for description, architecture, roadmap, research, RULES.md, plan files, fix plans, QA artifacts
   references, security state, patches, evolutions, loop state, and rules
 - `language.ui` / `language.artifacts` - prompt language vs generated artifact language
 - `git.enabled` / `git.base_branch` / `git.create_branches` / `git.branch_prefix` / `git.skip_push_after_commit` - planning, verification, and commit push behavior
@@ -247,6 +252,19 @@ Docs policy:
     - Docs: no or unset → WARN [docs] only (no mandatory prompt)
     ↓
 Offers to delete PLAN.md when done (keeps feature-*.md)
+
+/aif-qa [--all] [change-summary | test-plan | test-cases] [<branch>]
+    ↓
+Reads .ai-factory/DESCRIPTION.md + ARCHITECTURE.md + config.yaml for context
+    ↓
+change-summary → collects git diff, checks commit/diff size limits, explores key files in parallel
+               → saves .ai-factory/qa/<branch>/change-summary.md
+    ↓
+test-plan      → reads change-summary → determines scope and test types → saves test-plan.md
+    ↓
+test-cases     → reads change-summary + test-plan → writes TC-NNN scenarios → saves test-cases.md
+    ↓
+--all          → runs all three stages in sequence without inter-stage prompts
 
 /aif-fix <bug description>
     ↓

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 **AI Factory** (v2) is an npm package + skill system that automates AI agent context setup for projects. It provides:
 
 1. **CLI tool** (`ai-factory init/update/upgrade`) — installs skills and configures MCP
-2. **Built-in skills** (22 skills, all `aif-*` prefixed) — workflow commands for spec-driven development
+2. **Built-in skills** (24 skills, all `aif-*` prefixed) — workflow commands for spec-driven development
 3. **Spec-driven workflow** — structured approach: plan → implement → commit
 4. **Multi-agent support** — 15 agents (Claude Code, Cursor, Windsurf, Roo Code, Kilo Code, Antigravity, OpenCode, Warp,
    Zencoder, Codex CLI, GitHub Copilot, Gemini CLI, Junie, Qwen Code, Universal)
@@ -99,7 +99,7 @@ Artifact writers are command-scoped to prevent ownership conflicts:
 | `.ai-factory/skill-context/*`                                                                 | `/aif-evolve`          | skill-context overrides for built-in skills                                                      |
 | `paths.evolutions/*.md` and `paths.evolutions/patch-cursor.json`                              | `/aif-evolve`          | evolution logs and incremental patch cursor                                                      |
 | `.ai-factory/evolution/*` artifacts                                                           | `/aif-loop`            | loop state ownership                                                                             |
-| `paths.qa` (default: `.ai-factory/qa/<branch>/`)                                              | `/aif-qa`              | change-summary, test-plan, test-cases artifacts; branch slug used as subdirectory                |
+| `paths.qa` (default: `.ai-factory/qa/<branch-slug>/`)                                         | `/aif-qa`              | change-summary, test-plan, test-cases artifacts; branch slug used as subdirectory                |
 
 Quality commands (`/aif-commit`, `/aif-review`, `/aif-verify`) are read-only for context artifacts by default.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,9 +74,9 @@ artifacts, but the paths below remain the default layout:
 - `.ai-factory/skill-context/<skill>/SKILL.md` — project-specific overrides for skills (from /aif-evolve)
 - `.ai-factory/evolutions/*.md` — evolution logs (from /aif-evolve)
 - `.ai-factory/evolutions/patch-cursor.json` — incremental evolve cursor (latest processed patch)
-- `.ai-factory/qa/<branch>/change-summary.md` — QA change summary (from /aif-qa)
-- `.ai-factory/qa/<branch>/test-plan.md` — QA test plan (from /aif-qa)
-- `.ai-factory/qa/<branch>/test-cases.md` — QA test cases (from /aif-qa)
+- `.ai-factory/qa/<branch-slug>/change-summary.md` — QA change summary (from /aif-qa)
+- `.ai-factory/qa/<branch-slug>/test-plan.md` — QA test plan (from /aif-qa)
+- `.ai-factory/qa/<branch-slug>/test-cases.md` — QA test cases (from /aif-qa)
 - `.ai-factory/evolution/current.json` — active loop pointer (from /aif-loop)
 - `.ai-factory/evolution/<alias>/run.json` — current loop state
 - `.ai-factory/evolution/<alias>/history.jsonl` — loop event history (append-only)
@@ -258,7 +258,7 @@ Offers to delete PLAN.md when done (keeps feature-*.md)
 Reads .ai-factory/DESCRIPTION.md + ARCHITECTURE.md + config.yaml for context
     ↓
 change-summary → collects git diff, checks commit/diff size limits, explores key files in parallel
-               → saves .ai-factory/qa/<branch>/change-summary.md
+               → saves .ai-factory/qa/<branch-slug>/change-summary.md
     ↓
 test-plan      → reads change-summary → determines scope and test types → saves test-plan.md
     ↓

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -40,7 +40,7 @@ All other built-in skills treat `config.yaml` as read-only input.
 
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
-| `language.ui` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-reference`, `/aif-rules`, `/aif-security-checklist` | UI language for prompts, questions, and summaries |
+| `language.ui` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-reference`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa` | UI language for prompts, questions, and summaries |
 | `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-roadmap`, `/aif-implement`, `/aif-loop`, `/aif-docs`, `/aif-evolve` | Language for generated artifacts |
 | `language.technical_terms` | `keep` | No dedicated built-in reader yet | Present in schema and template; currently written by `/aif` and reserved for future translation policy |
 
@@ -64,6 +64,7 @@ All other built-in skills treat `config.yaml` as read-only input.
 | `paths.evolution` | `.ai-factory/evolution/` | `/aif-loop` | Reflex loop state root |
 | `paths.specs` | `.ai-factory/specs/` | `/aif-plan`, `/aif-verify` | Specs / archived plan support |
 | `paths.rules` | `.ai-factory/rules/` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-rules` | Area-rules directory and relative rule resolution base |
+| `paths.qa` | `.ai-factory/qa/` | `/aif-qa` | QA artifacts root; branch slug is appended as subdirectory (`<paths.qa>/<branch>/`) |
 
 ### `workflow`
 
@@ -120,6 +121,7 @@ All other built-in skills treat `config.yaml` as read-only input.
 | `/aif-evolve` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.rules`, `paths.patches`, `paths.evolutions`, `language.ui`, `language.artifacts`, `rules.base`, `rules.<area>` |
 | `/aif-reference` | Yes | No | `paths.references`, `paths.rules_file`, `language.ui` |
 | `/aif-security-checklist` | Yes | No | `paths.security`, `language.ui` |
+| `/aif-qa` | Yes | No | `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, `git.base_branch` |
 
 ### Config-Agnostic Built-ins
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -64,7 +64,7 @@ All other built-in skills treat `config.yaml` as read-only input.
 | `paths.evolution` | `.ai-factory/evolution/` | `/aif-loop` | Reflex loop state root |
 | `paths.specs` | `.ai-factory/specs/` | `/aif-plan`, `/aif-verify` | Specs / archived plan support |
 | `paths.rules` | `.ai-factory/rules/` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-rules` | Area-rules directory and relative rule resolution base |
-| `paths.qa` | `.ai-factory/qa/` | `/aif-qa` | QA artifacts root; branch slug is appended as subdirectory (`<paths.qa>/<branch>/`) |
+| `paths.qa` | `.ai-factory/qa/` | `/aif-qa` | QA artifacts root; branch slug is appended as subdirectory (`<paths.qa>/<branch-slug>/`) |
 
 ### `workflow`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,7 +162,7 @@ Current config-agnostic built-ins include `/aif-best-practices`, `/aif-build-aut
 - `git.skip_push_after_commit: true` makes `/aif-commit` stop after local commit without showing push prompt.
 - `paths.plan` remains the default fast-plan file. If you prefer fast plans inside `paths.plans/`, change `paths.plan` manually in `config.yaml`.
 - `paths.docs` controls where `/aif-docs` writes the detailed documentation pages. `README.md` remains the landing page in the project root.
-- `paths.qa` controls where `/aif-qa` stores QA artifacts. Branch slug is appended automatically: `<paths.qa>/<branch>/change-summary.md`, `test-plan.md`, `test-cases.md`.
+- `paths.qa` controls where `/aif-qa` stores QA artifacts. A derived branch slug is appended automatically: `<paths.qa>/<branch-slug>/change-summary.md`, `test-plan.md`, `test-cases.md`. The slug is an injective encoding of the branch name — see `skills/aif-qa/SKILL.md` for the full algorithm.
 
 **Current schema limits:** `config.yaml` still leaves `.ai-factory/skill-context/` fixed by command contract. `README.md` and `docs-html/` remain fixed by current documentation workflow.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -290,7 +290,7 @@ your-project/
 │   │       ├── history.jsonl
 │   │       └── artifact.md
 │   └── qa/                    # QA artifacts (from /aif-qa)
-│       └── <branch-name>/
+│       └── <branch-slug>/
 │           ├── change-summary.md
 │           ├── test-plan.md
 │           └── test-cases.md

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,7 @@ paths:
   evolution: .ai-factory/evolution/
   specs: .ai-factory/specs/
   rules: .ai-factory/rules/
+  qa: .ai-factory/qa/
 
 # Workflow Settings
 workflow:
@@ -148,7 +149,7 @@ rules:
 
 **Current config-aware skills** read `config.yaml` at Step 0. This currently includes:
 - Core workflow and quality commands: `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`
-- Additional utility commands: `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-security-checklist`
+- Additional utility commands: `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-security-checklist`, `/aif-qa`
 
 Other skills are config-agnostic for now and rely on repository context, explicit arguments, or fixed non-configurable paths such as `skill-context`.
 
@@ -161,6 +162,7 @@ Current config-agnostic built-ins include `/aif-best-practices`, `/aif-build-aut
 - `git.skip_push_after_commit: true` makes `/aif-commit` stop after local commit without showing push prompt.
 - `paths.plan` remains the default fast-plan file. If you prefer fast plans inside `paths.plans/`, change `paths.plan` manually in `config.yaml`.
 - `paths.docs` controls where `/aif-docs` writes the detailed documentation pages. `README.md` remains the landing page in the project root.
+- `paths.qa` controls where `/aif-qa` stores QA artifacts. Branch slug is appended automatically: `<paths.qa>/<branch>/change-summary.md`, `test-plan.md`, `test-cases.md`.
 
 **Current schema limits:** `config.yaml` still leaves `.ai-factory/skill-context/` fixed by command contract. `README.md` and `docs-html/` remain fixed by current documentation workflow.
 
@@ -281,12 +283,17 @@ your-project/
 │   ├── evolutions/            # Evolution logs (from /aif-evolve)
 │   │   ├── 2026-02-08-10.00.md
 │   │   └── patch-cursor.json  # Incremental evolve cursor (latest processed patch)
-│   └── evolution/             # Active reflex loop state (from /aif-loop)
-│       ├── current.json
-│       └── <task-alias>/
-│           ├── run.json
-│           ├── history.jsonl
-│           └── artifact.md
+│   ├── evolution/             # Active reflex loop state (from /aif-loop)
+│   │   ├── current.json
+│   │   └── <task-alias>/
+│   │       ├── run.json
+│   │       ├── history.jsonl
+│   │       └── artifact.md
+│   └── qa/                    # QA artifacts (from /aif-qa)
+│       └── <branch-name>/
+│           ├── change-summary.md
+│           ├── test-plan.md
+│           └── test-cases.md
 ├── .mcp.json                  # MCP servers config (Claude Code project scope)
 └── .ai-factory.json           # AI Factory config
 ```

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,7 +2,7 @@
 
 # Core Skills
 
-**Config-aware skills read `.ai-factory/config.yaml` at startup** to resolve paths, language settings, workflow preferences, and rules hierarchy. The current config-aware set is `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`, `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, and `/aif-security-checklist`.
+**Config-aware skills read `.ai-factory/config.yaml` at startup** to resolve paths, language settings, workflow preferences, and rules hierarchy. The current config-aware set is `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`, `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-security-checklist`, and `/aif-qa`.
 
 Config-agnostic built-ins in the current model: `/aif-best-practices`, `/aif-build-automation`, `/aif-ci`, `/aif-dockerize`, `/aif-grounded`, and `/aif-skill-generator`.
 
@@ -485,6 +485,33 @@ Each category includes a checklist, vulnerable/safe code examples (TypeScript, P
 - Reads `.ai-factory/config.yaml` for `paths.security` and `language.ui`
 
 - Config policy: config-aware; persistent ignore state uses `paths.security`
+
+### `/aif-qa [--all] [change-summary | test-plan | test-cases] [<branch>]`
+
+Three-stage QA workflow for manual testing of a feature or fix:
+
+```
+/aif-qa change-summary          # Analyze what changed on current branch
+/aif-qa change-summary feat/x   # Analyze a specific branch
+/aif-qa test-plan               # Create test plan (requires change-summary artifact)
+/aif-qa test-cases              # Write test cases (requires test-plan artifact)
+/aif-qa --all                   # Run all three stages in sequence
+/aif-qa --all feat/x            # Full pipeline for a specific branch
+```
+
+Each stage builds on the previous one and saves its artifact to `paths.qa/<branch>/`:
+
+| Stage            | Artifact            | What it produces                                    |
+|------------------|---------------------|-----------------------------------------------------|
+| `change-summary` | `change-summary.md` | Risk-annotated summary of git changes               |
+| `test-plan`      | `test-plan.md`      | Scoped test plan with types and acceptance criteria |
+| `test-cases`     | `test-cases.md`     | Concrete TC-NNN scenarios with steps and test data  |
+
+For large branches the `change-summary` stage checks commit count (>20) and diff size (>1000 lines) before proceeding — both gates ask the user how to continue rather than silently truncating.
+
+The `--all` flag runs all three stages in sequence without inter-stage prompts. If any stage fails, the pipeline stops and reports the failing stage.
+
+- Config policy: config-aware; reads `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, `git.base_branch`
 
 ## See Also
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -499,7 +499,7 @@ Three-stage QA workflow for manual testing of a feature or fix:
 /aif-qa --all feat/x            # Full pipeline for a specific branch
 ```
 
-Each stage builds on the previous one and saves its artifact to `paths.qa/<branch>/`:
+Each stage builds on the previous one and saves its artifact to `paths.qa/<branch-slug>/`:
 
 | Stage            | Artifact            | What it produces                                    |
 |------------------|---------------------|-----------------------------------------------------|

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -325,7 +325,7 @@ Reads patches incrementally using an evolve cursor, analyzes project patterns, a
 
 ---
 
-For full details on all skills including utility commands (`/aif-docs`, `/aif-dockerize`, `/aif-build-automation`, `/aif-ci`, `/aif-commit`, `/aif-skill-generator`, `/aif-reference`, `/aif-security-checklist`), see [Core Skills](skills.md).
+For full details on all skills including utility commands (`/aif-docs`, `/aif-dockerize`, `/aif-build-automation`, `/aif-ci`, `/aif-commit`, `/aif-skill-generator`, `/aif-reference`, `/aif-security-checklist`, `/aif-qa`), see [Core Skills](skills.md).
 
 ## Why Spec-Driven?
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -48,7 +48,7 @@ Run once per project. Sets up context files that all workflow skills depend on.
 
 The repeatable development loop. Each skill feeds into the next, sharing context through plan files and patches.
 
-Path examples below show the default `.ai-factory/` locations. `config.yaml` can relocate plan, fix, reference, security, patch, evolution, and loop artifacts while keeping the same ownership flow.
+Path examples below show the default `.ai-factory/` locations. `config.yaml` can relocate plan, fix, reference, security, patch, evolution, loop, and qa artifacts while keeping the same ownership flow.
 
 Optional discovery step: use `/aif-explore` before planning to investigate ideas, compare options, and clarify requirements.
 
@@ -117,19 +117,21 @@ Optional conventions step: use `/aif-rules` to append or refine project-wide axi
                              │                      │
                              └──────────┬───────────┘
                                         │
-                                        ▼
-                             ┌──────────────────────────────────────┐
-                             │                                      │
-                             │ /aif-verify                          │
-                             │    (optional)                        │
-                             │                                      │
-                             │ Check completeness                   │
-                             │ Build / test / lint                  │
-                             │    ↓                                 │
-                             │ → /aif-security-checklist            │
-                             │ → /aif-review                        │
-                             │                                      │
-                             └──────────────────┬───────────────────┘
+                                        ├─────────────────────────────────────────────────┐
+                                        │                                                 │
+                                        ▼                                                 ▼
+                             ┌──────────────────────────────────────┐       ┌───────────────────────────┐
+                             │                                      │       │                           │
+                             │ /aif-verify                          │       │ /aif-qa                   │
+                             │    (optional)                        │       │    (optional)             │
+                             │                                      │       │                           │
+                             │ Check completeness                   │       │ Manual QA artifacts:      │
+                             │ Build / test / lint                  │       │ → change-summary          │
+                             │    ↓                                 │       │ → test-plan               │
+                             │ → /aif-security-checklist            │       │ → test-cases              │
+                             │ → /aif-review                        │       │                           │
+                             │                                      │       │ paths.qa/<branch-slug>/   │
+                             └──────────────────┬───────────────────┘       └───────────────────────────┘
                                         │
                                         ▼
                              ┌─────────────────────┐
@@ -173,23 +175,25 @@ Optional conventions step: use `/aif-rules` to append or refine project-wide axi
 | `/aif-reference` | Create knowledge refs from URLs/docs for AI agents | No | No (`paths.references`, default `.ai-factory/references/`) |
 | `/aif-fix` | Bug fixes, errors, hotfixes | No | Optional (`paths.fix_plan`, default `.ai-factory/FIX_PLAN.md`) |
 | `/aif-verify` | Post-implementation quality check | No | No (reads existing) |
+| `/aif-qa` | Manual QA for a feature/fix: change summary → test plan → test cases | No | `paths.qa/<branch-slug>/*.md` (default: `.ai-factory/qa/<branch-slug>/`) |
 
 ## Artifact Ownership and Context Gates
 
 Ownership is command-scoped to avoid conflicting writers:
 
-| Command                                   | Primary artifact ownership                                                                               | Notes                                                   |
-|-------------------------------------------|----------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `/aif`                                    | `.ai-factory/DESCRIPTION.md`, setup `AGENTS.md`                                                          | invokes `/aif-architecture` for architecture file       |
-| `/aif-architecture`                       | `paths.architecture` (default: `.ai-factory/ARCHITECTURE.md`)                                           | may update architecture pointer in DESCRIPTION/AGENTS   |
-| `/aif-roadmap`                            | `paths.roadmap` (default: `.ai-factory/ROADMAP.md`)                                                      | `/aif-implement` may mark completed milestones          |
-| `/aif-rules`                              | `paths.rules_file` (default: `.ai-factory/RULES.md`), `paths.rules/<area>.md`, `rules.<area>`           | top-level axioms plus area-rule files and registration  |
-| `/aif-plan`                               | `paths.plan`, `paths.plans/<branch-or-slug>.md`                                                           | `/aif-improve` refines existing plans                   |
-| `/aif-explore`                            | `paths.research` (default: `.ai-factory/RESEARCH.md`)                                                    | all other artifacts are read-only in explore mode       |
-| `/aif-reference`                          | `paths.references/*`, `paths.references/INDEX.md`                                                        | knowledge references from external sources              |
-| `/aif-fix`                                | `paths.fix_plan`, `paths.patches/*.md`                                                                   | bug-fix learning loop artifacts                         |
-| `/aif-evolve`                             | `paths.evolutions/*.md`, `paths.evolutions/patch-cursor.json`, `.ai-factory/skill-context/*`            | skill-context overrides + evolution logs + cursor state |
-| `/aif-commit` `/aif-review` `/aif-verify` | read-only context by default                                                                             | gate and report, no default context-file writes         |
+| Command                                   | Primary artifact ownership                                                                    | Notes                                                     |
+|-------------------------------------------|-----------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+| `/aif`                                    | `.ai-factory/DESCRIPTION.md`, setup `AGENTS.md`                                               | invokes `/aif-architecture` for architecture file         |
+| `/aif-architecture`                       | `paths.architecture` (default: `.ai-factory/ARCHITECTURE.md`)                                 | may update architecture pointer in DESCRIPTION/AGENTS     |
+| `/aif-roadmap`                            | `paths.roadmap` (default: `.ai-factory/ROADMAP.md`)                                           | `/aif-implement` may mark completed milestones            |
+| `/aif-rules`                              | `paths.rules_file` (default: `.ai-factory/RULES.md`), `paths.rules/<area>.md`, `rules.<area>` | top-level axioms plus area-rule files and registration    |
+| `/aif-plan`                               | `paths.plan`, `paths.plans/<branch-or-slug>.md`                                               | `/aif-improve` refines existing plans                     |
+| `/aif-explore`                            | `paths.research` (default: `.ai-factory/RESEARCH.md`)                                         | all other artifacts are read-only in explore mode         |
+| `/aif-reference`                          | `paths.references/*`, `paths.references/INDEX.md`                                             | knowledge references from external sources                |
+| `/aif-fix`                                | `paths.fix_plan`, `paths.patches/*.md`                                                        | bug-fix learning loop artifacts                           |
+| `/aif-evolve`                             | `paths.evolutions/*.md`, `paths.evolutions/patch-cursor.json`, `.ai-factory/skill-context/*`  | skill-context overrides + evolution logs + cursor state   |
+| `/aif-qa`                                 | `paths.qa/<branch-slug>/change-summary.md`, `test-plan.md`, `test-cases.md`                   | derived branch slug as subdirectory (see aif-qa SKILL.md) |
+| `/aif-commit` `/aif-review` `/aif-verify` | read-only context by default                                                                  | gate and report, no default context-file writes           |
 
 Context-gate defaults for `/aif-commit`, `/aif-review`, `/aif-verify`:
 - Check architecture, roadmap, and rules alignment as read-only context.

--- a/scripts/test-aif-qa.sh
+++ b/scripts/test-aif-qa.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# Smoke tests for /aif-qa: branch-slug algorithm correctness and skill contract.
+# Usage: ./scripts/test-aif-qa.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL_DIR="$ROOT_DIR/skills/aif-qa"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() {
+    PASSED=$((PASSED + 1))
+    echo -e "  ${GREEN}✓${NC} $1"
+}
+
+fail() {
+    FAILED=$((FAILED + 1))
+    echo -e "  ${RED}✗${NC} $1"
+}
+
+# Reference implementation of the branch-slug algorithm documented in
+# skills/aif-qa/SKILL.md Step 0.2. Kept in lock-step with the skill's
+# three-step spec: safe_slug, 8-char hash of the original branch name, combine.
+aif_qa_slug() {
+    local branch="$1"
+    local safe_slug
+    safe_slug=$(printf '%s' "$branch" | sed -E 's|[^A-Za-z0-9._-]|-|g; s|-+|-|g; s|^-||; s|-$||')
+    if [[ -z "$safe_slug" ]]; then
+        safe_slug="branch"
+    fi
+    safe_slug="${safe_slug:0:40}"
+    local hash8
+    hash8=$(git hash-object --stdin <<< "$branch" | head -c 8)
+    printf '%s-%s\n' "$safe_slug" "$hash8"
+}
+
+# ─────────────────────────────────────────────
+# Part 1: branch-slug algorithm (branch-key uniqueness)
+# ─────────────────────────────────────────────
+echo -e "\n${BOLD}=== /aif-qa branch-slug algorithm ===${NC}\n"
+
+# Test 1: classic collision case that motivated the P1 fix in PR #68
+s1=$(aif_qa_slug "feature/foo")
+s2=$(aif_qa_slug "feature-foo")
+if [[ "$s1" != "$s2" ]]; then
+    pass "feature/foo vs feature-foo are distinct ($s1 ≠ $s2)"
+else
+    fail "feature/foo and feature-foo collapsed to $s1"
+fi
+
+# Test 2: multi-way injectivity — 4 branches that all share the same safe_slug
+# 'feat-x', plus two that differ on safe_slug. All 6 must produce unique slugs.
+branches=('feat/x' 'feat-x' 'feat x' 'feat--x' 'feat.x' 'feat_x')
+slugs=()
+for b in "${branches[@]}"; do
+    slugs+=("$(aif_qa_slug "$b")")
+done
+unique_count=$(printf '%s\n' "${slugs[@]}" | sort -u | wc -l | tr -d ' ')
+if [[ "$unique_count" -eq "${#branches[@]}" ]]; then
+    pass "${#branches[@]} colliding branches → ${#branches[@]} unique slugs"
+else
+    fail "expected ${#branches[@]} unique slugs, got $unique_count"
+    for i in "${!branches[@]}"; do
+        echo "      '${branches[$i]}' → ${slugs[$i]}"
+    done
+fi
+
+# Test 3: filesystem-safe output for exotic characters
+s=$(aif_qa_slug 'feat/foo<bar>*?')
+if [[ "$s" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    pass "slug is filesystem-safe for exotic branch: $s"
+else
+    fail "slug contains unsafe chars: $s"
+fi
+
+# Test 4: empty-ish branch (all special chars) still produces a valid slug
+s=$(aif_qa_slug "///")
+if [[ -n "$s" && "$s" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    pass "branch '///' produces non-empty safe slug: $s"
+else
+    fail "branch '///' produced bad slug: '$s'"
+fi
+
+# Test 5: slug always ends with an 8-char lowercase hex hash suffix
+s=$(aif_qa_slug "main")
+if [[ "$s" =~ -[0-9a-f]{8}$ ]]; then
+    pass "slug ends with 8-char hex hash: $s"
+else
+    fail "slug missing 8-char hex hash suffix: $s"
+fi
+
+# Test 6: deterministic — same input always produces the same slug
+s1=$(aif_qa_slug "feature/x")
+s2=$(aif_qa_slug "feature/x")
+if [[ "$s1" == "$s2" ]]; then
+    pass "slug is deterministic"
+else
+    fail "non-deterministic slug: $s1 vs $s2"
+fi
+
+# ─────────────────────────────────────────────
+# Part 2: skill contract (explicit-branch flow, --all mode, stage handoff)
+# ─────────────────────────────────────────────
+echo -e "\n${BOLD}=== /aif-qa skill contract ===${NC}\n"
+
+# Contract: SKILL.md documents the injective slug encoding
+if grep -qi 'injective' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md documents injective branch-slug encoding"
+else
+    fail "SKILL.md must mention 'injective' branch-slug encoding"
+fi
+
+# Contract: SKILL.md specifies git hash-object as the hash step
+if grep -q 'git hash-object' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md specifies git hash-object for hash suffix"
+else
+    fail "SKILL.md must reference git hash-object"
+fi
+
+# Contract: SKILL.md documents the explicit-branch argument flow
+if grep -q 'branch was provided in arguments' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md documents explicit-branch argument flow"
+else
+    fail "SKILL.md must document explicit-branch flow"
+fi
+
+# Contract: SKILL.md documents --all mode
+if grep -q 'all_mode' "$SKILL_DIR/SKILL.md" && grep -q -- '--all' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md documents --all mode"
+else
+    fail "SKILL.md must document --all mode"
+fi
+
+# Contract: stage references propagate resolved_branch across all three stages
+for stage in CHANGE-SUMMARY TEST-PLAN TEST-CASES; do
+    ref_file="$SKILL_DIR/references/${stage}.md"
+    if [[ -f "$ref_file" ]] && grep -q 'resolved_branch' "$ref_file"; then
+        pass "references/${stage}.md uses resolved_branch for stage handoff"
+    else
+        fail "references/${stage}.md must reference resolved_branch"
+    fi
+done
+
+# Contract: allowed-tools covers both Bash(git *) and Bash(mkdir *)
+# (an earlier PR review caught a mismatch between instructions and permissions)
+allowed_line=$(grep -E '^allowed-tools:' "$SKILL_DIR/SKILL.md" || true)
+if [[ "$allowed_line" == *"Bash(git *)"* && "$allowed_line" == *"Bash(mkdir *)"* ]]; then
+    pass "SKILL.md allowed-tools covers Bash(git *) and Bash(mkdir *)"
+else
+    fail "SKILL.md allowed-tools must include Bash(git *) and Bash(mkdir *)"
+fi
+
+# ─────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────
+TOTAL=$((PASSED + FAILED))
+echo ""
+echo -e "${BOLD}Total:${NC} $TOTAL, ${GREEN}Passed:${NC} $PASSED, ${RED}Failed:${NC} $FAILED"
+
+if [[ $FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -373,6 +373,23 @@ else
 fi
 
 # ─────────────────────────────────────────────
+# Part 8: aif-qa skill smoke tests
+# ─────────────────────────────────────────────
+echo -e "\n${BOLD}=== aif-qa skill smoke tests ===${NC}\n"
+
+set +e
+QA_SMOKE_OUTPUT=$(bash "$ROOT_DIR/scripts/test-aif-qa.sh" 2>&1)
+QA_SMOKE_EXIT=$?
+set -e
+
+if [[ $QA_SMOKE_EXIT -eq 0 ]]; then
+    pass "aif-qa smoke tests"
+else
+    fail "aif-qa smoke tests"
+    echo "$QA_SMOKE_OUTPUT" | sed 's/^/      /'
+fi
+
+# ─────────────────────────────────────────────
 # Summary
 # ─────────────────────────────────────────────
 echo -e "\n${BOLD}=== Results ===${NC}"

--- a/skills/aif-qa/SKILL.md
+++ b/skills/aif-qa/SKILL.md
@@ -81,7 +81,17 @@ Otherwise → run: git branch --show-current
 
 Store both values for use in all reference files:
 - `resolved_branch` — the branch being analyzed (used to locate/save artifacts)
-- `artifact_dir` — `<resolved paths.qa>/<branch-slug>` where `branch-slug` is `resolved_branch` with every `/` (and any other non-alphanumeric character except `-`) replaced by `-`; e.g. `feature/my-branch` → `feature-my-branch`
+- `artifact_dir` — `<resolved paths.qa>/<branch-slug>`, where `branch-slug` is an **injective** encoding of `resolved_branch`. Compute it in three steps:
+  1. **Safe slug.** Take `resolved_branch` and replace every character that is not in `[A-Za-z0-9._-]` with `-`, collapse runs of consecutive `-` into a single `-`, and trim leading/trailing `-`. If the result is empty, use `branch`. Optionally truncate to 40 characters. Call this `safe_slug`.
+  2. **Hash suffix.** Run `git hash-object --stdin <<< "<resolved_branch>"` and take the **first 8 hex characters** of the output. Call this `hash8`. The hash is derived from the **original, unnormalized** branch name — this is what guarantees uniqueness.
+  3. **Combine:** `branch-slug = "<safe_slug>-<hash8>"`.
+
+  **Why the hash:** a readable slug alone is lossy — `feature/foo` and `feature-foo` normalize to the same `safe_slug` and would overwrite each other's artifacts. Appending a hash of the full original name makes the mapping injective: different branches always resolve to different directories.
+
+  **Examples:**
+  - `feature/foo` → `safe_slug=feature-foo`, `hash8=a72ccce7` → `feature-foo-a72ccce7`
+  - `feature-foo` → `safe_slug=feature-foo`, `hash8=6f80dfc6` → `feature-foo-6f80dfc6`
+  - `main` → `safe_slug=main`, `hash8=<computed>` → `main-<hash8>`
 - `all_mode` — whether to skip inter-stage prompts
 
 **If no mode was provided and `all_mode = false` — ask the user:**

--- a/skills/aif-qa/SKILL.md
+++ b/skills/aif-qa/SKILL.md
@@ -2,7 +2,7 @@
 name: aif-qa
 description: QA workflow for testing a feature or task implementation. Analyzes changes, produces test plans, and describes concrete test scenarios. Use when user says "test this", "write test plan", "what should I test", or "QA this branch".
 argument-hint: "[--all] [change-summary | test-plan | test-cases] [<branch>]"
-allowed-tools: Bash(git *) Read Write Grep Glob AskUserQuestion Task
+allowed-tools: Read Write Grep Glob Bash(git *) Bash(mkdir *) AskUserQuestion Task
 disable-model-invocation: false
 ---
 
@@ -81,7 +81,7 @@ Otherwise → run: git branch --show-current
 
 Store both values for use in all reference files:
 - `resolved_branch` — the branch being analyzed (used to locate/save artifacts)
-- `artifact_dir` — `<resolved paths.qa>/<resolved_branch with / replaced by ->`
+- `artifact_dir` — `<resolved paths.qa>/<branch-slug>` where `branch-slug` is `resolved_branch` with every `/` (and any other non-alphanumeric character except `-`) replaced by `-`; e.g. `feature/my-branch` → `feature-my-branch`
 - `all_mode` — whether to skip inter-stage prompts
 
 **If no mode was provided and `all_mode = false` — ask the user:**
@@ -164,6 +164,12 @@ If any stage fails (e.g. git error, diff too large and user cancels) — stop th
 | High     | Core business logic, user data, payments, security, authorization               |
 | Medium   | Supporting functionality, UI/UX, reports, integrations                          |
 | Low      | Cosmetic changes, rare scenarios, nice-to-have                                  |
+
+## Artifact Ownership and Config Policy
+
+- Primary ownership: QA artifacts under `<paths.qa>/<branch-slug>/` — specifically `change-summary.md`, `test-plan.md`, and `test-cases.md`. The `--all` flag respects the same boundary.
+- Write policy: persistent writes are limited to the three owned artifacts above; no other files are created or modified.
+- Config policy: config-aware, read-only. Reads `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, and `git.base_branch`; never writes `config.yaml`.
 
 ## Critical Rules
 

--- a/skills/aif-qa/SKILL.md
+++ b/skills/aif-qa/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: aif-qa
+description: QA workflow for testing a feature or task implementation. Analyzes changes, produces test plans, and describes concrete test scenarios. Use when user says "test this", "write test plan", "what should I test", or "QA this branch".
+argument-hint: "[--all] [change-summary | test-plan | test-cases] [<branch>]"
+allowed-tools: Bash(git *) Read Write Grep Glob AskUserQuestion Task
+disable-model-invocation: false
+---
+
+# QA — Implementation Testing
+
+Generates change summaries, produces test plans, and describes test scenarios for a feature or task implementation.
+
+## Modes
+
+The skill operates in three sequential modes.
+
+| Argument         | Mode           | What you do                                                      |
+|------------------|----------------|------------------------------------------------------------------|
+| `change-summary` | Change summary | Analyze what changed, assess risks, produce a summary            |
+| `test-plan`      | Test plan      | Create a structured test plan based on the change summary        |
+| `test-cases`     | Test cases     | Describe concrete test scenarios based on the plan               |
+| `--all`          | Full pipeline  | Run all three modes in sequence without prompting between stages |
+
+---
+
+## Workflow
+
+### Step 0: Load Config
+
+**FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
+- **Paths:** `paths.description`, `paths.architecture`, `paths.qa` (default: `.ai-factory/qa`)
+- **Language:** `language.ui` for prompts
+- **Git:** `git.base_branch` for branch comparison
+
+If config.yaml doesn't exist, use defaults:
+- DESCRIPTION.md: `.ai-factory/DESCRIPTION.md`
+- ARCHITECTURE.md: `.ai-factory/ARCHITECTURE.md`
+- QA artifacts: `.ai-factory/qa/`
+- Language: `en` (English)
+- Git base branch: `main`
+
+### Step 0.1: Load Project Context
+
+**Read** the resolved description path if the file exists, to understand:
+- Tech stack (language, framework, database, ORM)
+- Project architecture and coding conventions
+- Non-functional requirements
+
+**Read** the resolved architecture path if the file exists, to understand:
+- Chosen architecture pattern
+- Folder structure conventions
+- Layer/module boundaries and dependency rules
+
+Use this context when generating summaries, test plans, and test cases.
+
+**Read `.ai-factory/skill-context/aif-qa/SKILL.md`** — MANDATORY if the file exists.
+
+This file contains project-specific rules accumulated by `/aif-evolve` from patches,
+codebase conventions, and tech-stack analysis. These rules are tailored to the current project.
+
+**How to apply skill-context rules:**
+- Treat them as **project-level overrides** for this skill's general instructions
+- When a skill-context rule conflicts with a general rule written in this SKILL.md,
+  **the skill-context rule wins**
+- When there is no conflict, apply both: general rules from SKILL.md + project rules from skill-context
+
+### Step 0.2: Parse Arguments and Resolve Branch
+
+Parse `$ARGUMENTS` fully before doing anything else:
+
+1. **Detect `--all` flag** — if present, set `all_mode = true` and remove the flag from arguments
+2. **Detect mode** — first word matching `change-summary`, `test-plan`, or `test-cases`; remove it from arguments
+3. **Detect branch** — remaining text (if any) is the target branch name
+
+**Resolve the working branch:**
+
+```
+If branch was provided in arguments → use it as the resolved branch
+Otherwise → run: git branch --show-current
+```
+
+Store both values for use in all reference files:
+- `resolved_branch` — the branch being analyzed (used to locate/save artifacts)
+- `artifact_dir` — `<resolved paths.qa>/<resolved_branch with / replaced by ->`
+- `all_mode` — whether to skip inter-stage prompts
+
+**If no mode was provided and `all_mode = false` — ask the user:**
+
+```
+AskUserQuestion: Which QA mode would you like to run?
+
+Options:
+1. Change summary (change-summary) — analyze what changed, assess risks, produce a summary
+2. Test plan (test-plan) — create a structured test plan based on the change summary
+3. Test cases (test-cases) — describe concrete test scenarios based on the plan
+4. Full pipeline (--all) — run all three modes in sequence
+```
+
+### Step 1: Execute the Selected Mode
+
+The skill runs **strictly sequentially** — each stage uses the artifact from the previous one:
+
+```
+change-summary → test-plan → test-cases
+```
+
+Read the detailed instructions for the selected mode:
+
+#### Change Summary (change-summary)
+
+Read `references/CHANGE-SUMMARY.md`
+
+#### Test Plan (test-plan)
+
+Read `references/TEST-PLAN.md`
+
+#### Test Cases (test-cases)
+
+Read `references/TEST-CASES.md`
+
+#### Full Pipeline (--all)
+
+Run all three modes in sequence. After each stage completes successfully,
+proceed to the next automatically — **do NOT show the inter-stage `AskUserQuestion`**.
+
+```
+1. Execute change-summary (references/CHANGE-SUMMARY.md) → save artifact
+2. Execute test-plan      (references/TEST-PLAN.md)      → save artifact
+3. Execute test-cases     (references/TEST-CASES.md)     → save artifact
+4. Show context cleanup prompt (Step 6 of TEST-CASES.md)
+```
+
+If any stage fails (e.g. git error, diff too large and user cancels) — stop the pipeline and report which stage failed.
+
+---
+
+## Principles
+
+### DO:
+
+- Understand the subject before writing test plans and test cases (analyze changes / test plan / merge request / task / text description)
+- Use the repository code only to the extent needed for the change analysis, test plan, and test cases
+- Write steps clearly enough that any tester can execute the test without knowledge of the codebase
+- Specify concrete test data, not abstract "enter valid data"
+- Prioritize — not everything is equally important
+- Think about adjacent systems, integrations, and dependencies
+- Include negative scenarios and edge cases — they catch most bugs
+- Ask clarifying questions when business logic is not obvious from the code
+
+### DO NOT:
+
+- Suggest automated tests or mention testing frameworks
+- Make assumptions about business logic without reading the code
+- Skip negative scenarios
+- Write test cases for everything — focus on risky areas
+- Ignore data edge cases
+
+---
+
+## Priority Reference
+
+| Priority | When to use                                                                     |
+|----------|---------------------------------------------------------------------------------|
+| High     | Core business logic, user data, payments, security, authorization               |
+| Medium   | Supporting functionality, UI/UX, reports, integrations                          |
+| Low      | Cosmetic changes, rare scenarios, nice-to-have                                  |
+
+## Critical Rules
+
+1. MUST NOT create a `test-plan` without a `change-summary` artifact
+2. MUST NOT create `test-cases` without a `test-plan` artifact
+3. MUST NOT skip stages

--- a/skills/aif-qa/references/CHANGE-SUMMARY.md
+++ b/skills/aif-qa/references/CHANGE-SUMMARY.md
@@ -116,13 +116,13 @@ Use the template from `templates/CHANGE-SUMMARY.md`.
 
 ## Step 5: Save Artifact
 
-Save the result to `<artifact_dir>/change-summary.md`.
-
 **Ensure the directory exists before saving:**
 
 ```bash
 mkdir -p <artifact_dir>
 ```
+
+Save the result to `<artifact_dir>/change-summary.md`.
 
 ## Step 6: Next Step
 
@@ -134,6 +134,6 @@ mkdir -p <artifact_dir>
 AskUserQuestion: Change summary saved. Proceed to writing the test plan?
 
 Options:
-1. Yes — run /aif-qa test-plan
+1. Yes — run /aif-qa test-plan <resolved_branch>
 2. No — stop here
 ```

--- a/skills/aif-qa/references/CHANGE-SUMMARY.md
+++ b/skills/aif-qa/references/CHANGE-SUMMARY.md
@@ -1,0 +1,139 @@
+# Reference: Change Summary (change-summary)
+
+> **When to use:** When invoked with the `change-summary` argument (or as the first stage of `--all`). Also run this mode first when the change context is unknown — before writing a test plan or test cases.
+
+---
+
+## Step 1: Gather Change Information
+
+Use the `resolved_branch` and `artifact_dir` resolved in SKILL.md Step 0.2.
+
+**Get commit list:**
+
+```bash
+git log <base_branch>..<resolved_branch> --oneline
+```
+
+> Use the `git.base_branch` value from config (default: `main`).
+> If `resolved_branch` IS the base branch, use `HEAD~1` instead.
+
+**Check commit count — if more than 20, ask before proceeding:**
+
+```
+AskUserQuestion: Found <N> commits to analyze. Processing all of them may consume significant context. How to proceed?
+
+Options:
+1. Analyze all <N> commits
+2. Analyze only the last 20
+3. Cancel
+```
+
+Based on choice:
+- "Analyze all" → continue with the full commit list
+- "Analyze only the last 20" → truncate to the 20 most recent
+- "Cancel" → **STOP**
+
+**Get changed files and diff:**
+
+```bash
+git diff <base_branch>...<resolved_branch> --name-status
+git diff <base_branch>...<resolved_branch>
+```
+
+**Check diff size — if the diff exceeds ~1000 lines, warn before proceeding:**
+
+```
+AskUserQuestion: The diff is large (<N> lines). Reading it in full will consume significant context. How to proceed?
+
+Options:
+1. Continue — read the full diff
+2. Read changed files individually instead (recommended for large diffs)
+3. Cancel
+```
+
+Based on choice:
+- "Continue" → use the full diff as-is
+- "Read files individually" → skip the raw diff; proceed to Step 2 where Explore agents will read the files
+- "Cancel" → **STOP**
+
+## Step 2: Explore Key Changed Files
+
+**Use `Task` tool with `subagent_type: Explore` to understand the changed files in parallel.**
+This keeps the main context clean and speeds up analysis on large diffs.
+
+From the `--name-status` output, identify the most important changed files (focus on business logic, skip lock files, generated files, and formatting-only changes).
+
+Launch 1–2 Explore agents simultaneously:
+
+```
+Agent 1 — Core changes:
+Task(subagent_type: Explore, model: sonnet, prompt:
+  "Read and summarize the key changed files: [list of most important files].
+   Focus on: what logic changed, what inputs/outputs changed, what side effects are possible.
+   Thoroughness: medium. Be concise.")
+
+Agent 2 — Integration points (if needed):
+Task(subagent_type: Explore, model: sonnet, prompt:
+  "Find all callers and consumers of [changed modules/functions].
+   Identify what adjacent functionality might be affected.
+   Thoroughness: quick.")
+```
+
+**Fallback:** If the Task tool is unavailable, read the key files directly using Read/Grep.
+
+After agents return, synthesize findings to understand:
+- What business logic actually changed
+- What dependent code could be affected
+- What integration points are at risk
+
+## Step 3: Risk Analysis
+
+For each changed component, assess:
+
+**Functional risks:**
+
+- Did the business logic change?
+- Were input/output data affected (formats, validation, structure)?
+- Are there dependent modules or components that might break?
+- How does the change affect user scenarios?
+
+**Technical risks:**
+
+- Changes to data schema (DB, API contracts, file formats, storage)?
+- Changes to configuration or environment variables?
+- Changes to error handling or edge case behavior?
+- Changes to integrations with external services or APIs?
+- Changes to authorization, access control, or security?
+
+**Regression risks:**
+
+- What existing functionality might have broken?
+- Which adjacent features need re-verification?
+
+## Step 4: Generate the Summary
+
+Use the template from `templates/CHANGE-SUMMARY.md`.
+
+## Step 5: Save Artifact
+
+Save the result to `<artifact_dir>/change-summary.md`.
+
+**Ensure the directory exists before saving:**
+
+```bash
+mkdir -p <artifact_dir>
+```
+
+## Step 6: Next Step
+
+**If `all_mode = true`** — do NOT show the prompt. Proceed directly to `references/TEST-PLAN.md`.
+
+**Otherwise:**
+
+```
+AskUserQuestion: Change summary saved. Proceed to writing the test plan?
+
+Options:
+1. Yes — run /aif-qa test-plan
+2. No — stop here
+```

--- a/skills/aif-qa/references/CHANGE-SUMMARY.md
+++ b/skills/aif-qa/references/CHANGE-SUMMARY.md
@@ -8,14 +8,19 @@
 
 Use the `resolved_branch` and `artifact_dir` resolved in SKILL.md Step 0.2.
 
+**Resolve the comparison base:**
+
+> Use the `git.base_branch` value from config (default: `main`).
+> If `resolved_branch` IS the base branch, set `effective_base = <resolved_branch>~1`.
+> Otherwise, set `effective_base = <base_branch>`.
+>
+> Use `effective_base` for all git commands below. This ensures the log and diff are always consistent and anchored to `resolved_branch`, not to the current checkout.
+
 **Get commit list:**
 
 ```bash
-git log <base_branch>..<resolved_branch> --oneline
+git log <effective_base>..<resolved_branch> --oneline
 ```
-
-> Use the `git.base_branch` value from config (default: `main`).
-> If `resolved_branch` IS the base branch, use `HEAD~1` instead.
 
 **Check commit count — if more than 20, ask before proceeding:**
 
@@ -36,8 +41,8 @@ Based on choice:
 **Get changed files and diff:**
 
 ```bash
-git diff <base_branch>...<resolved_branch> --name-status
-git diff <base_branch>...<resolved_branch>
+git diff <effective_base>...<resolved_branch> --name-status
+git diff <effective_base>...<resolved_branch>
 ```
 
 **Check diff size — if the diff exceeds ~1000 lines, warn before proceeding:**

--- a/skills/aif-qa/references/TEST-CASES.md
+++ b/skills/aif-qa/references/TEST-CASES.md
@@ -1,0 +1,106 @@
+# Reference: Test Cases (test-cases)
+
+> **When to use:** When invoked with the `test-cases` argument (or as the third stage of `--all`).
+
+---
+
+## Step 1: Verify Previous Stage Artifacts
+
+Use the `resolved_branch` and `artifact_dir` resolved in SKILL.md Step 0.2.
+
+Check for both files:
+
+- `<artifact_dir>/change-summary.md`
+- `<artifact_dir>/test-plan.md`
+
+**If `change-summary.md` is NOT found — STOP:**
+
+```
+AskUserQuestion: The change-summary artifact was not found. Test cases cannot be written without a change summary.
+
+Options:
+1. Run change summary first — /aif-qa change-summary
+2. Cancel
+```
+
+**If `test-plan.md` is NOT found — STOP:**
+
+```
+AskUserQuestion: The test-plan artifact was not found. Test cases cannot be written without a test plan.
+
+Options:
+1. Create test plan first — /aif-qa test-plan
+2. Cancel
+```
+
+→ Do not continue until both artifacts are present.
+
+**If both files are found** — read them and use as the basis. Proceed to Step 2.
+
+---
+
+## Step 2: Determine What to Test
+
+**Prioritize:**
+
+1. Core business logic of the changes
+2. Edge cases and non-standard inputs
+3. Negative scenarios (errors, invalid data)
+4. Regression checks on adjacent functionality
+
+## Step 3: Coverage Strategy
+
+For each changed area, write test cases grouped as follows:
+
+**Positive scenarios (Happy path):**
+
+- Standard usage with valid data
+- Main user scenarios
+- Different variants of valid inputs
+
+**Negative scenarios:**
+
+- Invalid or incorrect input data
+- Missing required fields or parameters
+- Business rule violations and constraint breaches
+- Unavailable dependencies (if applicable)
+
+**Edge cases:**
+
+- Minimum and maximum values
+- Empty strings, zero values, null/undefined
+- Very long strings or large data volumes
+- Special characters and different encodings
+- Concurrent requests (if applicable)
+
+**Regression checks:**
+
+- Adjacent functionality that might have broken
+- Integrations with other system components
+
+## Step 4: Write Test Cases
+
+Write test cases following these rules:
+
+- Use the test case and test data templates from `templates/TEST-CASES.md`
+- Fill in all `[...]` placeholders with the actual data for your test cases
+- Optional fields in the template may be omitted when not applicable
+- Negative tests are optional but recommended
+- High-priority tests are mandatory
+
+## Step 5: Save Artifact
+
+Save the result to `<artifact_dir>/test-cases.md`.
+
+## Step 6: Context Cleanup
+
+After saving, offer to free up context:
+
+```
+AskUserQuestion: Test cases saved. Free up context?
+
+Options:
+1. /clear — Full reset (recommended)
+2. /compact — Compress history
+3. Continue as-is
+```

--- a/skills/aif-qa/references/TEST-CASES.md
+++ b/skills/aif-qa/references/TEST-CASES.md
@@ -19,7 +19,7 @@ Check for both files:
 AskUserQuestion: The change-summary artifact was not found. Test cases cannot be written without a change summary.
 
 Options:
-1. Run change summary first — /aif-qa change-summary
+1. Run change summary first — /aif-qa change-summary <resolved_branch>
 2. Cancel
 ```
 
@@ -29,7 +29,7 @@ Options:
 AskUserQuestion: The test-plan artifact was not found. Test cases cannot be written without a test plan.
 
 Options:
-1. Create test plan first — /aif-qa test-plan
+1. Create test plan first — /aif-qa test-plan <resolved_branch>
 2. Cancel
 ```
 

--- a/skills/aif-qa/references/TEST-PLAN.md
+++ b/skills/aif-qa/references/TEST-PLAN.md
@@ -1,0 +1,90 @@
+# Reference: Test Plan (test-plan)
+
+> **When to use:** When invoked with the `test-plan` argument (or as the second stage of `--all`).
+
+---
+
+## Step 1: Verify Previous Stage Artifact
+
+Use the `resolved_branch` and `artifact_dir` resolved in SKILL.md Step 0.2.
+
+Check for the file `<artifact_dir>/change-summary.md`.
+
+**If the file is NOT found — STOP:**
+
+```
+AskUserQuestion: The change-summary artifact was not found. A test plan cannot be created without a change summary.
+
+Options:
+1. Run change summary first — /aif-qa change-summary
+2. Cancel
+```
+
+→ Do not continue until the artifact is created.
+
+**If the file is found** — read `<artifact_dir>/change-summary.md` and use it as the basis for the test plan. Proceed to Step 2.
+
+---
+
+## Step 2: Clarify Context
+
+Ask the user only if something is not obvious from the code and change-summary:
+
+- What feature or fix was implemented?
+- Are there existing test cases for this area?
+- What environment is available for testing?
+- Are there constraints or dependencies to account for?
+
+**Skip this step when `all_mode = true`** — proceed with what is available from the change-summary and codebase context.
+
+## Step 3: Define Test Scope
+
+Based on the change analysis, determine:
+
+**In Scope** — what we test:
+
+- Directly changed functionality
+- Adjacent components with high regression risk
+- Integration points affected by the changes
+
+**Out of Scope** — what we don't test:
+
+- Unrelated functionality
+- Components without changes and without dependencies on changed ones
+
+## Step 4: Define Test Types
+
+| Type              | Priority   | When to apply                                            |
+|-------------------|------------|----------------------------------------------------------|
+| Functional        | 🔴 High    | Always — verify core logic of the changes                |
+| Regression        | 🟡 Medium  | Adjacent functionality, potential breakage               |
+| Edge cases        | 🟡 Medium  | Non-standard inputs, boundary data                       |
+| Negative          | 🟡 Medium  | Invalid data, errors, service failures                   |
+| Security          | 🔴 High    | When authorization or user data is affected              |
+| Performance       | 🟢 Low     | When queries, algorithms, or caching were changed        |
+
+## Step 5: Build the Verification Checklist
+
+Describe checks as a checklist with priority labels (high / medium / low).
+
+## Step 6: Generate the Test Plan
+
+Use the template from `templates/TEST-PLAN.md`.
+
+## Step 7: Save Artifact
+
+Save the result to `<artifact_dir>/test-plan.md`.
+
+## Step 8: Next Step
+
+**If `all_mode = true`** — do NOT show the prompt. Proceed directly to `references/TEST-CASES.md`.
+
+**Otherwise:**
+
+```
+AskUserQuestion: Test plan saved. Proceed to writing test cases?
+
+Options:
+1. Yes — run /aif-qa test-cases
+2. No — stop here
+```

--- a/skills/aif-qa/references/TEST-PLAN.md
+++ b/skills/aif-qa/references/TEST-PLAN.md
@@ -16,7 +16,7 @@ Check for the file `<artifact_dir>/change-summary.md`.
 AskUserQuestion: The change-summary artifact was not found. A test plan cannot be created without a change summary.
 
 Options:
-1. Run change summary first — /aif-qa change-summary
+1. Run change summary first — /aif-qa change-summary <resolved_branch>
 2. Cancel
 ```
 
@@ -85,6 +85,6 @@ Save the result to `<artifact_dir>/test-plan.md`.
 AskUserQuestion: Test plan saved. Proceed to writing test cases?
 
 Options:
-1. Yes — run /aif-qa test-cases
+1. Yes — run /aif-qa test-cases <resolved_branch>
 2. No — stop here
 ```

--- a/skills/aif-qa/templates/CHANGE-SUMMARY.md
+++ b/skills/aif-qa/templates/CHANGE-SUMMARY.md
@@ -1,0 +1,49 @@
+## Change Summary
+
+**Commits:** [N]
+**Changed files:** [N]
+**Risk level:** 🟢 Low / 🟡 Medium / 🔴 High
+
+---
+
+### What Changed
+
+[Brief plain-language description — no technical details. What was implemented or fixed, and what the goal of these changes is.]
+
+---
+
+### Affected Areas
+
+| Component     | Change type                   | Description              |
+|---------------|-------------------------------|--------------------------|
+| [Component 1] | Added / Changed / Removed     | [What exactly changed]   |
+| [Component 2] | Added / Changed / Removed     | [What exactly changed]   |
+
+---
+
+### Risks
+
+🔴 **Critical** (must verify):
+
+- [Risk and why it matters]
+
+🟡 **Medium** (should verify):
+
+- [Risk and why it matters]
+
+🟢 **Low** (nice to verify):
+
+- [Risk]
+
+---
+
+### Testing Recommendations
+
+**First priority:**
+
+- [ ] [Most critical thing to check]
+- [ ] [Second most critical thing]
+
+**Regression:**
+
+- [ ] [Adjacent functionality to re-verify]

--- a/skills/aif-qa/templates/TEST-CASES.md
+++ b/skills/aif-qa/templates/TEST-CASES.md
@@ -1,0 +1,42 @@
+## Test Cases: [Test Area]
+
+---
+
+### TC-001: [Test Case Name]
+
+**Priority:** [High / Medium / Low]
+**Type:** [Positive / Negative]
+
+**Precondition:** (optional field)
+
+[What must be in place before the test: required data, authentication, system state]
+
+**Steps:**
+
+1. [Concrete action]
+2. [Concrete action]
+3. [Concrete action]
+
+**Expected result:**
+
+[What exactly should happen — specific, no abstractions]
+
+**Test data:**
+
+```
+[Concrete data to use in the test]
+```
+
+## Test Data (based on test design techniques)
+
+### Positive
+
+* [Test data item]
+* [Test data item]
+* [Test data item]
+
+### Negative (optional field)
+
+* [Test data item]
+* [Test data item]
+* [Test data item]

--- a/skills/aif-qa/templates/TEST-PLAN.md
+++ b/skills/aif-qa/templates/TEST-PLAN.md
@@ -1,0 +1,81 @@
+## Test Plan: [Task / MR / Feature Name]
+
+**Date:** [YYYY-MM-DD]
+**Branch / Version:** [branch-name / v1.2.3]
+**Environment:** [staging / development / local]
+
+---
+
+### 1. Testing Goal
+
+[What we are verifying and why. Brief: what functionality changed and whether it works correctly.]
+
+---
+
+### 2. Test Scope
+
+**In Scope** — we test:
+
+- [Component / feature 1]
+- [Component / feature 2]
+
+**Out of Scope** — we don't test:
+
+- [What is excluded and why]
+
+---
+
+### 3. Test Types
+
+| Type              | Priority   | Area                                   |
+|-------------------|------------|----------------------------------------|
+| Functional        | 🔴 High    | [Core changed functions]               |
+| Regression        | 🟡 Medium  | [Adjacent functionality]               |
+| Edge cases        | 🟡 Medium  | [Input edge cases]                     |
+| Negative          | 🟡 Medium  | [Error scenarios]                      |
+| Security          | 🔴 High    | [Only if authorization is affected]    |
+
+---
+
+### 4. Test Data
+
+| Category          | Data      | Purpose             |
+|-------------------|-----------|---------------------|
+| Valid data        | [example] | Happy path          |
+| Boundary values   | [example] | Edge cases          |
+| Invalid data      | [example] | Negative scenarios  |
+| Special cases     | [example] | [Project-specific]  |
+
+---
+
+### 5. Preconditions
+
+- [ ] Environment is deployed and accessible
+- [ ] Test data is prepared
+- [ ] Required roles / accounts are created
+- [ ] [Additional condition]
+
+---
+
+### 6. Acceptance Criteria
+
+- [ ] All 🔴 high-priority test cases pass
+- [ ] Critical regression scenarios pass
+- [ ] Negative scenarios return expected errors
+- [ ] [Project-specific criterion]
+
+---
+
+### 7. Plan Risks
+
+| Risk     | Impact               | Mitigation     |
+|----------|----------------------|----------------|
+| [Risk 1] | High / Medium / Low  | [How to reduce]|
+| [Risk 2] | High / Medium / Low  | [How to reduce]|
+
+### 8. Checklist
+
+| Check     | Priority              |
+|-----------|-----------------------|
+| [Check 1] | High / Medium / Low   |
+| [Check 2] | High / Medium / Low   |

--- a/skills/aif/references/config-template.yaml
+++ b/skills/aif/references/config-template.yaml
@@ -105,6 +105,12 @@ paths:
   # Default: .ai-factory/rules/
   rules: .ai-factory/rules/
 
+  # QA artifacts root directory
+  # /aif-qa stores change-summary, test-plan, and test-cases here,
+  # using the branch slug as a subdirectory: <qa>/<branch>/
+  # Default: .ai-factory/qa/
+  qa: .ai-factory/qa/
+
 # =============================================================================
 # Workflow Settings
 # =============================================================================

--- a/skills/aif/references/config-template.yaml
+++ b/skills/aif/references/config-template.yaml
@@ -107,7 +107,9 @@ paths:
 
   # QA artifacts root directory
   # /aif-qa stores change-summary, test-plan, and test-cases here,
-  # using the branch slug as a subdirectory: <qa>/<branch>/
+  # using a derived branch slug as a subdirectory: <qa>/<branch-slug>/
+  # The slug is an injective encoding of the branch name (see
+  # skills/aif-qa/SKILL.md for the exact algorithm).
   # Default: .ai-factory/qa/
   qa: .ai-factory/qa/
 

--- a/src/cli/wizard/skill-hints.ts
+++ b/src/cli/wizard/skill-hints.ts
@@ -15,6 +15,7 @@ const SKILL_HINTS: Record<string, string> = {
     'aif-improve': 'Improve existing plan quality',
     'aif-loop': 'Iterative quality refinement loop',
     'aif-plan': 'Plan tasks for feature',
+    'aif-qa': 'QA change-summary, test-plan, test-cases',
     'aif-reference': 'Create knowledge refs from URLs/docs',
     'aif-review': 'Review staged changes/PR',
     'aif-roadmap': 'Roadmap and milestones',


### PR DESCRIPTION
Adds a new built-in skill `/aif-qa` for manual QA of feature branches. The skill runs in three sequential stages, each building on the previous artifact.

## Skill

Three modes invoked as `/aif-qa <mode> [<branch>]`:
- `change-summary` — analyses git diff between the target branch and the configured base branch.
- `test-plan` — reads the change summary, defines test scope and types, produces a structured test plan with acceptance criteria.
- `test-cases` — reads both previous artifacts, writes concrete TC-NNN test scenarios grouped by positive / negative / edge cases.

`--all` flag — runs all three stages in sequence without inter-stage prompts. Stops and reports if any stage fails.
`<branch>` argument — analyzed branch can be passed explicitly to any mode; all stages resolve from the same `resolved_branch` without re-detecting it via git.

Artifacts are saved to `paths.qa/<branch>/` (one subdirectory per branch slug).                                                                                                                                                                                                                                    

## Config

New config key `paths.qa` (default: `.ai-factory/qa/`) — relocates the QA artifact root. Registered in:
- `skills/aif/references/config-template.yaml`
- `docs/config-reference.md` (paths table + skill matrix)
- `docs/configuration.md` (inline yaml example, path semantics, project structure tree)