### PR TITLE
Add extension-managed agent files for Codex and dynamic runtimes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,9 +11,9 @@
     {
       "id": "claude",
       "skillsDir": ".claude/skills",
-      "subagentsDir": ".claude/agents",
+      "agentsDir": ".claude/agents",
       "installedSkills": ["aif", "aif-plan", "aif-improve", "aif-implement", "aif-commit", "aif-build-automation"],
-      "installedSubagents": [
+      "installedAgentFiles": [
         "best-practices-sidecar.md",
         "commit-preparer.md",
         "docs-auditor.md",
@@ -44,6 +44,7 @@
     {
       "id": "codex",
       "skillsDir": ".codex/skills",
+      "agentsDir": ".codex/agents",
       "installedSkills": ["aif", "aif-plan", "aif-implement"],
       "mcp": {
         "github": false,
@@ -64,7 +65,7 @@
 }
 ```
 
-The `agents` array can include any supported agent IDs: `claude`, `cursor`, `windsurf`, `roocode`, `kilocode`, `antigravity`, `opencode`, `warp`, `zencoder`, `codex`, `copilot`, `gemini`, `junie`, or `universal`. Each agent keeps its own `skillsDir`, installed skills list, and MCP preferences. Claude Code agents also persist `subagentsDir` and `installedSubagents`, so `ai-factory update` can refresh `.claude/agents/` alongside skills. AI Factory additionally stores internal `managedSkills` and `managedSubagents` hash maps in `.ai-factory.json`; they are omitted from the example above for brevity.
+The `agents` array can include any built-in agent IDs plus runtime IDs provided by installed extensions. Each agent keeps its own `skillsDir`, installed skills list, and MCP preferences. Runtimes that support custom agent files also persist `agentsDir` and `installedAgentFiles`, so `ai-factory update` can refresh package-managed agent files alongside skills. AI Factory additionally stores internal `managedSkills` and `managedAgentFiles` hash maps in `.ai-factory.json`; they are omitted from the example above for brevity. `loadConfig()` still reads legacy Claude-only `subagentsDir`, `installedSubagents`, and `managedSubagents` keys for backward compatibility, but new saves use the universal field names.
 
 The optional `extensions` array tracks installed extensions by name, original source, and version. `ai-factory update` now refreshes these extensions from their saved sources before base-skill updates, and `ai-factory extension update [name] --force` refreshes them without running the full base-skill update flow.
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -2,7 +2,7 @@
 
 # Extensions
 
-Extensions let third-party developers add new capabilities to AI Factory — custom CLI commands, MCP servers, skill injections, agent definitions, and more. Extensions survive `ai-factory update` (injections are automatically re-applied after skills are refreshed).
+Extensions let third-party developers add new capabilities to AI Factory — custom CLI commands, MCP servers, skill injections, runtime definitions, runtime-specific agent files, and more. Extensions survive `ai-factory update` (injections and managed agent files are automatically re-applied after skills are refreshed).
 
 ## For Users
 
@@ -43,9 +43,11 @@ ai-factory extension remove aif-ext-example
 1. Extension files are copied to `.ai-factory/extensions/<name>/`
 2. Extension is recorded in `.ai-factory.json` under `extensions`
 3. Extension skills (from `skills`) are installed into configured agents
-4. Injections are applied to matching skill files (e.g. appending extra instructions to `/aif-implement`)
-5. MCP servers are merged into each agent's settings file (e.g. `.mcp.json`)
-6. Custom CLI commands become available immediately
+4. Runtime definitions from `agents` are added to the effective registry for future `ai-factory init` runs
+5. Agent files from `agentFiles` are copied into matching runtime `agentsDir` locations
+6. Injections are applied to matching skill files (e.g. appending extra instructions to `/aif-implement`)
+7. MCP servers are merged into each agent's settings file (e.g. `.mcp.json`)
+8. Custom CLI commands become available immediately
 
 ### What Happens on Update
 
@@ -175,9 +177,23 @@ my-extension/
       "displayName": "My Agent",
       "configDir": ".my-agent",
       "skillsDir": ".my-agent/skills",
+      "agentsDir": ".my-agent/agents",
+      "agentFileExtension": ".toml",
       "settingsFile": null,
       "supportsMcp": false,
       "skillsCliAgent": null
+    }
+  ],
+  "agentFiles": [
+    {
+      "runtime": "claude",
+      "source": "agent-files/claude/review-helper.md",
+      "target": "review-helper.md"
+    },
+    {
+      "runtime": "my-agent",
+      "source": "agent-files/my-agent/coordinator.toml",
+      "target": "coordinator.toml"
     }
   ],
   "injections": [
@@ -214,7 +230,8 @@ Only `name` and `version` are required. All other fields are optional.
 | `version` | `string` | **Required.** Version string (SemVer is recommended). |
 | `description` | `string` | Human-readable description. |
 | `commands` | `array` | CLI commands to register. |
-| `agents` | `array` | Agent definitions (id, directories, MCP support). |
+| `agents` | `array` | Runtime definitions that become available to `ai-factory init`, `--agents`, and core runtime lookups once the extension is installed. |
+| `agentFiles` | `array` | Runtime-aware agent assets copied into `agentsDir` for built-in or extension-defined runtimes. |
 | `injections` | `array` | Content to inject into existing skill files. |
 | `skills` | `array` | Paths to skill directories within the extension. |
 | `replaces` | `object` | Maps extension skill paths to base skill names they replace (e.g. `{"skills/my-commit": "aif-commit"}`). |
@@ -338,7 +355,7 @@ The template is merged into the agent's settings file under `mcpServers.<key>` (
 
 ### Agents
 
-Extensions can declare new agent configurations. These are currently stored in the manifest and shown during installation. Agent integration with the interactive wizard (`ai-factory init`) is planned for a future release.
+Extensions can declare new runtime configurations. Once the extension is installed, these runtime ids are loaded into the effective registry before `ai-factory init`, `--agents` validation, MCP routing, injections, and installer lookups.
 
 ```json
 {
@@ -361,6 +378,32 @@ Extensions can declare new agent configurations. These are currently stored in t
 | `settingsFile` | Path to the agent's MCP settings file, or `null`. |
 | `supportsMcp` | Whether this agent supports MCP server configuration. |
 | `skillsCliAgent` | Value for `--agent` flag in skills CLI, or `null`. |
+
+When a runtime supports custom agent files, set both:
+
+| Field | Description |
+|-------|-------------|
+| `agentsDir` | Runtime-local directory for custom agents (for example `.codex/agents`). |
+| `agentFileExtension` | Required file extension for agent assets (`.md` or `.toml`). |
+
+### Agent Files
+
+Use `agentFiles` to provide runtime-specific custom agent assets without conflating them with runtime definitions:
+
+```json
+{
+  "agentFiles": [
+    { "runtime": "claude", "source": "agent-files/claude/review-helper.md", "target": "review-helper.md" },
+    { "runtime": "codex", "source": "agent-files/codex/committee.toml", "target": "committee.toml" }
+  ]
+}
+```
+
+Rules:
+- `runtime` must exist in the effective registry (built-in or provided by an installed extension, including the current manifest).
+- `source` and `target` must be safe relative paths.
+- Source and target extensions must match the runtime's `agentFileExtension`.
+- Ownership is exclusive per `runtime + target`; conflicts with bundled Claude files or another extension are rejected before install.
 
 ---
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -404,6 +404,7 @@ Rules:
 - `source` and `target` must be safe relative paths.
 - Source and target extensions must match the runtime's `agentFileExtension`.
 - Ownership is exclusive per `runtime + target`; conflicts with bundled Claude files or another extension are rejected before install.
+- Bundled Claude filenames are reserved by target path from the package `subagents/` inventory; an extension cannot claim the same `claude` target filename even if the local managed copy was later edited or removed.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,7 @@ AI Factory works with any AI coding agent. During `ai-factory init`, you choose 
 | Qwen Code | `.qwen/` | `.qwen/skills/` |
 | Universal / Other | `.agents/` | `.agents/skills/` |
 
-When Claude Code is selected, AI Factory also installs bundled Claude subagents into `.claude/agents/` and tracks them in `.ai-factory.json`. This is Claude-only and is documented in [Subagents](subagents.md).
+When Claude Code is selected, AI Factory installs bundled Claude agent files into `.claude/agents/` and tracks them in `.ai-factory.json` with the universal `agentsDir`, `installedAgentFiles`, and `managedAgentFiles` fields. Extensions can also provide agent files for Codex or extension-defined runtimes. Claude-specific bundled roles are documented in [Subagents](subagents.md).
 
 MCP server configuration is supported for Claude Code, Cursor, GitHub Copilot, Roo Code, Kilo Code, OpenCode, and Qwen Code. Other agents get skills installed with correct paths but without MCP auto-configuration.
 
@@ -103,7 +103,7 @@ For v1 -> v2 migration, run `ai-factory upgrade` to rename old skills to the new
 `ai-factory update` now:
 - Checks for extension updates from their sources (npm, GitHub, etc.) before updating base skills
 - Prints per-agent status buckets for base skills (`changed`, `unchanged`, `skipped`, `removed`)
-- For Claude Code, also refreshes managed `.claude/agents/` subagents and prints a separate `Subagents` status block
+- For runtimes with managed agent files, also refreshes bundled package-managed agent files (Claude today) and prints a separate `Agent files` status block
 - Skills newly available in the package but not previously installed are shown as `skipped` (not auto-installed)
 
 ## Next Steps

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -2,13 +2,13 @@
 
 # Subagents
 
-> **Claude Code only.** AI Factory ships bundled Claude subagents from the package `subagents/` directory and installs them into `.claude/agents/` during `ai-factory init` whenever Claude Code is selected. `ai-factory update` refreshes those managed files and preserves this behavior as Claude-only rather than pretending it is portable across other agents.
+> **Bundled package assets are Claude-only.** AI Factory ships bundled Claude subagents from the package `subagents/` directory and installs them into `.claude/agents/` during `ai-factory init` whenever Claude Code is selected. `ai-factory update` refreshes those managed files. Extensions may also provide agent files for Codex or extension-defined runtimes, but those are configured through the extension manifest rather than this bundled package inventory.
 
 ## Migration Note
 
-If you have an existing AI Factory project that was initialized before subagent support was added, running `ai-factory update` will automatically install all bundled subagents into `.claude/agents/`. This is intentional migration behavior — `loadConfig()` infers `subagentsDir` from the agent type when it is missing from older configs. No opt-in is required; the subagents are part of the standard AI Factory package for Claude Code.
+If you have an existing AI Factory project that was initialized before subagent support was added, running `ai-factory update` will automatically install all bundled subagents into `.claude/agents/`. This is intentional migration behavior — `loadConfig()` reads legacy Claude-only `subagentsDir`, `installedSubagents`, and `managedSubagents`, but persists the universal `agentsDir`, `installedAgentFiles`, and `managedAgentFiles` fields on the next save. No opt-in is required; the bundled subagents remain part of the standard AI Factory package for Claude Code.
 
-If you already have custom agents in `.claude/agents/`, they will not be touched — AI Factory only manages files listed in `installedSubagents` / `managedSubagents` in `.ai-factory.json`.
+If you already have custom agents in `.claude/agents/`, they will not be touched — AI Factory only manages files listed in `installedAgentFiles` / `managedAgentFiles` in `.ai-factory.json`.
 
 ## Why This Exists
 

--- a/examples/extensions/aif-ext-hello/agent-files/claude/hello-reviewer.md
+++ b/examples/extensions/aif-ext-hello/agent-files/claude/hello-reviewer.md
@@ -1,0 +1,16 @@
+---
+name: hello-reviewer
+description: Review the hello extension manifest and agent assets for consistency.
+tools: Read, Glob, Grep
+model: inherit
+permissionMode: default
+---
+
+You verify that the example extension stays internally consistent.
+
+Focus on:
+- matching `runtime`, `source`, and `target` entries in `extension.json`
+- keeping Claude `.md` agent assets separate from Codex `.toml` assets
+- checking that custom runtime examples still declare their own `agentsDir`
+
+Do not edit files unless the parent agent explicitly asks.

--- a/examples/extensions/aif-ext-hello/agent-files/codex/hello_reviewer.toml
+++ b/examples/extensions/aif-ext-hello/agent-files/codex/hello_reviewer.toml
@@ -1,0 +1,10 @@
+name = "hello_reviewer"
+description = "Review the hello extension example for manifest, runtime, and agent-file consistency."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Inspect the example extension and confirm that runtime ids, file extensions, and target paths line up.
+Focus on `extension.json`, the example agent files, and the runtime-specific directory layout.
+Do not edit files unless the parent agent explicitly asks.
+"""

--- a/examples/extensions/aif-ext-hello/agent-files/test-agent/hello_helper.toml
+++ b/examples/extensions/aif-ext-hello/agent-files/test-agent/hello_helper.toml
@@ -1,0 +1,10 @@
+name = "hello_helper"
+description = "Example custom runtime worker that explains how the hello extension wires its assets together."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Explain how the example extension installs skills, injections, MCP config, and runtime-aware agent files.
+Keep answers grounded in the extension manifest and local files.
+Do not edit files unless the parent agent explicitly asks.
+"""

--- a/examples/extensions/aif-ext-hello/extension.json
+++ b/examples/extensions/aif-ext-hello/extension.json
@@ -1,7 +1,7 @@
 {
   "name": "aif-ext-hello",
   "version": "1.0.0",
-  "description": "Test extension: hello world command, implement injection, custom skill, skill replacement, custom agent, MCP server",
+  "description": "Example extension: command, injection, custom skills, skill replacement, MCP server, custom runtime, and runtime-aware agent files",
   "commands": [
     {
       "name": "hello",
@@ -15,9 +15,28 @@
       "displayName": "Test Agent",
       "configDir": ".test-agent",
       "skillsDir": ".test-agent/skills",
+      "agentsDir": ".test-agent/agents",
+      "agentFileExtension": ".toml",
       "settingsFile": null,
       "supportsMcp": false,
       "skillsCliAgent": null
+    }
+  ],
+  "agentFiles": [
+    {
+      "runtime": "claude",
+      "source": "agent-files/claude/hello-reviewer.md",
+      "target": "hello-reviewer.md"
+    },
+    {
+      "runtime": "codex",
+      "source": "agent-files/codex/hello_reviewer.toml",
+      "target": "hello_reviewer.toml"
+    },
+    {
+      "runtime": "test-agent",
+      "source": "agent-files/test-agent/hello_helper.toml",
+      "target": "hello_helper.toml"
     }
   ],
   "injections": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-factory",
-  "version": "2.7.0",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-factory",
-      "version": "2.7.0",
+      "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/scripts/test-init.sh
+++ b/scripts/test-init.sh
@@ -251,3 +251,41 @@ assert_not_exists "$EXT_PROJECT_DIR/.claude/agents/test-sidecar.md" "extension c
 assert_not_exists "$EXT_PROJECT_DIR/.codex/agents/test-helper.toml" "extension codex agent file must be removed"
 
 echo "extension agent file init smoke tests passed"
+
+# -------------------------------------------------------------------
+# Ownership conflict smoke: extension add must reject agentFiles that
+# collide with bundled Claude agent file targets.
+# -------------------------------------------------------------------
+
+CONFLICT_EXTENSION_DIR="$TMPDIR/runtime-agent-files-conflict"
+mkdir -p "$CONFLICT_EXTENSION_DIR/agent-files/claude"
+
+cat > "$CONFLICT_EXTENSION_DIR/extension.json" << 'EOF'
+{
+  "name": "aif-ext-runtime-agent-files-conflict",
+  "version": "1.0.0",
+  "agentFiles": [
+    {
+      "runtime": "claude",
+      "source": "agent-files/claude/plan-polisher.md",
+      "target": "plan-polisher.md"
+    }
+  ]
+}
+EOF
+
+cat > "$CONFLICT_EXTENSION_DIR/agent-files/claude/plan-polisher.md" << 'EOF'
+---
+name: conflicting-plan-polisher
+description: conflicting claude agent file
+---
+EOF
+
+if (cd "$EXT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" extension add "$CONFLICT_EXTENSION_DIR" > "$TMPDIR/init-ext-conflict.log" 2>&1); then
+  echo "Assertion failed: extension add must reject bundled Claude target collisions"
+  cat "$TMPDIR/init-ext-conflict.log"
+  exit 1
+fi
+assert_contains "$TMPDIR/init-ext-conflict.log" "already owned by AI Factory bundled Claude agent files" "bundled Claude target collision must be rejected with a clear message"
+
+echo "extension agent file conflict smoke tests passed"

--- a/scripts/test-init.sh
+++ b/scripts/test-init.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Smoke tests: validates ai-factory init for Claude Code subagent installation
+# Smoke tests: validates ai-factory init for bundled and extension-provided agent files
 
 set -euo pipefail
 
@@ -39,6 +39,16 @@ assert_exists() {
   fi
 }
 
+assert_not_exists() {
+  local path="$1"
+  local hint="$2"
+  if [[ -e "$path" ]]; then
+    echo "Assertion failed: $hint"
+    echo "Unexpected path: $path"
+    exit 1
+  fi
+}
+
 INIT_OUTPUT="$TMPDIR/init-claude.log"
 EXPECTED_SUBAGENTS=$(find "$ROOT_DIR/subagents" -type f | wc -l | tr -d ' ')
 
@@ -74,8 +84,8 @@ try {
 EOF
 
 assert_contains "$INIT_OUTPUT" "Claude Code:" "Claude Code summary must be printed"
-assert_contains "$INIT_OUTPUT" "Subagents directory:" "Claude init summary must include subagents directory"
-assert_contains "$INIT_OUTPUT" "Installed subagents: ${EXPECTED_SUBAGENTS}" "Claude init summary must report installed subagents"
+assert_contains "$INIT_OUTPUT" "Agent files directory:" "Claude init summary must include agent files directory"
+assert_contains "$INIT_OUTPUT" "Installed agent files: ${EXPECTED_SUBAGENTS}" "Claude init summary must report installed agent files"
 assert_exists "$PROJECT_DIR/.claude/agents/best-practices-sidecar.md" "Claude init must install best-practices sidecar"
 assert_exists "$PROJECT_DIR/.claude/agents/commit-preparer.md" "Claude init must install commit preparer"
 assert_exists "$PROJECT_DIR/.claude/agents/docs-auditor.md" "Claude init must install docs auditor"
@@ -87,12 +97,157 @@ assert_exists "$PROJECT_DIR/.claude/agents/security-sidecar.md" "Claude init mus
 
 ACTUAL_SUBAGENTS=$(find "$PROJECT_DIR/.claude/agents" -type f | wc -l | tr -d ' ')
 if [[ "$ACTUAL_SUBAGENTS" != "$EXPECTED_SUBAGENTS" ]]; then
-  echo "Assertion failed: Claude init must install all bundled subagents"
-  echo "Expected subagents: $EXPECTED_SUBAGENTS"
-  echo "Actual subagents: $ACTUAL_SUBAGENTS"
+  echo "Assertion failed: Claude init must install all bundled agent files"
+  echo "Expected agent files: $EXPECTED_SUBAGENTS"
+  echo "Actual agent files: $ACTUAL_SUBAGENTS"
   exit 1
 fi
 
-EXPECTED_SUBAGENTS="$EXPECTED_SUBAGENTS" node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];const expected=Number(process.env.EXPECTED_SUBAGENTS);if(a.id!=='claude')process.exit(1);if(a.subagentsDir!=='.claude/agents')process.exit(1);if(!Array.isArray(a.installedSubagents)||a.installedSubagents.length!==expected)process.exit(1);if(!a.installedSubagents.includes('best-practices-sidecar.md'))process.exit(1);if(!a.installedSubagents.includes('commit-preparer.md'))process.exit(1);if(!a.installedSubagents.includes('docs-auditor.md'))process.exit(1);if(!a.installedSubagents.includes('implement-worker.md'))process.exit(1);if(!a.installedSubagents.includes('loop-orchestrator.md'))process.exit(1);if(!a.installedSubagents.includes('plan-polisher.md'))process.exit(1);if(!a.installedSubagents.includes('review-sidecar.md'))process.exit(1);if(!a.installedSubagents.includes('security-sidecar.md'))process.exit(1);if(!a.managedSubagents||Object.keys(a.managedSubagents).length!==expected)process.exit(1);" "$PROJECT_DIR/.ai-factory.json"
+EXPECTED_SUBAGENTS="$EXPECTED_SUBAGENTS" node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];const expected=Number(process.env.EXPECTED_SUBAGENTS);if(a.id!=='claude')process.exit(1);if(a.agentsDir!=='.claude/agents')process.exit(1);if(!Array.isArray(a.installedAgentFiles)||a.installedAgentFiles.length!==expected)process.exit(1);if(!a.installedAgentFiles.includes('best-practices-sidecar.md'))process.exit(1);if(!a.installedAgentFiles.includes('commit-preparer.md'))process.exit(1);if(!a.installedAgentFiles.includes('docs-auditor.md'))process.exit(1);if(!a.installedAgentFiles.includes('implement-worker.md'))process.exit(1);if(!a.installedAgentFiles.includes('loop-orchestrator.md'))process.exit(1);if(!a.installedAgentFiles.includes('plan-polisher.md'))process.exit(1);if(!a.installedAgentFiles.includes('review-sidecar.md'))process.exit(1);if(!a.installedAgentFiles.includes('security-sidecar.md'))process.exit(1);if(!a.managedAgentFiles||Object.keys(a.managedAgentFiles).length!==expected)process.exit(1);" "$PROJECT_DIR/.ai-factory.json"
 
 echo "claude init smoke tests passed"
+
+# -------------------------------------------------------------------
+# Extension agent files + dynamic runtime smoke: init should accept
+# extension-defined runtimes in --agents, install agentFiles for
+# built-in and dynamic runtimes, refresh them on extension update,
+# and block remove while the dynamic runtime is still configured.
+# -------------------------------------------------------------------
+
+EXTENSION_DIR="$TMPDIR/runtime-agent-files-extension"
+mkdir -p "$EXTENSION_DIR/agent-files/claude" "$EXTENSION_DIR/agent-files/codex" "$EXTENSION_DIR/agent-files/test-runtime"
+
+cat > "$EXTENSION_DIR/extension.json" << 'EOF'
+{
+  "name": "aif-ext-runtime-agent-files",
+  "version": "1.0.0",
+  "agents": [
+    {
+      "id": "test-runtime",
+      "displayName": "Test Runtime",
+      "configDir": ".test-runtime",
+      "skillsDir": ".test-runtime/skills",
+      "agentsDir": ".test-runtime/agents",
+      "agentFileExtension": ".toml",
+      "settingsFile": null,
+      "supportsMcp": false,
+      "skillsCliAgent": null
+    }
+  ],
+  "agentFiles": [
+    {
+      "runtime": "claude",
+      "source": "agent-files/claude/test-sidecar.md",
+      "target": "test-sidecar.md"
+    },
+    {
+      "runtime": "codex",
+      "source": "agent-files/codex/test-helper.toml",
+      "target": "test-helper.toml"
+    },
+    {
+      "runtime": "test-runtime",
+      "source": "agent-files/test-runtime/test-agent.toml",
+      "target": "test-agent.toml"
+    }
+  ]
+}
+EOF
+
+cat > "$EXTENSION_DIR/agent-files/claude/test-sidecar.md" << 'EOF'
+---
+name: test-sidecar
+description: test extension claude agent file
+---
+EOF
+
+cat > "$EXTENSION_DIR/agent-files/codex/test-helper.toml" << 'EOF'
+name = "test-helper"
+description = "test extension codex agent file"
+EOF
+
+cat > "$EXTENSION_DIR/agent-files/test-runtime/test-agent.toml" << 'EOF'
+name = "test-agent"
+description = "test extension dynamic runtime agent file"
+EOF
+
+EXT_PROJECT_DIR="$TMPDIR/init-smoke-extension-runtime"
+mkdir -p "$EXT_PROJECT_DIR"
+
+(cd "$EXT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agents claude --skills aif > "$TMPDIR/init-ext-base.log" 2>&1)
+(cd "$EXT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" extension add "$EXTENSION_DIR" > "$TMPDIR/init-ext-add.log" 2>&1)
+(cd "$EXT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agents claude,codex,test-runtime --skills aif > "$TMPDIR/init-ext-reinit.log" 2>&1)
+
+assert_exists "$EXT_PROJECT_DIR/.claude/agents/test-sidecar.md" "extension claude agent file must be installed on init"
+assert_exists "$EXT_PROJECT_DIR/.codex/agents/test-helper.toml" "extension codex agent file must be installed on init"
+assert_exists "$EXT_PROJECT_DIR/.test-runtime/agents/test-agent.toml" "dynamic runtime agent file must be installed on init"
+
+node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const ids=c.agents.map(a=>a.id).sort().join(',');if(ids!=='claude,codex,test-runtime')process.exit(1);const dyn=c.agents.find(a=>a.id==='test-runtime');if(!dyn||dyn.agentsDir!=='.test-runtime/agents')process.exit(1);" "$EXT_PROJECT_DIR/.ai-factory.json"
+
+# Update extension-managed agent files from local source.
+cat > "$EXTENSION_DIR/extension.json" << 'EOF'
+{
+  "name": "aif-ext-runtime-agent-files",
+  "version": "1.0.1",
+  "agents": [
+    {
+      "id": "test-runtime",
+      "displayName": "Test Runtime",
+      "configDir": ".test-runtime",
+      "skillsDir": ".test-runtime/skills",
+      "agentsDir": ".test-runtime/agents",
+      "agentFileExtension": ".toml",
+      "settingsFile": null,
+      "supportsMcp": false,
+      "skillsCliAgent": null
+    }
+  ],
+  "agentFiles": [
+    {
+      "runtime": "claude",
+      "source": "agent-files/claude/test-sidecar.md",
+      "target": "test-sidecar.md"
+    },
+    {
+      "runtime": "codex",
+      "source": "agent-files/codex/test-helper.toml",
+      "target": "test-helper.toml"
+    },
+    {
+      "runtime": "test-runtime",
+      "source": "agent-files/test-runtime/test-agent.toml",
+      "target": "test-agent.toml"
+    }
+  ]
+}
+EOF
+
+cat > "$EXTENSION_DIR/agent-files/codex/test-helper.toml" << 'EOF'
+name = "test-helper"
+description = "updated codex agent file"
+EOF
+
+cat > "$EXTENSION_DIR/agent-files/test-runtime/test-agent.toml" << 'EOF'
+name = "test-agent"
+description = "updated dynamic runtime agent file"
+EOF
+
+(cd "$EXT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" extension update --force > "$TMPDIR/init-ext-update.log" 2>&1)
+assert_contains "$EXT_PROJECT_DIR/.codex/agents/test-helper.toml" "updated codex agent file" "extension update must refresh codex agent file"
+assert_contains "$EXT_PROJECT_DIR/.test-runtime/agents/test-agent.toml" "updated dynamic runtime agent file" "extension update must refresh dynamic runtime agent file"
+
+# Remove should be blocked while dynamic runtime is still configured.
+if (cd "$EXT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" extension remove aif-ext-runtime-agent-files > "$TMPDIR/init-ext-remove-blocked.log" 2>&1); then
+  echo "Assertion failed: extension remove must be blocked while dynamic runtime is configured"
+  cat "$TMPDIR/init-ext-remove-blocked.log"
+  exit 1
+fi
+assert_contains "$TMPDIR/init-ext-remove-blocked.log" "orphan configured runtime" "remove must explain orphan runtime block"
+
+# After deselecting the dynamic runtime, removal should succeed and clean agent files.
+(cd "$EXT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agents claude,codex --skills aif > "$TMPDIR/init-ext-deselect.log" 2>&1)
+(cd "$EXT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" extension remove aif-ext-runtime-agent-files > "$TMPDIR/init-ext-remove.log" 2>&1)
+assert_not_exists "$EXT_PROJECT_DIR/.claude/agents/test-sidecar.md" "extension claude agent file must be removed"
+assert_not_exists "$EXT_PROJECT_DIR/.codex/agents/test-helper.toml" "extension codex agent file must be removed"
+
+echo "extension agent file init smoke tests passed"

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -226,8 +226,8 @@ assert_not_exists "$KILO_PROJECT_DIR/.kilocode/skills/aif-commit" "workflow skil
 echo "kilocode workflow smoke tests passed"
 
 # -------------------------------------------------------------------
-# Claude subagents smoke: update should install bundled subagents,
-# persist subagent state in config, and heal local drift.
+# Claude agent files smoke: update should install bundled Claude files,
+# persist universal agent file state in config, and heal local drift.
 # -------------------------------------------------------------------
 
 CLAUDE_PROJECT_DIR="$TMPDIR/update-smoke-claude"
@@ -257,28 +257,28 @@ EOF
 CLAUDE_FIRST_OUTPUT="$TMPDIR/update-claude-first.log"
 CLAUDE_SECOND_OUTPUT="$TMPDIR/update-claude-second.log"
 
-# First update should add bundled Claude subagents and persist state.
+# First update should add bundled Claude agent files and persist state.
 (cd "$CLAUDE_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update > "$CLAUDE_FIRST_OUTPUT" 2>&1)
-assert_contains "$CLAUDE_FIRST_OUTPUT" "\[claude\] Subagents:" "claude subagents section must be printed"
-assert_contains "$CLAUDE_FIRST_OUTPUT" "loop-orchestrator\\.md \(new in package\)" "new bundled subagent must be installed"
+assert_contains "$CLAUDE_FIRST_OUTPUT" "\[claude\] Agent files:" "claude agent files section must be printed"
+assert_contains "$CLAUDE_FIRST_OUTPUT" "loop-orchestrator\\.md \(new in package\)" "new bundled agent file must be installed"
 assert_exists "$CLAUDE_PROJECT_DIR/.claude/agents/best-practices-sidecar.md" "best-practices sidecar must be installed"
 assert_exists "$CLAUDE_PROJECT_DIR/.claude/agents/commit-preparer.md" "commit preparer must be installed"
 assert_exists "$CLAUDE_PROJECT_DIR/.claude/agents/docs-auditor.md" "docs auditor must be installed"
 assert_exists "$CLAUDE_PROJECT_DIR/.claude/agents/implement-worker.md" "implement worker must be installed"
-assert_exists "$CLAUDE_PROJECT_DIR/.claude/agents/loop-orchestrator.md" "bundled Claude subagent must be installed"
-assert_exists "$CLAUDE_PROJECT_DIR/.claude/agents/plan-polisher.md" "planning subagent must be installed"
+assert_exists "$CLAUDE_PROJECT_DIR/.claude/agents/loop-orchestrator.md" "bundled Claude agent file must be installed"
+assert_exists "$CLAUDE_PROJECT_DIR/.claude/agents/plan-polisher.md" "planning agent file must be installed"
 assert_exists "$CLAUDE_PROJECT_DIR/.claude/agents/review-sidecar.md" "review sidecar must be installed"
 assert_exists "$CLAUDE_PROJECT_DIR/.claude/agents/security-sidecar.md" "security sidecar must be installed"
 
-node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];if(a.subagentsDir!=='.claude/agents')process.exit(1);if(!Array.isArray(a.installedSubagents)||!a.installedSubagents.includes('best-practices-sidecar.md')||!a.installedSubagents.includes('commit-preparer.md')||!a.installedSubagents.includes('docs-auditor.md')||!a.installedSubagents.includes('implement-worker.md')||!a.installedSubagents.includes('loop-orchestrator.md')||!a.installedSubagents.includes('plan-polisher.md')||!a.installedSubagents.includes('review-sidecar.md')||!a.installedSubagents.includes('security-sidecar.md'))process.exit(1);if(!a.managedSubagents||!a.managedSubagents['best-practices-sidecar.md']||!a.managedSubagents['commit-preparer.md']||!a.managedSubagents['docs-auditor.md']||!a.managedSubagents['implement-worker.md']||!a.managedSubagents['loop-orchestrator.md']||!a.managedSubagents['plan-polisher.md']||!a.managedSubagents['review-sidecar.md']||!a.managedSubagents['security-sidecar.md'])process.exit(1);" "$CLAUDE_PROJECT_DIR/.ai-factory.json"
+node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];if(a.agentsDir!=='.claude/agents')process.exit(1);if(!Array.isArray(a.installedAgentFiles)||!a.installedAgentFiles.includes('best-practices-sidecar.md')||!a.installedAgentFiles.includes('commit-preparer.md')||!a.installedAgentFiles.includes('docs-auditor.md')||!a.installedAgentFiles.includes('implement-worker.md')||!a.installedAgentFiles.includes('loop-orchestrator.md')||!a.installedAgentFiles.includes('plan-polisher.md')||!a.installedAgentFiles.includes('review-sidecar.md')||!a.installedAgentFiles.includes('security-sidecar.md'))process.exit(1);if(!a.managedAgentFiles||!a.managedAgentFiles['best-practices-sidecar.md']||!a.managedAgentFiles['commit-preparer.md']||!a.managedAgentFiles['docs-auditor.md']||!a.managedAgentFiles['implement-worker.md']||!a.managedAgentFiles['loop-orchestrator.md']||!a.managedAgentFiles['plan-polisher.md']||!a.managedAgentFiles['review-sidecar.md']||!a.managedAgentFiles['security-sidecar.md'])process.exit(1);" "$CLAUDE_PROJECT_DIR/.ai-factory.json"
 
-# Modify one managed subagent to simulate local drift, then update again.
+# Modify one managed agent file to simulate local drift, then update again.
 echo "" >> "$CLAUDE_PROJECT_DIR/.claude/agents/loop-orchestrator.md"
 echo "<!-- drift -->" >> "$CLAUDE_PROJECT_DIR/.claude/agents/loop-orchestrator.md"
 
 (cd "$CLAUDE_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update > "$CLAUDE_SECOND_OUTPUT" 2>&1)
-assert_contains "$CLAUDE_SECOND_OUTPUT" "Local modifications detected in subagent" "local drift warning must be printed"
-assert_contains "$CLAUDE_SECOND_OUTPUT" "loop-orchestrator\\.md \(local drift\)" "subagent drift must be repaired on update"
-assert_contains "$CLAUDE_PROJECT_DIR/.claude/agents/loop-orchestrator.md" "name: loop-orchestrator" "reinstalled subagent content must be restored"
+assert_contains "$CLAUDE_SECOND_OUTPUT" "Local modifications detected in agent file" "local drift warning must be printed"
+assert_contains "$CLAUDE_SECOND_OUTPUT" "loop-orchestrator\\.md \(local drift\)" "agent file drift must be repaired on update"
+assert_contains "$CLAUDE_PROJECT_DIR/.claude/agents/loop-orchestrator.md" "name: loop-orchestrator" "reinstalled agent file content must be restored"
 
-echo "claude subagents smoke tests passed"
+echo "claude agent files smoke tests passed"

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -282,3 +282,46 @@ assert_contains "$CLAUDE_SECOND_OUTPUT" "loop-orchestrator\\.md \(local drift\)"
 assert_contains "$CLAUDE_PROJECT_DIR/.claude/agents/loop-orchestrator.md" "name: loop-orchestrator" "reinstalled agent file content must be restored"
 
 echo "claude agent files smoke tests passed"
+
+# -------------------------------------------------------------------
+# Legacy Claude migration smoke: update should read old subagents*
+# keys and persist only the universal agent-file state on save.
+# -------------------------------------------------------------------
+
+LEGACY_CLAUDE_PROJECT_DIR="$TMPDIR/update-smoke-legacy-claude"
+mkdir -p "$LEGACY_CLAUDE_PROJECT_DIR/.claude/agents"
+
+cp "$ROOT_DIR/subagents/plan-polisher.md" "$LEGACY_CLAUDE_PROJECT_DIR/.claude/agents/plan-polisher.md"
+
+cat > "$LEGACY_CLAUDE_PROJECT_DIR/.ai-factory.json" << 'EOF'
+{
+  "version": "2.4.0",
+  "agents": [
+    {
+      "id": "claude",
+      "skillsDir": ".claude/skills",
+      "installedSkills": ["aif"],
+      "subagentsDir": ".claude/agents",
+      "installedSubagents": ["plan-polisher.md"],
+      "managedSubagents": {},
+      "mcp": {
+        "github": false,
+        "filesystem": false,
+        "postgres": false,
+        "chromeDevtools": false,
+        "playwright": false
+      }
+    }
+  ],
+  "extensions": []
+}
+EOF
+
+LEGACY_CLAUDE_OUTPUT="$TMPDIR/update-legacy-claude.log"
+
+(cd "$LEGACY_CLAUDE_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update > "$LEGACY_CLAUDE_OUTPUT" 2>&1)
+assert_contains "$LEGACY_CLAUDE_OUTPUT" "\[claude\] Agent files:" "legacy claude config must still update bundled agent files"
+
+node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];if('subagentsDir' in a || 'installedSubagents' in a || 'managedSubagents' in a)process.exit(1);if(a.agentsDir!=='.claude/agents')process.exit(1);if(!Array.isArray(a.installedAgentFiles)||!a.installedAgentFiles.includes('plan-polisher.md'))process.exit(1);if(!a.managedAgentFiles||!a.managedAgentFiles['plan-polisher.md'])process.exit(1);" "$LEGACY_CLAUDE_PROJECT_DIR/.ai-factory.json"
+
+echo "legacy claude migration smoke tests passed"

--- a/src/cli/commands/extension.ts
+++ b/src/cli/commands/extension.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import path from 'path';
-import { loadConfig, saveConfig } from '../../core/config.js';
+import { loadConfig, saveConfig, type AiFactoryConfig } from '../../core/config.js';
 import { hydrateProjectAgentRegistry } from '../../core/agents.js';
 import {
   resolveExtension,
@@ -18,27 +18,28 @@ import {
   removeCustomSkillsForAllAgents,
   commitResolvedExtension,
   refreshExtensions,
+  getManifestRuntimeIds,
+  assertNoConfiguredRuntimeOrphans,
 } from '../../core/extension-ops.js';
 
-function getManifestRuntimeIds(manifest: { agents?: Array<{ id: string }> } | null): string[] {
-  return manifest?.agents?.map(agent => agent.id) ?? [];
-}
-
-function assertNoConfiguredRuntimeOrphans(
-  configuredAgents: Array<{ id: string }>,
-  runtimeIds: string[],
-  extensionName: string,
-): void {
-  const configured = configuredAgents
-    .filter(agent => runtimeIds.includes(agent.id))
-    .map(agent => agent.id);
-
-  if (configured.length > 0) {
-    throw new Error(
-      `Cannot remove extension "${extensionName}" because it would orphan configured runtime(s): ${configured.join(', ')}. ` +
-      `Re-run "ai-factory init" without them first.`,
-    );
+async function loadHydratedExtensionConfig(
+  projectDir: string,
+  options: { showInitHint?: boolean } = {},
+): Promise<AiFactoryConfig> {
+  const config = await loadConfig(projectDir);
+  if (!config) {
+    console.log(chalk.red('Error: No .ai-factory.json found.'));
+    if (options.showInitHint) {
+      console.log(chalk.dim('Run "ai-factory init" to set up your project first.'));
+    }
+    process.exit(1);
   }
+
+  await hydrateProjectAgentRegistry(projectDir, {
+    extensionNames: config.extensions?.map(extension => extension.name) ?? [],
+  });
+
+  return config;
 }
 
 export async function extensionAddCommand(source: string): Promise<void> {
@@ -46,16 +47,7 @@ export async function extensionAddCommand(source: string): Promise<void> {
 
   console.log(chalk.bold.blue('\n🏭 AI Factory - Install Extension\n'));
 
-  const config = await loadConfig(projectDir);
-  if (!config) {
-    console.log(chalk.red('Error: No .ai-factory.json found.'));
-    console.log(chalk.dim('Run "ai-factory init" to set up your project first.'));
-    process.exit(1);
-  }
-
-  await hydrateProjectAgentRegistry(projectDir, {
-    extensionNames: config.extensions?.map(extension => extension.name) ?? [],
-  });
+  const config = await loadHydratedExtensionConfig(projectDir, { showInitHint: true });
 
   console.log(chalk.dim(`Installing from: ${source}\n`));
 
@@ -102,15 +94,7 @@ export async function extensionRemoveCommand(name: string): Promise<void> {
 
   console.log(chalk.bold.blue('\n🏭 AI Factory - Remove Extension\n'));
 
-  const config = await loadConfig(projectDir);
-  if (!config) {
-    console.log(chalk.red('Error: No .ai-factory.json found.'));
-    process.exit(1);
-  }
-
-  await hydrateProjectAgentRegistry(projectDir, {
-    extensionNames: config.extensions?.map(extension => extension.name) ?? [],
-  });
+  const config = await loadHydratedExtensionConfig(projectDir);
 
   const extensions = config.extensions ?? [];
   const index = extensions.findIndex(e => e.name === name);
@@ -123,7 +107,7 @@ export async function extensionRemoveCommand(name: string): Promise<void> {
   try {
     const extensionDir = path.join(getExtensionsDir(projectDir), name);
     const manifest = await loadExtensionManifest(extensionDir);
-    assertNoConfiguredRuntimeOrphans(config.agents, getManifestRuntimeIds(manifest), name);
+    assertNoConfiguredRuntimeOrphans(config, getManifestRuntimeIds(manifest), name, 'remove');
 
     if (manifest?.agentFiles?.length) {
       const removedAgentFiles = await removeExtensionAgentFilesForAllAgents(projectDir, config.agents, manifest);
@@ -192,15 +176,7 @@ export async function extensionRemoveCommand(name: string): Promise<void> {
 export async function extensionListCommand(): Promise<void> {
   const projectDir = process.cwd();
 
-  const config = await loadConfig(projectDir);
-  if (!config) {
-    console.log(chalk.red('Error: No .ai-factory.json found.'));
-    process.exit(1);
-  }
-
-  await hydrateProjectAgentRegistry(projectDir, {
-    extensionNames: config.extensions?.map(extension => extension.name) ?? [],
-  });
+  const config = await loadHydratedExtensionConfig(projectDir);
 
   const extensions = config.extensions ?? [];
 
@@ -245,16 +221,7 @@ export async function extensionUpdateCommand(name?: string, options?: { force?: 
     console.log(chalk.dim('Force mode: refreshing all extensions regardless of version\n'));
   }
 
-  const config = await loadConfig(projectDir);
-  if (!config) {
-    console.log(chalk.red('Error: No .ai-factory.json found.'));
-    console.log(chalk.dim('Run "ai-factory init" to set up your project first.'));
-    process.exit(1);
-  }
-
-  await hydrateProjectAgentRegistry(projectDir, {
-    extensionNames: config.extensions?.map(extension => extension.name) ?? [],
-  });
+  const config = await loadHydratedExtensionConfig(projectDir, { showInitHint: true });
 
   const extensions = config.extensions ?? [];
 

--- a/src/cli/commands/extension.ts
+++ b/src/cli/commands/extension.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import path from 'path';
 import { loadConfig, saveConfig } from '../../core/config.js';
+import { hydrateProjectAgentRegistry } from '../../core/agents.js';
 import {
   resolveExtension,
   removeExtensionFiles,
@@ -11,12 +12,34 @@ import { removeExtensionMcpServers } from '../../core/mcp.js';
 import {
   removeSkillsForAllAgents,
   collectReplacedSkills,
+  removeExtensionAgentFilesForAllAgents,
   restoreBaseSkills,
   stripInjectionsForAllAgents,
   removeCustomSkillsForAllAgents,
   commitResolvedExtension,
   refreshExtensions,
 } from '../../core/extension-ops.js';
+
+function getManifestRuntimeIds(manifest: { agents?: Array<{ id: string }> } | null): string[] {
+  return manifest?.agents?.map(agent => agent.id) ?? [];
+}
+
+function assertNoConfiguredRuntimeOrphans(
+  configuredAgents: Array<{ id: string }>,
+  runtimeIds: string[],
+  extensionName: string,
+): void {
+  const configured = configuredAgents
+    .filter(agent => runtimeIds.includes(agent.id))
+    .map(agent => agent.id);
+
+  if (configured.length > 0) {
+    throw new Error(
+      `Cannot remove extension "${extensionName}" because it would orphan configured runtime(s): ${configured.join(', ')}. ` +
+      `Re-run "ai-factory init" without them first.`,
+    );
+  }
+}
 
 export async function extensionAddCommand(source: string): Promise<void> {
   const projectDir = process.cwd();
@@ -29,6 +52,10 @@ export async function extensionAddCommand(source: string): Promise<void> {
     console.log(chalk.dim('Run "ai-factory init" to set up your project first.'));
     process.exit(1);
   }
+
+  await hydrateProjectAgentRegistry(projectDir, {
+    extensionNames: config.extensions?.map(extension => extension.name) ?? [],
+  });
 
   console.log(chalk.dim(`Installing from: ${source}\n`));
 
@@ -81,6 +108,10 @@ export async function extensionRemoveCommand(name: string): Promise<void> {
     process.exit(1);
   }
 
+  await hydrateProjectAgentRegistry(projectDir, {
+    extensionNames: config.extensions?.map(extension => extension.name) ?? [],
+  });
+
   const extensions = config.extensions ?? [];
   const index = extensions.findIndex(e => e.name === name);
 
@@ -92,6 +123,16 @@ export async function extensionRemoveCommand(name: string): Promise<void> {
   try {
     const extensionDir = path.join(getExtensionsDir(projectDir), name);
     const manifest = await loadExtensionManifest(extensionDir);
+    assertNoConfiguredRuntimeOrphans(config.agents, getManifestRuntimeIds(manifest), name);
+
+    if (manifest?.agentFiles?.length) {
+      const removedAgentFiles = await removeExtensionAgentFilesForAllAgents(projectDir, config.agents, manifest);
+      for (const [agentId, files] of removedAgentFiles) {
+        if (files.length > 0) {
+          console.log(chalk.green(`✓ Agent files removed for ${agentId}: ${files.join(', ')}`));
+        }
+      }
+    }
 
     // Strip injections before removing files
     await stripInjectionsForAllAgents(projectDir, config.agents, name, manifest);
@@ -157,6 +198,10 @@ export async function extensionListCommand(): Promise<void> {
     process.exit(1);
   }
 
+  await hydrateProjectAgentRegistry(projectDir, {
+    extensionNames: config.extensions?.map(extension => extension.name) ?? [],
+  });
+
   const extensions = config.extensions ?? [];
 
   if (extensions.length === 0) {
@@ -206,6 +251,10 @@ export async function extensionUpdateCommand(name?: string, options?: { force?: 
     console.log(chalk.dim('Run "ai-factory init" to set up your project first.'));
     process.exit(1);
   }
+
+  await hydrateProjectAgentRegistry(projectDir, {
+    extensionNames: config.extensions?.map(extension => extension.name) ?? [],
+  });
 
   const extensions = config.extensions ?? [];
 
@@ -278,4 +327,3 @@ export async function extensionUpdateCommand(name?: string, options?: { force?: 
     process.exit(1);
   }
 }
-

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -4,11 +4,12 @@ import { runWizard, type WizardAnswers } from '../wizard/prompts.js';
 import { buildManagedSkillsState, buildManagedSubagentsState, installSkills, installSubagents, getAvailableSkills } from '../../core/installer.js';
 import { saveConfig, configExists, loadConfig, getCurrentVersion, type AgentInstallation } from '../../core/config.js';
 import { configureMcp, getMcpInstructions } from '../../core/mcp.js';
-import { getAgentConfig, getAvailableAgentIds } from '../../core/agents.js';
+import { getAgentConfig, getAvailableAgentIds, hydrateProjectAgentRegistry } from '../../core/agents.js';
 import { cleanupAgentSetup, getAgentOnboarding } from '../../core/transformer.js';
 import { removeDirectory, removeFile, copyFile, fileExists, getSkillsDir } from '../../utils/fs.js';
 import { applyExtensionInjections } from '../../core/injections.js';
-import { collectReplacedSkills } from '../../core/extension-ops.js';
+import { collectReplacedSkills, installExtensionAgentFilesForAllAgents } from '../../core/extension-ops.js';
+import { loadAllExtensions } from '../../core/extensions.js';
 
 export interface InitOptions {
   agents?: string;
@@ -81,13 +82,13 @@ async function removeAgentSetup(projectDir: string, agent: AgentInstallation): P
   const agentConfig = getAgentConfig(agent.id);
   await removeDirectory(path.join(projectDir, agent.skillsDir));
 
-  // Remove only AI Factory-managed subagents, not the entire directory.
+  // Remove only AI Factory-managed agent files, not the entire directory.
   // The directory may contain user-created custom agents unrelated to AI Factory.
-  const subagentsDir = agent.subagentsDir ?? agentConfig.subagentsDir;
-  if (subagentsDir) {
-    const managedFiles = agent.installedSubagents ?? [];
+  const agentsDir = agent.agentsDir ?? agentConfig.agentsDir;
+  if (agentsDir) {
+    const managedFiles = agent.installedAgentFiles ?? [];
     for (const relPath of managedFiles) {
-      await removeFile(path.join(projectDir, subagentsDir, relPath));
+      await removeFile(path.join(projectDir, agentsDir, relPath));
     }
   }
 
@@ -102,6 +103,9 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
 
   const hasExistingConfig = await configExists(projectDir);
   const existingConfig = hasExistingConfig ? await loadConfig(projectDir) : null;
+  await hydrateProjectAgentRegistry(projectDir, {
+    extensionNames: existingConfig?.extensions?.map(extension => extension.name) ?? [],
+  });
 
   if (hasExistingConfig) {
     console.log(chalk.yellow('Warning: .ai-factory.json already exists.'));
@@ -144,10 +148,11 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
         skills: answers.selectedSkills,
         agentId: agentSelection.id,
       });
-      const installedSubagents = agentConfig.subagentsDir
+      const installedAgentFiles = agentConfig.agentsDir
         ? await installSubagents({
           projectDir,
-          subagentsDir: agentConfig.subagentsDir,
+          agentId: agentSelection.id,
+          agentsDir: agentConfig.agentsDir,
         })
         : [];
 
@@ -167,9 +172,9 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
         id: agentSelection.id,
         skillsDir: agentConfig.skillsDir,
         installedSkills,
-        ...(agentConfig.subagentsDir ? {
-          subagentsDir: agentConfig.subagentsDir,
-          installedSubagents,
+        ...(agentConfig.agentsDir ? {
+          agentsDir: agentConfig.agentsDir,
+          installedAgentFiles,
         } : {}),
         mcp: {
           github: agentSelection.mcpGithub,
@@ -185,6 +190,11 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
 
     // Re-apply extension injections after skill installation
     if (existingExtensions.length > 0) {
+      const loadedExtensions = await loadAllExtensions(projectDir, existingExtensions.map(extension => extension.name));
+      for (const { dir, manifest } of loadedExtensions) {
+        await installExtensionAgentFilesForAllAgents(projectDir, installedAgents, dir, manifest);
+      }
+
       let totalInjections = 0;
       for (const agent of installedAgents) {
         totalInjections += await applyExtensionInjections(projectDir, agent, existingExtensions);
@@ -198,8 +208,8 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     for (const agent of installedAgents) {
       const managedBaseSkills = agent.installedSkills.filter(skill => !replacedSkills.has(skill));
       agent.managedSkills = await buildManagedSkillsState(projectDir, agent, managedBaseSkills);
-      if (agent.subagentsDir) {
-        agent.managedSubagents = await buildManagedSubagentsState(projectDir, agent, agent.installedSubagents ?? []);
+      if (agent.agentsDir) {
+        agent.managedAgentFiles = await buildManagedSubagentsState(projectDir, agent, agent.installedAgentFiles ?? []);
       }
     }
 
@@ -231,9 +241,9 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
       console.log(chalk.bold(`${agentConfig.displayName}:`));
       console.log(chalk.dim(`  Skills directory: ${path.join(projectDir, agent.skillsDir)}`));
       console.log(chalk.dim(`  Installed skills: ${agent.installedSkills.length}`));
-      if (agent.subagentsDir) {
-        console.log(chalk.dim(`  Subagents directory: ${path.join(projectDir, agent.subagentsDir)}`));
-        console.log(chalk.dim(`  Installed subagents: ${agent.installedSubagents?.length ?? 0}`));
+      if (agent.agentsDir) {
+        console.log(chalk.dim(`  Agent files directory: ${path.join(projectDir, agent.agentsDir)}`));
+        console.log(chalk.dim(`  Installed agent files: ${agent.installedAgentFiles?.length ?? 0}`));
       }
 
       const configuredMcp = mcpSummary[agent.id];

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -8,7 +8,11 @@ import { getAgentConfig, getAvailableAgentIds, hydrateProjectAgentRegistry } fro
 import { cleanupAgentSetup, getAgentOnboarding } from '../../core/transformer.js';
 import { removeDirectory, removeFile, copyFile, fileExists, getSkillsDir } from '../../utils/fs.js';
 import { applyExtensionInjections } from '../../core/injections.js';
-import { collectReplacedSkills, installExtensionAgentFilesForAllAgents } from '../../core/extension-ops.js';
+import {
+  assertNoAgentFileConflicts,
+  collectReplacedSkills,
+  installExtensionAgentFilesForAllAgents,
+} from '../../core/extension-ops.js';
 import { loadAllExtensions } from '../../core/extensions.js';
 
 export interface InitOptions {
@@ -191,7 +195,17 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     // Re-apply extension injections after skill installation
     if (existingExtensions.length > 0) {
       const loadedExtensions = await loadAllExtensions(projectDir, existingExtensions.map(extension => extension.name));
+      const conflictCheckConfig = existingConfig ?? {
+        version: getCurrentVersion(),
+        agents: installedAgents,
+        extensions: existingExtensions,
+      };
       for (const { dir, manifest } of loadedExtensions) {
+        await assertNoAgentFileConflicts(projectDir, {
+          ...conflictCheckConfig,
+          extensions: existingExtensions,
+          agents: installedAgents,
+        }, manifest);
         await installExtensionAgentFilesForAllAgents(projectDir, installedAgents, dir, manifest);
       }
 

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -5,6 +5,7 @@ import {execSync} from 'child_process';
 import inquirer from 'inquirer';
 import {getCurrentVersion, loadConfig, saveConfig} from '../../core/config.js';
 import {compareExtensionVersions, getExtensionsDir, getNpmVersionCheckResult, loadExtensionManifest} from '../../core/extensions.js';
+import { hydrateProjectAgentRegistry } from '../../core/agents.js';
 import {
   buildManagedSkillsState,
   buildManagedSubagentsState,
@@ -159,6 +160,10 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
     process.exit(1);
   }
 
+  await hydrateProjectAgentRegistry(projectDir, {
+    extensionNames: config.extensions?.map(extension => extension.name) ?? [],
+  });
+
   const currentVersion = getCurrentVersion();
 
   console.log(chalk.dim(`Config version: ${config.version}`));
@@ -212,6 +217,10 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
         `Extensions: ${extensionSummary.updated.length} updated, ${extensionSummary.unchanged.length} unchanged, ${extensionSummary.failed.length} failed\n`,
       ),
     );
+
+    await hydrateProjectAgentRegistry(projectDir, {
+      extensionNames: config.extensions?.map(extension => extension.name) ?? [],
+    });
   }
 
   console.log(chalk.dim('Updating skills and agent assets...\n'));
@@ -236,7 +245,7 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
       skillEntriesByAgent.set(agent.id, result.entries);
 
       const subagentResult = await updateSubagents(agent, projectDir, { force });
-      agent.installedSubagents = subagentResult.installedSubagents;
+      agent.installedAgentFiles = subagentResult.installedSubagents;
       subagentEntriesByAgent.set(agent.id, subagentResult.entries);
     }
 
@@ -316,8 +325,8 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
       const { base: baseSkills } = partitionSkills(agent.installedSkills);
       const managedBaseSkills = baseSkills.filter(skill => availableSkills.includes(skill) && !finalReplacedSkills.has(skill));
       agent.managedSkills = await buildManagedSkillsState(projectDir, agent, managedBaseSkills);
-      if (agent.subagentsDir) {
-        agent.managedSubagents = await buildManagedSubagentsState(projectDir, agent, agent.installedSubagents ?? []);
+      if (agent.agentsDir) {
+        agent.managedAgentFiles = await buildManagedSubagentsState(projectDir, agent, agent.installedAgentFiles ?? []);
       }
     }
 
@@ -386,10 +395,10 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
       }
 
       const subagentEntries = subagentEntriesByAgent.get(agent.id) ?? [];
-      if (agent.subagentsDir || subagentEntries.length > 0) {
+      if (agent.agentsDir || subagentEntries.length > 0) {
         const groupedSubagents = groupAndSortEntriesByStatus(subagentEntries, e => e.subagent);
 
-        console.log(chalk.bold(`[${agent.id}] Subagents:`));
+        console.log(chalk.bold(`[${agent.id}] Agent files:`));
         console.log(chalk.dim(`  changed: ${groupedSubagents.changed.length}`));
         console.log(chalk.dim(`  unchanged: ${groupedSubagents.unchanged.length}`));
         console.log(chalk.dim(`  skipped: ${groupedSubagents.skipped.length}`));
@@ -422,7 +431,7 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
           'source-missing',
         ].includes(entry.reason));
         if (recoveredSubagents.length > 0) {
-          console.log(chalk.yellow('  WARN: managed subagent state recovered for:'));
+          console.log(chalk.yellow('  WARN: managed agent file state recovered for:'));
           for (const entry of recoveredSubagents) {
             console.log(chalk.yellow(`    - ${entry.subagent} (${formatReason(entry.reason)})`));
           }

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -245,7 +245,7 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
       skillEntriesByAgent.set(agent.id, result.entries);
 
       const subagentResult = await updateSubagents(agent, projectDir, { force });
-      agent.installedAgentFiles = subagentResult.installedSubagents;
+      agent.installedAgentFiles = subagentResult.installedAgentFiles;
       subagentEntriesByAgent.set(agent.id, subagentResult.entries);
     }
 

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { loadConfig, saveConfig, getCurrentVersion } from '../../core/config.js';
 import { buildManagedSkillsState, buildManagedSubagentsState, installSkills, installSubagents, getAvailableSkills, partitionSkills } from '../../core/installer.js';
-import { getAgentConfig } from '../../core/agents.js';
+import { getAgentConfig, hydrateProjectAgentRegistry } from '../../core/agents.js';
 import { fileExists, removeDirectory, removeFile } from '../../utils/fs.js';
 
 // Old v1 skill directory names that were renamed to aif-* in v2
@@ -120,6 +120,10 @@ export async function upgradeCommand(): Promise<void> {
     process.exit(1);
   }
 
+  await hydrateProjectAgentRegistry(projectDir, {
+    extensionNames: config.extensions?.map(extension => extension.name) ?? [],
+  });
+
   // Step 1: Migrate legacy plan directories to .ai-factory/plans/
   // Also ensure newer v2 working directories exist.
   const aiFactoryDir = path.join(projectDir, '.ai-factory');
@@ -209,17 +213,18 @@ export async function upgradeCommand(): Promise<void> {
       skills: availableSkills,
       agentId: agent.id,
     });
-    const installedSubagents = agent.subagentsDir
+    const installedAgentFiles = agent.agentsDir
       ? await installSubagents({
         projectDir,
-        subagentsDir: agent.subagentsDir,
+        agentId: agent.id,
+        agentsDir: agent.agentsDir,
       })
       : [];
 
     agent.installedSkills = [...installedSkills, ...customSkills];
-    if (agent.subagentsDir) {
-      agent.installedSubagents = installedSubagents;
-      agent.managedSubagents = await buildManagedSubagentsState(projectDir, agent, installedSubagents);
+    if (agent.agentsDir) {
+      agent.installedAgentFiles = installedAgentFiles;
+      agent.managedAgentFiles = await buildManagedSubagentsState(projectDir, agent, installedAgentFiles);
     }
     agent.managedSkills = await buildManagedSkillsState(projectDir, agent, installedSkills);
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,7 +5,6 @@ import { upgradeCommand } from './commands/upgrade.js';
 import { extensionAddCommand, extensionRemoveCommand, extensionListCommand, extensionUpdateCommand } from './commands/extension.js';
 import { getCurrentVersion, loadConfig } from '../core/config.js';
 import { loadAllExtensions } from '../core/extensions.js';
-import { hydrateProjectAgentRegistry, resetExtensionAgentRegistry } from '../core/agents.js';
 
 const program = new Command();
 
@@ -87,19 +86,5 @@ async function loadExtensionCommands(): Promise<void> {
   }
 }
 
-async function bootstrapProjectAgentRegistry(): Promise<void> {
-  try {
-    const projectDir = process.cwd();
-    const config = await loadConfig(projectDir);
-    await hydrateProjectAgentRegistry(projectDir, {
-      extensionNames: config?.extensions?.map(extension => extension.name) ?? [],
-    });
-  } catch (err) {
-    resetExtensionAgentRegistry();
-    console.error(`Warning: Failed to hydrate extension-defined runtimes: ${(err as Error).message}`);
-  }
-}
-
-await bootstrapProjectAgentRegistry();
 await loadExtensionCommands();
 program.parse();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import { upgradeCommand } from './commands/upgrade.js';
 import { extensionAddCommand, extensionRemoveCommand, extensionListCommand, extensionUpdateCommand } from './commands/extension.js';
 import { getCurrentVersion, loadConfig } from '../core/config.js';
 import { loadAllExtensions } from '../core/extensions.js';
+import { hydrateProjectAgentRegistry, resetExtensionAgentRegistry } from '../core/agents.js';
 
 const program = new Command();
 
@@ -86,5 +87,19 @@ async function loadExtensionCommands(): Promise<void> {
   }
 }
 
+async function bootstrapProjectAgentRegistry(): Promise<void> {
+  try {
+    const projectDir = process.cwd();
+    const config = await loadConfig(projectDir);
+    await hydrateProjectAgentRegistry(projectDir, {
+      extensionNames: config?.extensions?.map(extension => extension.name) ?? [],
+    });
+  } catch (err) {
+    resetExtensionAgentRegistry();
+    console.error(`Warning: Failed to hydrate extension-defined runtimes: ${(err as Error).message}`);
+  }
+}
+
+await bootstrapProjectAgentRegistry();
 await loadExtensionCommands();
 program.parse();

--- a/src/core/agents.ts
+++ b/src/core/agents.ts
@@ -309,7 +309,3 @@ export function getAgentChoices(): { name: string; value: string }[] {
 export function getAvailableAgentIds(): string[] {
   return getRegistryEntries().map(agent => agent.id);
 }
-
-export function isBuiltInAgent(id: string): boolean {
-  return id in BUILTIN_AGENT_REGISTRY;
-}

--- a/src/core/agents.ts
+++ b/src/core/agents.ts
@@ -1,24 +1,50 @@
+import { loadAllExtensions } from './extensions.js';
+
+export type AgentFileExtension = '.md' | '.toml';
+
 export interface AgentConfig {
   id: string;
   displayName: string;
   configDir: string;
   skillsDir: string;
-  subagentsDir?: string;
+  agentsDir?: string;
+  agentFileExtension?: AgentFileExtension;
+  settingsFile: string | null;
+  supportsMcp: boolean;
+  skillsCliAgent: string | null;
+  source: 'builtin' | 'extension';
+  extensionName?: string;
+}
+
+export interface RuntimeDefinitionInput {
+  id: string;
+  displayName: string;
+  configDir: string;
+  skillsDir: string;
+  agentsDir?: string;
+  agentFileExtension?: AgentFileExtension;
   settingsFile: string | null;
   supportsMcp: boolean;
   skillsCliAgent: string | null;
 }
 
-const AGENT_REGISTRY: Record<string, AgentConfig> = {
+export interface RuntimeManifestInput {
+  name: string;
+  agents?: RuntimeDefinitionInput[];
+}
+
+const BUILTIN_AGENT_REGISTRY: Record<string, AgentConfig> = {
   claude: {
     id: 'claude',
     displayName: 'Claude Code',
     configDir: '.claude',
     skillsDir: '.claude/skills',
-    subagentsDir: '.claude/agents',
+    agentsDir: '.claude/agents',
+    agentFileExtension: '.md',
     settingsFile: '.mcp.json',
     supportsMcp: true,
     skillsCliAgent: 'claude-code',
+    source: 'builtin',
   },
   cursor: {
     id: 'cursor',
@@ -28,15 +54,19 @@ const AGENT_REGISTRY: Record<string, AgentConfig> = {
     settingsFile: '.cursor/mcp.json',
     supportsMcp: true,
     skillsCliAgent: 'cursor',
+    source: 'builtin',
   },
   codex: {
     id: 'codex',
     displayName: 'Codex CLI',
     configDir: '.codex',
     skillsDir: '.codex/skills',
+    agentsDir: '.codex/agents',
+    agentFileExtension: '.toml',
     settingsFile: null,
     supportsMcp: false,
     skillsCliAgent: 'codex',
+    source: 'builtin',
   },
   copilot: {
     id: 'copilot',
@@ -46,6 +76,7 @@ const AGENT_REGISTRY: Record<string, AgentConfig> = {
     settingsFile: '.vscode/mcp.json',
     supportsMcp: true,
     skillsCliAgent: 'github-copilot',
+    source: 'builtin',
   },
   gemini: {
     id: 'gemini',
@@ -55,6 +86,7 @@ const AGENT_REGISTRY: Record<string, AgentConfig> = {
     settingsFile: null,
     supportsMcp: false,
     skillsCliAgent: 'gemini-cli',
+    source: 'builtin',
   },
   junie: {
     id: 'junie',
@@ -64,6 +96,7 @@ const AGENT_REGISTRY: Record<string, AgentConfig> = {
     settingsFile: null,
     supportsMcp: false,
     skillsCliAgent: 'junie',
+    source: 'builtin',
   },
   qwen: {
     id: 'qwen',
@@ -73,6 +106,7 @@ const AGENT_REGISTRY: Record<string, AgentConfig> = {
     settingsFile: '.qwen/settings.json',
     supportsMcp: true,
     skillsCliAgent: null,
+    source: 'builtin',
   },
   windsurf: {
     id: 'windsurf',
@@ -82,6 +116,7 @@ const AGENT_REGISTRY: Record<string, AgentConfig> = {
     settingsFile: null,
     supportsMcp: false,
     skillsCliAgent: 'windsurf',
+    source: 'builtin',
   },
   warp: {
     id: 'warp',
@@ -91,6 +126,7 @@ const AGENT_REGISTRY: Record<string, AgentConfig> = {
     settingsFile: null,
     supportsMcp: false,
     skillsCliAgent: null,
+    source: 'builtin',
   },
   zencoder: {
     id: 'zencoder',
@@ -100,6 +136,7 @@ const AGENT_REGISTRY: Record<string, AgentConfig> = {
     settingsFile: null,
     supportsMcp: false,
     skillsCliAgent: 'zencoder',
+    source: 'builtin',
   },
   roocode: {
     id: 'roocode',
@@ -109,6 +146,7 @@ const AGENT_REGISTRY: Record<string, AgentConfig> = {
     settingsFile: '.roo/mcp.json',
     supportsMcp: true,
     skillsCliAgent: 'roo',
+    source: 'builtin',
   },
   kilocode: {
     id: 'kilocode',
@@ -118,6 +156,7 @@ const AGENT_REGISTRY: Record<string, AgentConfig> = {
     settingsFile: '.kilocode/mcp.json',
     supportsMcp: true,
     skillsCliAgent: 'kilo',
+    source: 'builtin',
   },
   antigravity: {
     id: 'antigravity',
@@ -127,6 +166,7 @@ const AGENT_REGISTRY: Record<string, AgentConfig> = {
     settingsFile: null,
     supportsMcp: false,
     skillsCliAgent: 'antigravity',
+    source: 'builtin',
   },
   opencode: {
     id: 'opencode',
@@ -136,6 +176,7 @@ const AGENT_REGISTRY: Record<string, AgentConfig> = {
     settingsFile: 'opencode.json',
     supportsMcp: true,
     skillsCliAgent: 'opencode',
+    source: 'builtin',
   },
   universal: {
     id: 'universal',
@@ -145,24 +186,130 @@ const AGENT_REGISTRY: Record<string, AgentConfig> = {
     settingsFile: null,
     supportsMcp: false,
     skillsCliAgent: null,
+    source: 'builtin',
   },
 };
 
+const extensionAgentRegistry = new Map<string, AgentConfig>();
+
+function getRegistryEntries(): AgentConfig[] {
+  return [
+    ...Object.values(BUILTIN_AGENT_REGISTRY),
+    ...extensionAgentRegistry.values(),
+  ];
+}
+
+function isValidRuntimeDefinition(definition: RuntimeDefinitionInput): boolean {
+  return Boolean(
+    definition.id &&
+      definition.displayName &&
+      definition.configDir &&
+      definition.skillsDir,
+  );
+}
+
+function normalizeRuntimeDefinition(
+  definition: RuntimeDefinitionInput,
+  extensionName: string,
+): AgentConfig {
+  return {
+    id: definition.id,
+    displayName: definition.displayName,
+    configDir: definition.configDir,
+    skillsDir: definition.skillsDir,
+    agentsDir: definition.agentsDir,
+    agentFileExtension: definition.agentFileExtension,
+    settingsFile: definition.settingsFile,
+    supportsMcp: definition.supportsMcp,
+    skillsCliAgent: definition.skillsCliAgent,
+    source: 'extension',
+    extensionName,
+  };
+}
+
+export function resetExtensionAgentRegistry(): void {
+  extensionAgentRegistry.clear();
+}
+
+export function registerRuntimeDefinitions(
+  definitions: RuntimeDefinitionInput[],
+  extensionName: string,
+): void {
+  for (const definition of definitions) {
+    if (!isValidRuntimeDefinition(definition)) {
+      throw new Error(`Extension "${extensionName}" defines an invalid runtime. Required fields: id, displayName, configDir, skillsDir.`);
+    }
+
+    if (definition.id in BUILTIN_AGENT_REGISTRY) {
+      throw new Error(`Extension "${extensionName}" cannot redefine built-in runtime "${definition.id}".`);
+    }
+
+    const existing = extensionAgentRegistry.get(definition.id);
+    if (existing && existing.extensionName !== extensionName) {
+      throw new Error(
+        `Runtime "${definition.id}" is already provided by extension "${existing.extensionName}". ` +
+        `Extension "${extensionName}" cannot claim the same runtime id.`,
+      );
+    }
+
+    extensionAgentRegistry.set(definition.id, normalizeRuntimeDefinition(definition, extensionName));
+  }
+}
+
+export async function hydrateProjectAgentRegistry(
+  projectDir: string,
+  options?: {
+    extensionNames?: string[];
+    extraManifests?: RuntimeManifestInput[];
+  },
+): Promise<void> {
+  resetExtensionAgentRegistry();
+
+  const extraNames = new Set((options?.extraManifests ?? []).map(manifest => manifest.name));
+  const extensionNames = (options?.extensionNames ?? []).filter(name => !extraNames.has(name));
+
+  if (extensionNames.length > 0) {
+    const installed = await loadAllExtensions(projectDir, extensionNames);
+    for (const { manifest } of installed) {
+      if (manifest.agents?.length) {
+        registerRuntimeDefinitions(manifest.agents, manifest.name);
+      }
+    }
+  }
+
+  for (const manifest of options?.extraManifests ?? []) {
+    if (manifest.agents?.length) {
+      registerRuntimeDefinitions(manifest.agents, manifest.name);
+    }
+  }
+}
+
+export function findAgentConfig(id: string): AgentConfig | undefined {
+  if (id in BUILTIN_AGENT_REGISTRY) {
+    return BUILTIN_AGENT_REGISTRY[id];
+  }
+  return extensionAgentRegistry.get(id);
+}
+
 export function getAgentConfig(id: string): AgentConfig {
-  const config = AGENT_REGISTRY[id];
+  const config = findAgentConfig(id);
   if (!config) {
-    throw new Error(`Unknown agent: ${id}. Available: ${Object.keys(AGENT_REGISTRY).join(', ')}`);
+    throw new Error(`Unknown agent: ${id}. Available: ${getAvailableAgentIds().join(', ')}`);
   }
   return config;
 }
 
 export function getAgentChoices(): { name: string; value: string }[] {
-  return Object.values(AGENT_REGISTRY).map(agent => ({
+  return getRegistryEntries().map(agent => ({
     name: `${agent.displayName} (${agent.configDir}/)`,
     value: agent.id,
   }));
 }
 
 export function getAvailableAgentIds(): string[] {
-  return Object.keys(AGENT_REGISTRY);
+  return getRegistryEntries().map(agent => agent.id);
+}
+
+export function isBuiltInAgent(id: string): boolean {
+  return id in BUILTIN_AGENT_REGISTRY;
 }

--- a/src/core/agents.ts
+++ b/src/core/agents.ts
@@ -244,6 +244,9 @@ export function registerRuntimeDefinitions(
       throw new Error(`Extension "${extensionName}" cannot redefine built-in runtime "${definition.id}".`);
     }
 
+    // The registry is reset before each hydrate, but this still guards
+    // collisions between different installed extensions and any extra
+    // manifests being validated in the same hydration pass.
     const existing = extensionAgentRegistry.get(definition.id);
     if (existing && existing.extensionName !== extensionName) {
       throw new Error(

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { createRequire } from 'module';
 import { readJsonFile, writeJsonFile, fileExists } from '../utils/fs.js';
-import { getAgentConfig } from './agents.js';
+import { findAgentConfig, getAgentConfig } from './agents.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../../package.json');
@@ -24,9 +24,9 @@ export interface AgentInstallation {
   skillsDir: string;
   installedSkills: string[];
   managedSkills?: Record<string, ManagedArtifactState>;
-  subagentsDir?: string;
-  installedSubagents?: string[];
-  managedSubagents?: Record<string, ManagedArtifactState>;
+  agentsDir?: string;
+  installedAgentFiles?: string[];
+  managedAgentFiles?: Record<string, ManagedArtifactState>;
   mcp: McpConfig;
 }
 
@@ -48,6 +48,20 @@ interface LegacyAiFactoryConfig {
   agent?: string;
   skillsDir?: string;
   installedSkills?: string[];
+  mcp?: Partial<McpConfig>;
+}
+
+interface LegacyAgentInstallationShape {
+  id: string;
+  skillsDir?: string;
+  installedSkills?: string[];
+  managedSkills?: unknown;
+  agentsDir?: string;
+  installedAgentFiles?: string[];
+  managedAgentFiles?: unknown;
+  subagentsDir?: string;
+  installedSubagents?: string[];
+  managedSubagents?: unknown;
   mcp?: Partial<McpConfig>;
 }
 
@@ -75,9 +89,9 @@ function createAgentInstallation(agentId: string, legacy?: LegacyAiFactoryConfig
     id: agentId,
     installedSkills: legacy?.installedSkills ?? [],
     managedSkills: {},
-    subagentsDir: agent.subagentsDir,
-    installedSubagents: [],
-    managedSubagents: {},
+    agentsDir: agent.agentsDir,
+    installedAgentFiles: [],
+    managedAgentFiles: {},
     mcp: normalizeMcp(legacy?.mcp),
   };
 }
@@ -114,16 +128,37 @@ export async function loadConfig(projectDir: string): Promise<AiFactoryConfig | 
 
   if (Array.isArray(raw.agents)) {
     const normalizedAgents = raw.agents.map(agent => {
-      const agentConfig = getAgentConfig(agent.id);
+      const legacyAgent = agent as unknown as LegacyAgentInstallationShape;
+      const agentConfig = findAgentConfig(agent.id);
+      const skillsDir = legacyAgent.skillsDir || agentConfig?.skillsDir;
+
+      if (!skillsDir) {
+        throw new Error(
+          `Configured agent "${agent.id}" is missing "skillsDir" and no runtime definition is currently registered for it.`,
+        );
+      }
+
+      const agentsDir = legacyAgent.agentsDir
+        || legacyAgent.subagentsDir
+        || agentConfig?.agentsDir;
+      const installedAgentFiles = Array.isArray(legacyAgent.installedAgentFiles)
+        ? legacyAgent.installedAgentFiles
+        : Array.isArray(legacyAgent.installedSubagents)
+          ? legacyAgent.installedSubagents
+          : [];
+      const managedAgentFiles = normalizeManagedArtifacts(
+        legacyAgent.managedAgentFiles ?? legacyAgent.managedSubagents,
+      );
+
       return {
         id: agent.id,
-        skillsDir: agent.skillsDir || agentConfig.skillsDir,
-        installedSkills: Array.isArray(agent.installedSkills) ? agent.installedSkills : [],
-        managedSkills: normalizeManagedArtifacts((agent as { managedSkills?: unknown }).managedSkills),
-        subagentsDir: agent.subagentsDir || agentConfig.subagentsDir,
-        installedSubagents: Array.isArray(agent.installedSubagents) ? agent.installedSubagents : [],
-        managedSubagents: normalizeManagedArtifacts((agent as { managedSubagents?: unknown }).managedSubagents),
-        mcp: normalizeMcp(agent.mcp),
+        skillsDir,
+        installedSkills: Array.isArray(legacyAgent.installedSkills) ? legacyAgent.installedSkills : [],
+        managedSkills: normalizeManagedArtifacts(legacyAgent.managedSkills),
+        agentsDir,
+        installedAgentFiles,
+        managedAgentFiles,
+        mcp: normalizeMcp(legacyAgent.mcp),
       };
     });
 

--- a/src/core/extension-ops.ts
+++ b/src/core/extension-ops.ts
@@ -14,6 +14,7 @@ import {
   type ResolvedExtension,
 } from './extensions.js';
 import {
+  AgentFileInstallError,
   installSkills,
   getAvailableSkills,
   getAvailableSubagents,
@@ -123,13 +124,20 @@ export async function installExtensionAgentFilesForAllAgents(
   const results = new Map<string, string[]>();
 
   for (const agent of agents) {
-    const installed = await installExtensionAgentFiles(
-      projectDir,
-      agent,
-      extensionDir,
-      manifest.agentFiles ?? [],
-    );
-    results.set(agent.id, installed);
+    try {
+      const installed = await installExtensionAgentFiles(
+        projectDir,
+        agent,
+        extensionDir,
+        manifest.agentFiles ?? [],
+      );
+      results.set(agent.id, installed);
+    } catch (error) {
+      if (error instanceof AgentFileInstallError) {
+        results.set(agent.id, error.installedTargets);
+      }
+      throw error;
+    }
   }
 
   return results;
@@ -153,11 +161,11 @@ export async function removeExtensionAgentFilesForAllAgents(
   return results;
 }
 
-function getManifestRuntimeIds(manifest?: ExtensionManifest | null): string[] {
+export function getManifestRuntimeIds(manifest?: ExtensionManifest | null): string[] {
   return manifest?.agents?.map(agent => agent.id) ?? [];
 }
 
-function assertNoConfiguredRuntimeOrphans(
+export function assertNoConfiguredRuntimeOrphans(
   config: AiFactoryConfig,
   runtimeIds: string[],
   extensionName: string,
@@ -179,7 +187,7 @@ function assertNoConfiguredRuntimeOrphans(
   }
 }
 
-async function assertNoAgentFileConflicts(
+export async function assertNoAgentFileConflicts(
   projectDir: string,
   config: AiFactoryConfig,
   manifest: ExtensionManifest,

--- a/src/core/extension-ops.ts
+++ b/src/core/extension-ops.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import type { AgentInstallation, AiFactoryConfig, ExtensionRecord } from './config.js';
+import { findAgentConfig, hydrateProjectAgentRegistry } from './agents.js';
 import {
   type ExtensionManifest,
   classifyExtensionSource,
@@ -9,9 +10,18 @@ import {
   resolveExtension,
   getExtensionsDir,
   loadExtensionManifest,
+  loadAllExtensions,
   type ResolvedExtension,
 } from './extensions.js';
-import { installSkills, getAvailableSkills, installExtensionSkills, removeExtensionSkills } from './installer.js';
+import {
+  installSkills,
+  getAvailableSkills,
+  getAvailableSubagents,
+  installExtensionAgentFiles,
+  installExtensionSkills,
+  removeExtensionAgentFiles,
+  removeExtensionSkills,
+} from './installer.js';
 import { applySingleExtensionInjections, stripAllExtensionInjections, stripInjectionsByExtensionName } from './injections.js';
 import { configureExtensionMcpServers, removeExtensionMcpServers, validateMcpTemplate, type McpServerConfig } from './mcp.js';
 import { copyDirectory, ensureDir, fileExists, readJsonFile, removeDirectory } from '../utils/fs.js';
@@ -26,6 +36,7 @@ export interface ExtensionAssetInstallResult {
     agentCount: number;
   }>;
   customSkillInstalls: Map<string, string[]>;
+  agentFileInstalls: Map<string, string[]>;
   injectionCount: number;
   configuredMcpServers: string[];
 }
@@ -103,6 +114,131 @@ export async function installExtensionSkillsForAllAgents(
   return results;
 }
 
+export async function installExtensionAgentFilesForAllAgents(
+  projectDir: string,
+  agents: AgentInstallation[],
+  extensionDir: string,
+  manifest: ExtensionManifest,
+): Promise<Map<string, string[]>> {
+  const results = new Map<string, string[]>();
+
+  for (const agent of agents) {
+    const installed = await installExtensionAgentFiles(
+      projectDir,
+      agent,
+      extensionDir,
+      manifest.agentFiles ?? [],
+    );
+    results.set(agent.id, installed);
+  }
+
+  return results;
+}
+
+export async function removeExtensionAgentFilesForAllAgents(
+  projectDir: string,
+  agents: AgentInstallation[],
+  manifest: ExtensionManifest,
+): Promise<Map<string, string[]>> {
+  const results = new Map<string, string[]>();
+
+  for (const agent of agents) {
+    const targets = (manifest.agentFiles ?? [])
+      .filter(agentFile => agentFile.runtime === agent.id)
+      .map(agentFile => agentFile.target);
+    const removed = await removeExtensionAgentFiles(projectDir, agent, targets);
+    results.set(agent.id, removed);
+  }
+
+  return results;
+}
+
+function getManifestRuntimeIds(manifest?: ExtensionManifest | null): string[] {
+  return manifest?.agents?.map(agent => agent.id) ?? [];
+}
+
+function assertNoConfiguredRuntimeOrphans(
+  config: AiFactoryConfig,
+  runtimeIds: string[],
+  extensionName: string,
+  action: 'remove' | 'update',
+): void {
+  if (runtimeIds.length === 0) {
+    return;
+  }
+
+  const configured = config.agents
+    .filter(agent => runtimeIds.includes(agent.id))
+    .map(agent => agent.id);
+
+  if (configured.length > 0) {
+    throw new Error(
+      `Cannot ${action} extension "${extensionName}" because it would orphan configured runtime(s): ${configured.join(', ')}. ` +
+      `Re-run "ai-factory init" without them first.`,
+    );
+  }
+}
+
+async function assertNoAgentFileConflicts(
+  projectDir: string,
+  config: AiFactoryConfig,
+  manifest: ExtensionManifest,
+): Promise<void> {
+  const extensionNames = (config.extensions ?? []).map(extension => extension.name);
+  await hydrateProjectAgentRegistry(projectDir, {
+    extensionNames,
+    extraManifests: [{ name: manifest.name, agents: manifest.agents }],
+  });
+
+  for (const agentFile of manifest.agentFiles ?? []) {
+    const runtime = findAgentConfig(agentFile.runtime);
+    if (!runtime) {
+      throw new Error(
+        `Extension "${manifest.name}" references unknown runtime "${agentFile.runtime}" in agentFiles.`,
+      );
+    }
+
+    if (!runtime.agentsDir || !runtime.agentFileExtension) {
+      throw new Error(
+        `Runtime "${agentFile.runtime}" does not support managed agent files, but extension "${manifest.name}" declares one.`,
+      );
+    }
+
+    const sourceExt = path.extname(agentFile.source).toLowerCase();
+    const targetExt = path.extname(agentFile.target).toLowerCase();
+    if (sourceExt !== runtime.agentFileExtension || targetExt !== runtime.agentFileExtension) {
+      throw new Error(
+        `Extension "${manifest.name}" agent file "${agentFile.target}" must use ${runtime.agentFileExtension} for runtime "${agentFile.runtime}".`,
+      );
+    }
+  }
+
+  const ownership = new Map<string, string>();
+  const otherExtensionNames = extensionNames.filter(name => name !== manifest.name);
+  const installedManifests = await loadAllExtensions(projectDir, otherExtensionNames);
+
+  for (const { manifest: installedManifest } of installedManifests) {
+    for (const agentFile of installedManifest.agentFiles ?? []) {
+      ownership.set(`${agentFile.runtime}::${agentFile.target}`, installedManifest.name);
+    }
+  }
+
+  const bundledClaudeFiles = await getAvailableSubagents();
+  for (const relPath of bundledClaudeFiles) {
+    ownership.set(`claude::${relPath}`, 'AI Factory bundled Claude agent files');
+  }
+
+  for (const agentFile of manifest.agentFiles ?? []) {
+    const key = `${agentFile.runtime}::${agentFile.target}`;
+    const owner = ownership.get(key);
+    if (owner) {
+      throw new Error(
+        `Extension "${manifest.name}" cannot manage "${agentFile.target}" for runtime "${agentFile.runtime}" because it is already owned by ${owner}.`,
+      );
+    }
+  }
+}
+
 /**
  * Collect all replaced skills from extensions, optionally excluding one extension by name.
  */
@@ -166,6 +302,10 @@ export async function removePreviousExtensionState(
   oldRecord?: ExtensionRecord | null,
   oldManifest?: ExtensionManifest | null,
 ): Promise<void> {
+  if (oldManifest?.agentFiles?.length) {
+    await removeExtensionAgentFilesForAllAgents(projectDir, agents, oldManifest);
+  }
+
   await stripInjectionsForAllAgents(projectDir, agents, extensionName, oldManifest);
 
   if (oldManifest?.mcpServers?.length) {
@@ -192,6 +332,15 @@ async function cleanupPartialExtensionState(
   manifest: ExtensionManifest,
   partialAssetInstall?: ExtensionAssetInstallResult | null,
 ): Promise<void> {
+  if (manifest.agentFiles?.length) {
+    for (const agent of agents) {
+      const installedTargets = partialAssetInstall?.agentFileInstalls.get(agent.id) ?? [];
+      if (installedTargets.length > 0) {
+        await removeExtensionAgentFiles(projectDir, agent, installedTargets);
+      }
+    }
+  }
+
   await stripInjectionsForAllAgents(projectDir, agents, extensionName, manifest);
 
   if (manifest.mcpServers?.length) {
@@ -292,6 +441,7 @@ export async function installExtensionAssetsForAllAgents(
     replacedSkills: [],
     replacementOutcomes: [],
     customSkillInstalls: new Map<string, string[]>(),
+    agentFileInstalls: new Map<string, string[]>(),
     injectionCount: 0,
     configuredMcpServers: [],
   };
@@ -361,6 +511,13 @@ export async function installExtensionAssetsForAllAgents(
       }
     }
 
+    if (manifest.agentFiles?.length) {
+      const results = await installExtensionAgentFilesForAllAgents(projectDir, agents, extensionDir, manifest);
+      for (const [agentId, installed] of results) {
+        partialResult.agentFileInstalls.set(agentId, installed);
+      }
+    }
+
     if (manifest.injections?.length) {
       for (const agent of agents) {
         partialResult.injectionCount += await applySingleExtensionInjections(projectDir, agent, extensionDir, manifest);
@@ -417,6 +574,11 @@ export async function commitResolvedExtension(
     ? await loadExtensionManifest(extensionDir)
     : null;
 
+  const removedRuntimeIds = oldManifest
+    ? getManifestRuntimeIds(oldManifest).filter(id => !getManifestRuntimeIds(manifest).includes(id))
+    : [];
+  assertNoConfiguredRuntimeOrphans(config, removedRuntimeIds, manifest.name, 'update');
+  await assertNoAgentFileConflicts(projectDir, config, manifest);
   assertNoReplacementConflicts(extensions, manifest, manifest.name);
 
   let backupDir: string | null = null;
@@ -468,6 +630,12 @@ export async function commitResolvedExtension(
   for (const [agentId, installed] of assetInstall.customSkillInstalls) {
     if (installed.length > 0) {
       log('info', `Skills installed for ${agentId}: ${installed.join(', ')}`);
+    }
+  }
+
+  for (const [agentId, installed] of assetInstall.agentFileInstalls) {
+    if (installed.length > 0) {
+      log('info', `Agent files installed for ${agentId}: ${installed.join(', ')}`);
     }
   }
 

--- a/src/core/extension-ops.ts
+++ b/src/core/extension-ops.ts
@@ -14,7 +14,6 @@ import {
   type ResolvedExtension,
 } from './extensions.js';
 import {
-  AgentFileInstallError,
   installSkills,
   getAvailableSkills,
   getAvailableSubagents,
@@ -133,9 +132,6 @@ export async function installExtensionAgentFilesForAllAgents(
       );
       results.set(agent.id, installed);
     } catch (error) {
-      if (error instanceof AgentFileInstallError) {
-        results.set(agent.id, error.installedTargets);
-      }
       throw error;
     }
   }

--- a/src/core/extensions.ts
+++ b/src/core/extensions.ts
@@ -135,7 +135,7 @@ export async function fetchLatestNpmPackageVersion(packageName: string): Promise
     }
 
     const data = await response.json() as NpmRegistryVersionResponse;
-    if (typeof data.version !== 'string' || !isValidVersionString(data.version)) {
+    if (!isValidVersionString(data.version)) {
       logExtension('warn', 'npm package metadata missing version', {
         sourceType: 'npm',
         packageName,
@@ -253,7 +253,10 @@ export interface ExtensionManifest {
 }
 
 function isSafeRelativeAssetPath(filePath: string): boolean {
-  if (!filePath || path.isAbsolute(filePath)) {
+  const windowsDriveAbsolute = /^[a-zA-Z]:[\\/]/.test(filePath);
+  const windowsUncAbsolute = /^(\\\\|\/\/)/.test(filePath);
+
+  if (!filePath || path.isAbsolute(filePath) || windowsDriveAbsolute || windowsUncAbsolute) {
     return false;
   }
 

--- a/src/core/extensions.ts
+++ b/src/core/extensions.ts
@@ -220,9 +220,17 @@ export interface ExtensionAgentDef {
   displayName: string;
   configDir: string;
   skillsDir: string;
+  agentsDir?: string;
+  agentFileExtension?: '.md' | '.toml';
   settingsFile: string | null;
   supportsMcp: boolean;
   skillsCliAgent: string | null;
+}
+
+export interface ExtensionAgentFile {
+  runtime: string;
+  source: string;
+  target: string;
 }
 
 export interface ExtensionMcpServer {
@@ -237,10 +245,65 @@ export interface ExtensionManifest {
   description?: string;
   commands?: ExtensionCommand[];
   agents?: ExtensionAgentDef[];
+  agentFiles?: ExtensionAgentFile[];
   injections?: ExtensionInjection[];
   skills?: string[];
   replaces?: Record<string, string>;
   mcpServers?: ExtensionMcpServer[];
+}
+
+function isSafeRelativeAssetPath(filePath: string): boolean {
+  if (!filePath || path.isAbsolute(filePath)) {
+    return false;
+  }
+
+  const normalized = filePath.replaceAll('\\', '/').replace(/^\.\//, '');
+
+  return !normalized.split('/').some(segment => segment === '..' || segment.length === 0);
+}
+
+function validateRuntimeAwareAgentDefinition(agent: ExtensionAgentDef, extensionName: string): void {
+  if (!agent.id || !agent.displayName || !agent.configDir || !agent.skillsDir) {
+    throw new Error(
+      `Extension "${extensionName}" defines an invalid runtime. Required fields: id, displayName, configDir, skillsDir.`,
+    );
+  }
+
+  if ((agent.agentsDir && !agent.agentFileExtension) || (!agent.agentsDir && agent.agentFileExtension)) {
+    throw new Error(
+      `Extension "${extensionName}" runtime "${agent.id}" must set both "agentsDir" and "agentFileExtension" together.`,
+    );
+  }
+
+  if (agent.agentsDir && !isSafeRelativeAssetPath(agent.agentsDir)) {
+    throw new Error(
+      `Extension "${extensionName}" runtime "${agent.id}" has an invalid "agentsDir". It must be a safe relative path without "..".`,
+    );
+  }
+
+  if (agent.agentFileExtension && agent.agentFileExtension !== '.md' && agent.agentFileExtension !== '.toml') {
+    throw new Error(
+      `Extension "${extensionName}" runtime "${agent.id}" has unsupported "agentFileExtension": ${agent.agentFileExtension}.`,
+    );
+  }
+}
+
+function validateExtensionAgentFile(manifest: ExtensionManifest, agentFile: ExtensionAgentFile): void {
+  if (!agentFile.runtime) {
+    throw new Error(`Extension "${manifest.name}" has an agentFiles entry without "runtime".`);
+  }
+
+  if (!isSafeRelativeAssetPath(agentFile.source)) {
+    throw new Error(
+      `Extension "${manifest.name}" agentFiles entry for runtime "${agentFile.runtime}" has an invalid "source" path.`,
+    );
+  }
+
+  if (!isSafeRelativeAssetPath(agentFile.target)) {
+    throw new Error(
+      `Extension "${manifest.name}" agentFiles entry for runtime "${agentFile.runtime}" has an invalid "target" path.`,
+    );
+  }
 }
 
 function validateExtensionManifest(manifest: ExtensionManifest): void {
@@ -254,6 +317,27 @@ function validateExtensionManifest(manifest: ExtensionManifest): void {
     for (const baseSkillName of Object.values(manifest.replaces)) {
       validateSkillName(baseSkillName);
     }
+  }
+
+  const runtimeIds = new Set<string>();
+  for (const agent of manifest.agents ?? []) {
+    validateRuntimeAwareAgentDefinition(agent, manifest.name);
+    if (runtimeIds.has(agent.id)) {
+      throw new Error(`Extension "${manifest.name}" declares duplicate runtime id "${agent.id}".`);
+    }
+    runtimeIds.add(agent.id);
+  }
+
+  const ownedTargets = new Set<string>();
+  for (const agentFile of manifest.agentFiles ?? []) {
+    validateExtensionAgentFile(manifest, agentFile);
+    const ownershipKey = `${agentFile.runtime}::${agentFile.target}`;
+    if (ownedTargets.has(ownershipKey)) {
+      throw new Error(
+        `Extension "${manifest.name}" declares duplicate agent file target "${agentFile.target}" for runtime "${agentFile.runtime}".`,
+      );
+    }
+    ownedTargets.add(ownershipKey);
   }
 }
 

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -18,6 +18,7 @@ import {
 } from '../utils/fs.js';
 import type { AgentInstallation, ManagedArtifactState } from './config.js';
 import { getAgentConfig } from './agents.js';
+import type { ExtensionAgentFile } from './extensions.js';
 import { processSkillTemplates, buildTemplateVars, processTemplate } from './template.js';
 import { getTransformer, extractFrontmatterName, replaceFrontmatterName } from './transformer.js';
 
@@ -61,7 +62,9 @@ export interface InstallOptions {
 
 export interface InstallSubagentsOptions {
   projectDir: string;
-  subagentsDir: string;
+  agentId?: string;
+  agentsDir?: string;
+  subagentsDir?: string;
 }
 
 interface ResolvedSkillPaths {
@@ -73,10 +76,11 @@ interface ResolvedSkillPaths {
   flat: boolean;
 }
 
-interface ResolvedSubagentPaths {
+interface ResolvedAgentFilePaths {
   sourceFile: string;
   targetFile: string;
-  relPath: string;
+  sourceRelPath: string;
+  targetRelPath: string;
 }
 
 function normalizeMarkdownForManagedHash(content: string): string {
@@ -172,14 +176,36 @@ function resolveSkillPaths(
   };
 }
 
-function resolveSubagentPaths(projectDir: string, subagentsDir: string, relPath: string): ResolvedSubagentPaths {
-  const sourceRoot = getSubagentsDir();
-  const targetRoot = path.join(projectDir, subagentsDir);
+function ensureTargetWithinRoot(targetRoot: string, targetFile: string): void {
+  const resolvedRoot = path.resolve(targetRoot);
+  const resolvedTarget = path.resolve(targetFile);
+
+  if (resolvedTarget !== resolvedRoot && !resolvedTarget.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new Error(`Agent file target escapes agents directory: ${targetFile}`);
+  }
+}
+
+function resolveAgentFilePaths(
+  projectDir: string,
+  agentsDir: string,
+  sourceRoot: string,
+  sourceRelPath: string,
+  targetRelPath: string = sourceRelPath,
+): ResolvedAgentFilePaths {
+  const targetRoot = path.join(projectDir, agentsDir);
+  const sourceFile = path.join(sourceRoot, sourceRelPath);
+  const targetFile = path.join(targetRoot, targetRelPath);
+  ensureTargetWithinRoot(targetRoot, targetFile);
   return {
-    sourceFile: path.join(sourceRoot, relPath),
-    targetFile: path.join(targetRoot, relPath),
-    relPath,
+    sourceFile,
+    targetFile,
+    sourceRelPath,
+    targetRelPath,
   };
+}
+
+function getBundledAgentFilesSourceDir(agentId: string): string | null {
+  return agentId === 'claude' ? getSubagentsDir() : null;
 }
 
 async function hashInstalledSkill(paths: ResolvedSkillPaths): Promise<string | null> {
@@ -252,8 +278,11 @@ export async function buildManagedSkillsState(
   return state;
 }
 
-export async function getAvailableSubagents(): Promise<string[]> {
-  const packageSubagentsDir = getSubagentsDir();
+export async function getAvailableSubagents(agentId: string = 'claude'): Promise<string[]> {
+  const packageSubagentsDir = getBundledAgentFilesSourceDir(agentId);
+  if (!packageSubagentsDir) {
+    return [];
+  }
   const files = await listFilesRecursive(packageSubagentsDir);
   return files.map(filePath => path.relative(packageSubagentsDir, filePath).replaceAll('\\', '/'));
 }
@@ -263,11 +292,16 @@ async function getManagedSubagentState(
   agentInstallation: AgentInstallation,
   relPath: string,
 ): Promise<ManagedArtifactState | null> {
-  if (!agentInstallation.subagentsDir) {
+  if (!agentInstallation.agentsDir) {
     return null;
   }
 
-  const paths = resolveSubagentPaths(projectDir, agentInstallation.subagentsDir, relPath);
+  const sourceRoot = getBundledAgentFilesSourceDir(agentInstallation.id);
+  if (!sourceRoot) {
+    return null;
+  }
+
+  const paths = resolveAgentFilePaths(projectDir, agentInstallation.agentsDir, sourceRoot, relPath);
   const sourceHash = await hashManagedFile(paths.sourceFile, relPath);
   if (!sourceHash) {
     return null;
@@ -291,7 +325,7 @@ export async function buildManagedSubagentsState(
 ): Promise<Record<string, ManagedArtifactState>> {
   const state: Record<string, ManagedArtifactState> = {};
 
-  if (!agentInstallation.subagentsDir) {
+  if (!agentInstallation.agentsDir) {
     return state;
   }
 
@@ -379,18 +413,27 @@ export async function installSkills(options: InstallOptions): Promise<string[]> 
 }
 
 export async function installSubagents(options: InstallSubagentsOptions): Promise<string[]> {
-  const { projectDir, subagentsDir } = options;
-  const availableSubagents = await getAvailableSubagents();
+  const { projectDir } = options;
+  const agentId = options.agentId ?? 'claude';
+  const agentsDir = options.agentsDir ?? options.subagentsDir;
+  if (!agentsDir) {
+    return [];
+  }
+  const sourceRoot = getBundledAgentFilesSourceDir(agentId);
+  if (!sourceRoot) {
+    return [];
+  }
+  const availableSubagents = await getAvailableSubagents(agentId);
 
   if (availableSubagents.length === 0) {
     return [];
   }
 
-  const targetRoot = path.join(projectDir, subagentsDir);
+  const targetRoot = path.join(projectDir, agentsDir);
   await ensureDir(targetRoot);
 
   for (const relPath of availableSubagents) {
-    const paths = resolveSubagentPaths(projectDir, subagentsDir, relPath);
+    const paths = resolveAgentFilePaths(projectDir, agentsDir, sourceRoot, relPath);
     await copyFile(paths.sourceFile, paths.targetFile);
   }
 
@@ -467,7 +510,7 @@ async function removeSubagentsByName(
   agentInstallation: AgentInstallation,
   subagentNames: string[],
 ): Promise<string[]> {
-  if (!agentInstallation.subagentsDir) {
+  if (!agentInstallation.agentsDir) {
     return [];
   }
 
@@ -475,7 +518,9 @@ async function removeSubagentsByName(
 
   for (const relPath of subagentNames) {
     try {
-      const { targetFile } = resolveSubagentPaths(projectDir, agentInstallation.subagentsDir, relPath);
+      const targetRoot = path.join(projectDir, agentInstallation.agentsDir);
+      const targetFile = path.join(targetRoot, relPath);
+      ensureTargetWithinRoot(targetRoot, targetFile);
       await removeFile(targetFile);
       removed.push(relPath);
     } catch {
@@ -636,7 +681,7 @@ export async function updateSubagents(
   projectDir: string,
   options: UpdateSkillsOptions = {},
 ): Promise<UpdateSubagentsResult> {
-  if (!agentInstallation.subagentsDir) {
+  if (!agentInstallation.agentsDir) {
     return {
       installedSubagents: [],
       entries: [],
@@ -644,14 +689,22 @@ export async function updateSubagents(
   }
 
   const { force = false } = options;
-  const availableSubagents = await getAvailableSubagents();
+  const sourceRoot = getBundledAgentFilesSourceDir(agentInstallation.id);
+  if (!sourceRoot) {
+    return {
+      installedSubagents: [],
+      entries: [],
+    };
+  }
+
+  const availableSubagents = await getAvailableSubagents(agentInstallation.id);
   const availableSet = new Set(availableSubagents);
-  const previousInstalled = agentInstallation.installedSubagents ?? [];
+  const previousInstalled = agentInstallation.installedAgentFiles ?? [];
   const previousInstalledSet = new Set(previousInstalled);
-  const previousManaged = agentInstallation.managedSubagents ?? {};
+  const previousManaged = agentInstallation.managedAgentFiles ?? {};
   const entries: SubagentUpdateEntry[] = [];
 
-  const removedSubagents = previousInstalled.filter(subagent => !availableSet.has(subagent));
+  const removedSubagents = previousInstalled.filter((subagent: string) => !availableSet.has(subagent));
   if (removedSubagents.length > 0) {
     await removeSubagentsByName(projectDir, agentInstallation, removedSubagents);
     for (const subagent of removedSubagents) {
@@ -666,7 +719,7 @@ export async function updateSubagents(
   const shouldInstall = new Map<string, { install: boolean; reason: string }>();
 
   for (const relPath of availableSubagents) {
-    const paths = resolveSubagentPaths(projectDir, agentInstallation.subagentsDir, relPath);
+    const paths = resolveAgentFilePaths(projectDir, agentInstallation.agentsDir, sourceRoot, relPath);
     const sourceHash = await hashManagedFile(paths.sourceFile, relPath);
     const installedHash = await hashManagedFile(paths.targetFile, relPath);
     const previousState = previousManaged[relPath];
@@ -702,7 +755,7 @@ export async function updateSubagents(
     }
 
     if (previousState.installedHash !== installedHash) {
-      console.warn(`Warning: Local modifications detected in subagent "${relPath}" — will be overwritten by update.`);
+      console.warn(`Warning: Local modifications detected in agent file "${relPath}" — will be overwritten by update.`);
       shouldInstall.set(relPath, { install: true, reason: 'installed-hash-drift' });
       continue;
     }
@@ -715,7 +768,7 @@ export async function updateSubagents(
 
   for (const relPath of subagentsToInstall) {
     try {
-      const paths = resolveSubagentPaths(projectDir, agentInstallation.subagentsDir, relPath);
+      const paths = resolveAgentFilePaths(projectDir, agentInstallation.agentsDir, sourceRoot, relPath);
       await copyFile(paths.sourceFile, paths.targetFile);
       installedSubagents.push(relPath);
     } catch {
@@ -753,4 +806,69 @@ export async function updateSubagents(
     installedSubagents: syncedSubagents,
     entries,
   };
+}
+
+export async function installExtensionAgentFiles(
+  projectDir: string,
+  agentInstallation: AgentInstallation,
+  extensionDir: string,
+  agentFiles: ExtensionAgentFile[],
+): Promise<string[]> {
+  const agentsDir = agentInstallation.agentsDir;
+  if (!agentsDir || agentFiles.length === 0) {
+    return [];
+  }
+
+  const installed: string[] = [];
+
+  for (const agentFile of agentFiles) {
+    if (agentFile.runtime !== agentInstallation.id) {
+      continue;
+    }
+
+    try {
+      const paths = resolveAgentFilePaths(
+        projectDir,
+        agentsDir,
+        extensionDir,
+        agentFile.source,
+        agentFile.target,
+      );
+      await copyFile(paths.sourceFile, paths.targetFile);
+      installed.push(agentFile.target);
+    } catch (error) {
+      console.warn(
+        `Warning: Could not install extension agent file "${agentFile.target}" for runtime "${agentInstallation.id}": ${error}`,
+      );
+    }
+  }
+
+  return installed;
+}
+
+export async function removeExtensionAgentFiles(
+  projectDir: string,
+  agentInstallation: AgentInstallation,
+  targets: string[],
+): Promise<string[]> {
+  const agentsDir = agentInstallation.agentsDir;
+  if (!agentsDir || targets.length === 0) {
+    return [];
+  }
+
+  const removed: string[] = [];
+  const targetRoot = path.join(projectDir, agentsDir);
+
+  for (const relPath of targets) {
+    try {
+      const targetFile = path.join(targetRoot, relPath);
+      ensureTargetWithinRoot(targetRoot, targetFile);
+      await removeFile(targetFile);
+      removed.push(relPath);
+    } catch {
+      // File may already be absent.
+    }
+  }
+
+  return removed;
 }

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { existsSync, lstatSync } from 'fs';
 import { createHash } from 'crypto';
 import {
   copyDirectory,
@@ -44,7 +45,7 @@ export interface SubagentUpdateEntry {
 }
 
 export interface UpdateSubagentsResult {
-  installedSubagents: string[];
+  installedAgentFiles: string[];
   entries: SubagentUpdateEntry[];
 }
 
@@ -178,6 +179,14 @@ function resolveSkillPaths(
 
 function ensureTargetWithinRoot(targetRoot: string, targetFile: string): void {
   const resolvedRoot = path.resolve(targetRoot);
+
+  // Reject a symlinked root when it already exists so managed agent files
+  // cannot be redirected outside the project by replacing `.claude/agents`
+  // or another runtime-local agents directory with a symlink.
+  if (existsSync(resolvedRoot) && lstatSync(resolvedRoot).isSymbolicLink()) {
+    throw new Error(`Agent files directory must not be a symbolic link: ${targetRoot}`);
+  }
+
   const resolvedTarget = path.resolve(targetFile);
 
   if (resolvedTarget !== resolvedRoot && !resolvedTarget.startsWith(`${resolvedRoot}${path.sep}`)) {
@@ -683,7 +692,7 @@ export async function updateSubagents(
 ): Promise<UpdateSubagentsResult> {
   if (!agentInstallation.agentsDir) {
     return {
-      installedSubagents: [],
+      installedAgentFiles: [],
       entries: [],
     };
   }
@@ -692,7 +701,7 @@ export async function updateSubagents(
   const sourceRoot = getBundledAgentFilesSourceDir(agentInstallation.id);
   if (!sourceRoot) {
     return {
-      installedSubagents: [],
+      installedAgentFiles: [],
       entries: [],
     };
   }
@@ -803,9 +812,19 @@ export async function updateSubagents(
   const syncedSubagents = availableSubagents.filter(relPath => installedSet.has(relPath) || previousInstalledSet.has(relPath));
 
   return {
-    installedSubagents: syncedSubagents,
+    installedAgentFiles: syncedSubagents,
     entries,
   };
+}
+
+export class AgentFileInstallError extends Error {
+  installedTargets: string[];
+
+  constructor(message: string, installedTargets: string[]) {
+    super(message);
+    this.name = 'AgentFileInstallError';
+    this.installedTargets = installedTargets;
+  }
 }
 
 export async function installExtensionAgentFiles(
@@ -837,8 +856,9 @@ export async function installExtensionAgentFiles(
       await copyFile(paths.sourceFile, paths.targetFile);
       installed.push(agentFile.target);
     } catch (error) {
-      console.warn(
-        `Warning: Could not install extension agent file "${agentFile.target}" for runtime "${agentInstallation.id}": ${error}`,
+      throw new AgentFileInstallError(
+        `Could not install extension agent file "${agentFile.target}" for runtime "${agentInstallation.id}": ${(error as Error).message}`,
+        installed,
       );
     }
   }


### PR DESCRIPTION
This PR adds first-class support for runtime-aware agent files in AI Factory extensions.

Before this change, AI Factory could install bundled Claude subagents from the package, but extensions could not install custom agent assets into runtime-specific agent directories such as `.codex/agents/` or extension-defined agent folders. Extension manifests could declare `agents`, but those runtime definitions were not fully integrated into the active registry or install lifecycle.

This change introduces a new manifest field, `agentFiles`, separate from `agents`.

What this enables:
- Extensions can now install custom Claude agent files into `.claude/agents/`
- Extensions can now install Codex custom agents into `.codex/agents/*.toml`
- Extensions can provide their own runtimes and install agent files into those runtime-specific `agentsDir` locations
- `init`, `update`, `upgrade`, `extension add`, `extension update`, and `extension remove` now participate in the same managed lifecycle for these files

Key changes:
- Added universal agent-file state in `.ai-factory.json`:
  - `agentsDir`
  - `installedAgentFiles`
  - `managedAgentFiles`
- Kept backward compatibility by reading legacy Claude-only keys:
  - `subagentsDir`
  - `installedSubagents`
  - `managedSubagents`
- Hydrated the effective runtime registry from installed extensions before CLI validation and runtime lookups
- Added `agentFiles` manifest validation:
  - runtime must exist
  - source and target must be safe relative paths
  - file extensions must match the runtime format
  - ownership conflicts on `runtime + target` are rejected before install
- Unified bundled Claude agent files and extension-provided agent files under one managed artifact pipeline
- Added rollback and orphan-runtime protection for extension update/remove flows

Why this matters:
- Codex users can now receive custom agents from extensions without manual copying
- Extension authors can ship runtime-specific agent assets in a predictable, managed way
- AI Factory now cleanly separates two concepts:
  - `agents`: define runtimes
  - `agentFiles`: provide agent assets for those runtimes

Also included:
- Documentation updates for extensions, configuration, getting started, and Claude subagents
- Smoke test coverage for:
  - Codex agent files
  - dynamic runtime registration
  - extension lifecycle install/update/remove
  - legacy config migration
  - conflict and orphan-runtime protections
- Updated example extension showing `agentFiles` for Claude, Codex, and an extension-defined runtime
