### PR TITLE
fix(aif): resolve localization before setup artifacts

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -30,7 +30,9 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 
 - If both language keys already exist in `config.yaml`, `/aif` reuses them and does not ask again.
 - If only one language key exists, `/aif` keeps the existing value and resolves only the missing key via `config.yaml` → `AGENTS.md` → `CLAUDE.md` → `RULES.md` → user question.
-- After language resolution, `/aif` refreshes `config.yaml` from `skills/aif/references/config-template.yaml` before writing `.ai-factory/DESCRIPTION.md`, `.ai-factory/rules/base.md`, `AGENTS.md`, or invoking `/aif-architecture`.
+- When `.ai-factory/config.yaml` already exists, `/aif` merges the resolved `language.ui` / `language.artifacts` values into the existing file and preserves other sections such as `paths.*`, `git.*`, `workflow.*`, and `rules.*`.
+- `/aif` preserves an existing `language.technical_terms` value and defaults it to `keep` only when the key is missing.
+- After language resolution, `/aif` updates `config.yaml` from `skills/aif/references/config-template.yaml` before writing `.ai-factory/DESCRIPTION.md`, `.ai-factory/rules/base.md`, `AGENTS.md`, or invoking `/aif-architecture`.
 - This ordering keeps all setup-time artifacts in a single run aligned to one `language.artifacts` value, while prompts, questions, summaries, and next-step guidance use `language.ui`.
 
 ## Schema Summary
@@ -51,7 +53,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 |-----|---------|----------------|-------|
 | `language.ui` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-reference`, `/aif-rules`, `/aif-security-checklist` | UI language for prompts, questions, and summaries; `/aif` resolves it before downstream setup questions |
 | `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-roadmap`, `/aif-implement`, `/aif-loop`, `/aif-docs`, `/aif-evolve` | Language for generated artifacts; `/aif` locks it before the first setup artifact so DESCRIPTION/rules base/AGENTS/ARCHITECTURE stay aligned in one run |
-| `language.technical_terms` | `keep` | No dedicated built-in reader yet | Present in schema and template; currently written by `/aif` and reserved for future translation policy |
+| `language.technical_terms` | `keep` | No dedicated built-in reader yet | Present in schema and template; `/aif` preserves an existing value when present and otherwise writes the default `keep`, while the wider translation policy stays reserved for future use |
 
 ### `paths`
 
@@ -107,7 +109,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 
 | Skill | Reads config | Writes config | Write scope |
 |-------|--------------|---------------|-------------|
-| `/aif` | Yes | Yes | Creates or refreshes the whole `config.yaml` during setup, after early language resolution and before the first setup artifact |
+| `/aif` | Yes | Yes | Creates or refreshes `config.yaml` during setup by merging resolved language values into any existing file after early language resolution and before the first setup artifact |
 | `/aif-rules` | Yes | Yes, limited | Adds or updates `rules.<area>` registrations when creating area rules; may bootstrap a minimal config file when the first area rule is created |
 
 ### Config Readers

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -24,6 +24,15 @@ Use it when you need to know:
 
 All other built-in skills treat `config.yaml` as read-only input.
 
+## `/aif` Setup Order
+
+During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately after mode detection and before it writes any setup artifact.
+
+- If both language keys already exist in `config.yaml`, `/aif` reuses them and does not ask again.
+- If only one language key exists, `/aif` keeps the existing value and resolves only the missing key via `config.yaml` → `AGENTS.md` → `CLAUDE.md` → `RULES.md` → user question.
+- After language resolution, `/aif` refreshes `config.yaml` from `skills/aif/references/config-template.yaml` before writing `.ai-factory/DESCRIPTION.md`, `.ai-factory/rules/base.md`, `AGENTS.md`, or invoking `/aif-architecture`.
+- This ordering keeps all setup-time artifacts in a single run aligned to one `language.artifacts` value, while prompts, questions, summaries, and next-step guidance use `language.ui`.
+
 ## Schema Summary
 
 | Section | Purpose |
@@ -40,8 +49,8 @@ All other built-in skills treat `config.yaml` as read-only input.
 
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
-| `language.ui` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-reference`, `/aif-rules`, `/aif-security-checklist` | UI language for prompts, questions, and summaries |
-| `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-roadmap`, `/aif-implement`, `/aif-loop`, `/aif-docs`, `/aif-evolve` | Language for generated artifacts |
+| `language.ui` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-reference`, `/aif-rules`, `/aif-security-checklist` | UI language for prompts, questions, and summaries; `/aif` resolves it before downstream setup questions |
+| `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-roadmap`, `/aif-implement`, `/aif-loop`, `/aif-docs`, `/aif-evolve` | Language for generated artifacts; `/aif` locks it before the first setup artifact so DESCRIPTION/rules base/AGENTS/ARCHITECTURE stay aligned in one run |
 | `language.technical_terms` | `keep` | No dedicated built-in reader yet | Present in schema and template; currently written by `/aif` and reserved for future translation policy |
 
 ### `paths`
@@ -98,7 +107,7 @@ All other built-in skills treat `config.yaml` as read-only input.
 
 | Skill | Reads config | Writes config | Write scope |
 |-------|--------------|---------------|-------------|
-| `/aif` | Yes | Yes | Creates or refreshes the whole `config.yaml` during setup |
+| `/aif` | Yes | Yes | Creates or refreshes the whole `config.yaml` during setup, after early language resolution and before the first setup artifact |
 | `/aif-rules` | Yes | Yes, limited | Adds or updates `rules.<area>` registrations when creating area rules; may bootstrap a minimal config file when the first area rule is created |
 
 ### Config Readers

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -213,6 +213,27 @@ fi
 
 # /aif localization contract regression checks
 AIF_SKILL="$ROOT_DIR/skills/aif/SKILL.md"
+MODE2_DESCRIPTION_SECTION="$(awk '
+    /^\*\*Step 3: Create \.ai-factory\/DESCRIPTION\.md\*\*$/ { capture=1 }
+    capture { print }
+    /^\*\*Step 4: Search & Install Skills\*\*$/ { if (capture) exit }
+' "$AIF_SKILL")"
+AGENTS_TEMPLATE_SECTION="$(awk '
+    /^## AGENTS\.md Generation$/ { in_section=1 }
+    in_section && /^\*\*Template:\*\*$/ { capture=1 }
+    capture { print }
+    capture && /^\*\*Rules for AGENTS\.md:\*\*$/ { exit }
+' "$AIF_SKILL")"
+SUMMARY_SECTION="$(awk '
+    /^Present the completion summary and next-step recommendations in resolved `language\.ui`\. Cover:$/ { capture=1 }
+    capture { print }
+    /^\*\*For existing projects \(Mode 1\), also suggest next steps:\*\*$/ { if (capture) exit }
+' "$AIF_SKILL")"
+EXISTING_PROJECT_SUGGESTIONS_SECTION="$(awk '
+    /^Present these suggestions in resolved `language\.ui`:$/ { capture=1 }
+    capture { print }
+    /^Present these as `AskUserQuestion` with multi-select options:$/ { if (capture) exit }
+' "$AIF_SKILL")"
 
 if grep -Fq 'Immediately after determining Mode 1, Mode 2, or Mode 3, resolve the project language settings for the entire `/aif` run.' "$AIF_SKILL"; then
     pass "/aif resolves language immediately after mode detection"
@@ -225,6 +246,20 @@ if grep -Fq 'Write or update `.ai-factory/config.yaml` immediately after resolvi
     pass "/aif writes config before first artifact and /aif-architecture"
 else
     fail "/aif config write ordering contract missing"
+fi
+
+if grep -Fq 'If `.ai-factory/config.yaml` already exists, merge the resolved language values into the existing file instead of replacing the rest of the document.' "$AIF_SKILL" \
+   && grep -Fq 'Preserve existing `paths.*`, `git.*`, `workflow.*`, `rules.*`, and any other non-language keys already present in the file.' "$AIF_SKILL"; then
+    pass "/aif preserves non-language config when updating resolved languages"
+else
+    fail "/aif config merge contract missing for existing config"
+fi
+
+if grep -Fq '`language.technical_terms` — preserve the existing value if it is already set; default to `keep` only when the key is missing' "$AIF_SKILL" \
+   && grep -Fq 'Preserve `language.technical_terms` from existing config when present; otherwise set it to `keep` when writing config.' "$AIF_SKILL"; then
+    pass "/aif preserves language.technical_terms semantics"
+else
+    fail "/aif language.technical_terms preservation contract missing"
 fi
 
 if grep -Fq 'use for all `AskUserQuestion` prompts, intermediate explanations, final summary, and next-step recommendations' "$AIF_SKILL" \
@@ -246,48 +281,87 @@ else
     pass "no hard-coded English DESCRIPTION placeholder in /aif"
 fi
 
-if grep -Fq '# [Localized project title in resolved artifacts language]' "$AIF_SKILL" \
-   && grep -Fq '## [Localized heading: Tech Stack]' "$AIF_SKILL" \
-   && grep -Fq '**[Localized label: Programming language]:** [user choice]' "$AIF_SKILL"; then
+if printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '# [Localized project title in resolved artifacts language]' \
+   && printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '## [Localized heading: Tech Stack]' \
+   && printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '**[Localized label: Programming language]:** [user choice]'; then
     pass "/aif DESCRIPTION template uses localized artifact placeholders"
 else
     fail "/aif DESCRIPTION template localization placeholders missing"
 fi
 
-if grep -Fq '# Project: [Project Name]' "$AIF_SKILL" \
-   || grep -Fq '## Overview' "$AIF_SKILL" \
-   || grep -Fq '## Core Features' "$AIF_SKILL" \
-   || grep -Fq '## Tech Stack' "$AIF_SKILL" \
-   || grep -Fq '## Architecture Notes' "$AIF_SKILL" \
-   || grep -Fq '## Non-Functional Requirements' "$AIF_SKILL"; then
+MODE2_CONFIG_LINE=$(printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -nF 'Write `.ai-factory/config.yaml` from `skills/aif/references/config-template.yaml` before saving this file.' | cut -d: -f1 | head -n1)
+MODE2_SAVE_LINE=$(printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -nF 'Save to `.ai-factory/DESCRIPTION.md`.' | cut -d: -f1 | head -n1)
+if [[ -n "$MODE2_CONFIG_LINE" && -n "$MODE2_SAVE_LINE" && "$MODE2_CONFIG_LINE" -lt "$MODE2_SAVE_LINE" ]]; then
+    pass "/aif Mode 2 writes config before saving DESCRIPTION.md"
+else
+    fail "/aif Mode 2 DESCRIPTION/config ordering is wrong"
+fi
+
+if printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '# Project: [Project Name]' \
+   || printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '## Overview' \
+   || printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '## Core Features' \
+   || printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '## Tech Stack' \
+   || printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '## Architecture Notes' \
+   || printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '## Non-Functional Requirements'; then
     fail "English DESCRIPTION template headings reintroduced in /aif"
 else
     pass "no English DESCRIPTION template headings in /aif"
 fi
 
-if grep -Fq '| [Localized header: File] | [Localized header: Purpose] |' "$AIF_SKILL" \
-   && grep -Fq '| [Localized header: Document] | [Localized header: Path] | [Localized header: Description] |' "$AIF_SKILL" \
-   && grep -Fq '**[Localized label: Framework]:** [framework]' "$AIF_SKILL" \
-   && grep -Fq '[Localized shell-command decomposition rule in resolved artifacts language]' "$AIF_SKILL"; then
+if printf '%s\n' "$AGENTS_TEMPLATE_SECTION" | grep -Fq '| [Localized header: File] | [Localized header: Purpose] |' \
+   && printf '%s\n' "$AGENTS_TEMPLATE_SECTION" | grep -Fq '| [Localized header: Document] | [Localized header: Path] | [Localized header: Description] |' \
+   && printf '%s\n' "$AGENTS_TEMPLATE_SECTION" | grep -Fq '**[Localized label: Framework]:** [framework]' \
+   && printf '%s\n' "$AGENTS_TEMPLATE_SECTION" | grep -Fq '[Localized shell-command decomposition rule in resolved artifacts language]'; then
     pass "/aif AGENTS template uses localized artifact placeholders"
 else
     fail "/aif AGENTS template localization placeholders missing"
 fi
 
-if grep -Fq '| File | Purpose |' "$AIF_SKILL" \
-   || grep -Fq '| Document | Path | Description |' "$AIF_SKILL" \
-   || grep -Fq 'Project landing page' "$AIF_SKILL" \
-   || grep -Fq '**Programming language:** [language]' "$AIF_SKILL" \
-   || grep -Fq '**Framework:** [framework]' "$AIF_SKILL" \
-   || grep -Fq '**Database:** [database]' "$AIF_SKILL" \
-   || grep -Fq '**ORM:** [orm]' "$AIF_SKILL" \
-   || grep -Fq 'Never combine shell commands with `&&`, `||`, or `;`' "$AIF_SKILL" \
-   || grep -Fq -- '- Project description:' "$AIF_SKILL" \
-   || grep -Fq -- '- Skills installed:' "$AIF_SKILL" \
-   || grep -Fq -- '- Next steps:' "$AIF_SKILL"; then
-    fail "English AGENTS or UI summary template text reintroduced in /aif"
+if printf '%s\n' "$AGENTS_TEMPLATE_SECTION" | grep -Fq '| File | Purpose |' \
+   || printf '%s\n' "$AGENTS_TEMPLATE_SECTION" | grep -Fq '| Document | Path | Description |' \
+   || printf '%s\n' "$AGENTS_TEMPLATE_SECTION" | grep -Fq 'Project landing page' \
+   || printf '%s\n' "$AGENTS_TEMPLATE_SECTION" | grep -Fq '**Programming language:** [language]' \
+   || printf '%s\n' "$AGENTS_TEMPLATE_SECTION" | grep -Fq '**Framework:** [framework]' \
+   || printf '%s\n' "$AGENTS_TEMPLATE_SECTION" | grep -Fq '**Database:** [database]' \
+   || printf '%s\n' "$AGENTS_TEMPLATE_SECTION" | grep -Fq '**ORM:** [orm]' \
+   || printf '%s\n' "$AGENTS_TEMPLATE_SECTION" | grep -Fq 'Never combine shell commands with `&&`, `||`, or `;`'; then
+    fail "English AGENTS template text reintroduced in /aif"
 else
-    pass "no English AGENTS or UI summary template text in /aif"
+    pass "no English AGENTS template text in /aif"
+fi
+
+if printf '%s\n' "$SUMMARY_SECTION" | grep -Fq '[Localized completion heading in `language.ui`]' \
+   && printf '%s\n' "$SUMMARY_SECTION" | grep -Fq '[Localized roadmap recommendation in `language.ui`]' \
+   && printf '%s\n' "$SUMMARY_SECTION" | grep -Fq '[Localized execution recommendation in `language.ui`]'; then
+    pass "/aif summary template uses localized UI placeholders"
+else
+    fail "/aif summary template localization placeholders missing"
+fi
+
+if printf '%s\n' "$SUMMARY_SECTION" | grep -Fq -- '- Project description:' \
+   || printf '%s\n' "$SUMMARY_SECTION" | grep -Fq -- '- Skills installed:' \
+   || printf '%s\n' "$SUMMARY_SECTION" | grep -Fq -- '- Next steps:'; then
+    fail "English summary template text reintroduced in /aif"
+else
+    pass "no English summary template text in /aif"
+fi
+
+if printf '%s\n' "$EXISTING_PROJECT_SUGGESTIONS_SECTION" | grep -Fq '[Localized documentation recommendation in `language.ui`]' \
+   && printf '%s\n' "$EXISTING_PROJECT_SUGGESTIONS_SECTION" | grep -Fq '[Localized CI recommendation in `language.ui`]' \
+   && printf '%s\n' "$EXISTING_PROJECT_SUGGESTIONS_SECTION" | grep -Fq '[Localized containerization recommendation in `language.ui`]'; then
+    pass "/aif existing-project suggestions use localized UI placeholders"
+else
+    fail "/aif existing-project suggestions localization placeholders missing"
+fi
+
+if printf '%s\n' "$EXISTING_PROJECT_SUGGESTIONS_SECTION" | grep -Fq 'Generate project documentation' \
+   || printf '%s\n' "$EXISTING_PROJECT_SUGGESTIONS_SECTION" | grep -Fq 'Add project-specific rules and conventions' \
+   || printf '%s\n' "$EXISTING_PROJECT_SUGGESTIONS_SECTION" | grep -Fq 'Configure build scripts and automation' \
+   || printf '%s\n' "$EXISTING_PROJECT_SUGGESTIONS_SECTION" | grep -Fq 'Set up CI/CD pipeline' \
+   || printf '%s\n' "$EXISTING_PROJECT_SUGGESTIONS_SECTION" | grep -Fq 'Containerize the project'; then
+    fail "English existing-project suggestions reintroduced in /aif"
+else
+    pass "no English existing-project suggestions in /aif"
 fi
 
 # No hardcoded agent-specific values (must use {{template_vars}})

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -211,6 +211,85 @@ else
     fail "found $DOTTED_REFS dotted invocations in docs"
 fi
 
+# /aif localization contract regression checks
+AIF_SKILL="$ROOT_DIR/skills/aif/SKILL.md"
+
+if grep -Fq 'Immediately after determining Mode 1, Mode 2, or Mode 3, resolve the project language settings for the entire `/aif` run.' "$AIF_SKILL"; then
+    pass "/aif resolves language immediately after mode detection"
+else
+    fail "/aif language resolution order missing immediate post-mode contract"
+fi
+
+if grep -Fq 'Write or update `.ai-factory/config.yaml` immediately after resolving the run-scoped language state.' "$AIF_SKILL" \
+   && grep -Fq 'This write MUST happen before writing the first setup artifact and before invoking `/aif-architecture`.' "$AIF_SKILL"; then
+    pass "/aif writes config before first artifact and /aif-architecture"
+else
+    fail "/aif config write ordering contract missing"
+fi
+
+if grep -Fq 'use for all `AskUserQuestion` prompts, intermediate explanations, final summary, and next-step recommendations' "$AIF_SKILL" \
+   && grep -Fq 'use for all setup-time text artifacts created in this run:' "$AIF_SKILL"; then
+    pass "/aif documents language.ui vs language.artifacts split"
+else
+    fail "/aif language.ui vs language.artifacts split missing"
+fi
+
+if grep -Fq 'After creating DESCRIPTION.md, resolve the project language settings.' "$AIF_SKILL"; then
+    fail "late language resolution wording reintroduced in /aif"
+else
+    pass "no late language resolution wording in /aif"
+fi
+
+if grep -Fq '[Enhanced, clear description of the project in English]' "$AIF_SKILL"; then
+    fail "hard-coded English DESCRIPTION placeholder reintroduced in /aif"
+else
+    pass "no hard-coded English DESCRIPTION placeholder in /aif"
+fi
+
+if grep -Fq '# [Localized project title in resolved artifacts language]' "$AIF_SKILL" \
+   && grep -Fq '## [Localized heading: Tech Stack]' "$AIF_SKILL" \
+   && grep -Fq '**[Localized label: Programming language]:** [user choice]' "$AIF_SKILL"; then
+    pass "/aif DESCRIPTION template uses localized artifact placeholders"
+else
+    fail "/aif DESCRIPTION template localization placeholders missing"
+fi
+
+if grep -Fq '# Project: [Project Name]' "$AIF_SKILL" \
+   || grep -Fq '## Overview' "$AIF_SKILL" \
+   || grep -Fq '## Core Features' "$AIF_SKILL" \
+   || grep -Fq '## Tech Stack' "$AIF_SKILL" \
+   || grep -Fq '## Architecture Notes' "$AIF_SKILL" \
+   || grep -Fq '## Non-Functional Requirements' "$AIF_SKILL"; then
+    fail "English DESCRIPTION template headings reintroduced in /aif"
+else
+    pass "no English DESCRIPTION template headings in /aif"
+fi
+
+if grep -Fq '| [Localized header: File] | [Localized header: Purpose] |' "$AIF_SKILL" \
+   && grep -Fq '| [Localized header: Document] | [Localized header: Path] | [Localized header: Description] |' "$AIF_SKILL" \
+   && grep -Fq '**[Localized label: Framework]:** [framework]' "$AIF_SKILL" \
+   && grep -Fq '[Localized shell-command decomposition rule in resolved artifacts language]' "$AIF_SKILL"; then
+    pass "/aif AGENTS template uses localized artifact placeholders"
+else
+    fail "/aif AGENTS template localization placeholders missing"
+fi
+
+if grep -Fq '| File | Purpose |' "$AIF_SKILL" \
+   || grep -Fq '| Document | Path | Description |' "$AIF_SKILL" \
+   || grep -Fq 'Project landing page' "$AIF_SKILL" \
+   || grep -Fq '**Programming language:** [language]' "$AIF_SKILL" \
+   || grep -Fq '**Framework:** [framework]' "$AIF_SKILL" \
+   || grep -Fq '**Database:** [database]' "$AIF_SKILL" \
+   || grep -Fq '**ORM:** [orm]' "$AIF_SKILL" \
+   || grep -Fq 'Never combine shell commands with `&&`, `||`, or `;`' "$AIF_SKILL" \
+   || grep -Fq -- '- Project description:' "$AIF_SKILL" \
+   || grep -Fq -- '- Skills installed:' "$AIF_SKILL" \
+   || grep -Fq -- '- Next steps:' "$AIF_SKILL"; then
+    fail "English AGENTS or UI summary template text reintroduced in /aif"
+else
+    pass "no English AGENTS or UI summary template text in /aif"
+fi
+
 # No hardcoded agent-specific values (must use {{template_vars}})
 # skills_dir patterns
 HARDCODED_SKILLS_DIR=$(grep -rE '\.(claude|cursor|codex|github|gemini|junie|qwen|windsurf|warp)/skills' "$ROOT_DIR/skills/" "$ROOT_DIR/subagents/" --include='*.md' 2>/dev/null | grep -v '{{' | wc -l | tr -d ' ' || true)

--- a/skills/aif-architecture/SKILL.md
+++ b/skills/aif-architecture/SKILL.md
@@ -18,6 +18,8 @@ Generate `.ai-factory/ARCHITECTURE.md` with architecture decisions tailored to t
 - **Paths:** `paths.description` and `paths.architecture`
 - **Language:** `language.ui` for prompts and `language.artifacts` for generated architecture content
 
+When invoked by `/aif`, assume `.ai-factory/config.yaml` has already been written for the current setup run and already contains the resolved `language.ui` / `language.artifacts` values.
+
 If config.yaml doesn't exist, use defaults:
 - DESCRIPTION.md: `.ai-factory/DESCRIPTION.md`
 - ARCHITECTURE.md: `.ai-factory/ARCHITECTURE.md`

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -123,7 +123,7 @@ Immediately after determining Mode 1, Mode 2, or Mode 3, resolve the project lan
 **Run-scoped language state:**
 - `language.ui` — use for all `AskUserQuestion` prompts, intermediate explanations, final summary, and next-step recommendations
 - `language.artifacts` — use for all setup-time text artifacts created in this run: `.ai-factory/DESCRIPTION.md`, `.ai-factory/rules/base.md`, `AGENTS.md`, and `.ai-factory/ARCHITECTURE.md` via `/aif-architecture`
-- `language.technical_terms` — keep current semantics: `keep`
+- `language.technical_terms` — preserve the existing value if it is already set; default to `keep` only when the key is missing
 
 **Resolution order for each missing key:**
 1. `.ai-factory/config.yaml`
@@ -137,7 +137,8 @@ Immediately after determining Mode 1, Mode 2, or Mode 3, resolve the project lan
 2. If both keys are already set, reuse them and do not ask again.
 3. If only one key is missing, resolve only that missing key via the priority order above. Ask the user only for the missing value if repository context is still insufficient.
 4. If both keys are missing and repository context is insufficient, the first user question after mode detection MUST be about `UI language`, and the second language question MUST be about `Artifact language`.
-5. Keep the resolved language state fixed for the entire `/aif` run. Do not generate setup-time text artifacts in a different language later in the same run.
+5. Preserve `language.technical_terms` from existing config when present; otherwise set it to `keep` when writing config.
+6. Keep the resolved language state fixed for the entire `/aif` run. Do not generate setup-time text artifacts in a different language later in the same run.
 
 All user-facing text examples below are structure examples only. Ask them in resolved `language.ui`, never hard-code English when another UI language was resolved.
 
@@ -189,7 +190,10 @@ Options:
 **Persist resolved settings in `.ai-factory/config.yaml`:**
 
 - Use `skills/aif/references/config-template.yaml` as the source template.
-- Preserve the inline comments so developers can edit `config.yaml` manually later.
+- If `.ai-factory/config.yaml` already exists, merge the resolved language values into the existing file instead of replacing the rest of the document.
+- Replace only `language.ui` and `language.artifacts`; preserve existing `language.technical_terms` if it is already set, otherwise default it to `keep`.
+- Preserve existing `paths.*`, `git.*`, `workflow.*`, `rules.*`, and any other non-language keys already present in the file.
+- Preserve the inline comments from the template so developers can edit `config.yaml` manually later.
 - Fill in the resolved values; do **not** replace the file with a stripped-down minimal YAML blob.
 - Write or update `.ai-factory/config.yaml` immediately after resolving the run-scoped language state.
 - This write MUST happen before writing the first setup artifact and before invoking `/aif-architecture`.
@@ -198,7 +202,7 @@ Options:
 language:
   ui: <resolved-ui-language>
   artifacts: <resolved-artifacts-language>
-  technical_terms: keep
+  technical_terms: <existing-value-or-keep-when-missing>
 
 paths:
   description: .ai-factory/DESCRIPTION.md
@@ -344,7 +348,8 @@ Proceed? [Y/n]
 
 1. Create directory: `mkdir -p .ai-factory`
 2. **Create config.yaml first** (from language resolution step):
-   - Write `.ai-factory/config.yaml` from `skills/aif/references/config-template.yaml`, preserving comments and filling in the resolved values
+   - Write `.ai-factory/config.yaml` from `skills/aif/references/config-template.yaml`, merging resolved language keys into any existing config while preserving comments and non-language sections
+   - Preserve existing `language.technical_terms` when present; default it to `keep` only if the key is missing
    - Keep the resolved `language.ui` / `language.artifacts` values as the source of truth for the rest of the run
 3. Save `.ai-factory/DESCRIPTION.md` in resolved `language.artifacts`
 4. **Create rules/base.md**:
@@ -421,8 +426,8 @@ After user confirms choices, create specification in resolved `language.artifact
 - [Localized label: Security]: [relevant security considerations]
 ```
 
-Save to `.ai-factory/DESCRIPTION.md`.
 Write `.ai-factory/config.yaml` from `skills/aif/references/config-template.yaml` before saving this file.
+Save to `.ai-factory/DESCRIPTION.md`.
 
 ```bash
 mkdir -p .ai-factory
@@ -646,18 +651,18 @@ Present the completion summary and next-step recommendations in resolved `langua
 **For existing projects (Mode 1), also suggest next steps:**
 
 Present these suggestions in resolved `language.ui`:
-- `/aif-docs` — Generate project documentation
-- `/aif-rules` — Add project-specific rules and conventions
-- `/aif-build-automation` — Configure build scripts and automation
-- `/aif-ci` — Set up CI/CD pipeline
-- `/aif-dockerize` — Containerize the project
+- `/aif-docs` — [Localized documentation recommendation in `language.ui`]
+- `/aif-rules` — [Localized rules recommendation in `language.ui`]
+- `/aif-build-automation` — [Localized build-automation recommendation in `language.ui`]
+- `/aif-ci` — [Localized CI recommendation in `language.ui`]
+- `/aif-dockerize` — [Localized containerization recommendation in `language.ui`]
 
 Present these as `AskUserQuestion` with multi-select options:
-1. Generate docs (`/aif-docs`)
-2. Build automation (`/aif-build-automation`)
-3. CI/CD (`/aif-ci`)
-4. Dockerize (`/aif-dockerize`)
-5. Skip — I'll do it later
+1. [Localized docs option label in `language.ui`] (`/aif-docs`)
+2. [Localized build-automation option label in `language.ui`] (`/aif-build-automation`)
+3. [Localized CI option label in `language.ui`] (`/aif-ci`)
+4. [Localized docker option label in `language.ui`] (`/aif-dockerize`)
+5. [Localized skip option label in `language.ui`]
 
 If user selects one or more → invoke the selected skills sequentially.
 If user skips → done.

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -118,19 +118,33 @@ Check $ARGUMENTS:
 
 ## Language Resolution
 
-After creating DESCRIPTION.md, resolve the project language settings.
+Immediately after determining Mode 1, Mode 2, or Mode 3, resolve the project language settings for the entire `/aif` run.
 
-**Resolution order:**
-1. `.ai-factory/config.yaml` → use `language.ui` and `language.artifacts` if present
-2. `AGENTS.md` → look for language hints in comments or content
-3. `CLAUDE.md` → look for language preferences
-4. `RULES.md` → look for language rules
-5. Ask user if not found
+**Run-scoped language state:**
+- `language.ui` — use for all `AskUserQuestion` prompts, intermediate explanations, final summary, and next-step recommendations
+- `language.artifacts` — use for all setup-time text artifacts created in this run: `.ai-factory/DESCRIPTION.md`, `.ai-factory/rules/base.md`, `AGENTS.md`, and `.ai-factory/ARCHITECTURE.md` via `/aif-architecture`
+- `language.technical_terms` — keep current semantics: `keep`
 
-**Questions to ask (if config.yaml doesn't exist):**
+**Resolution order for each missing key:**
+1. `.ai-factory/config.yaml`
+2. `AGENTS.md`
+3. `CLAUDE.md`
+4. `RULES.md`
+5. Ask the user
+
+**Resolution workflow:**
+1. Read `.ai-factory/config.yaml` if it exists and preserve any already-set `language.ui` / `language.artifacts` values.
+2. If both keys are already set, reuse them and do not ask again.
+3. If only one key is missing, resolve only that missing key via the priority order above. Ask the user only for the missing value if repository context is still insufficient.
+4. If both keys are missing and repository context is insufficient, the first user question after mode detection MUST be about `UI language`, and the second language question MUST be about `Artifact language`.
+5. Keep the resolved language state fixed for the entire `/aif` run. Do not generate setup-time text artifacts in a different language later in the same run.
+
+All user-facing text examples below are structure examples only. Ask them in resolved `language.ui`, never hard-code English when another UI language was resolved.
+
+**Questions to ask only when a value is still missing:**
 
 ```
-AskUserQuestion: What language should I use for communication and artifacts?
+AskUserQuestion: What UI language should I use for communication during this `/aif` run?
 
 Options:
 1. English (en) — Default
@@ -139,16 +153,19 @@ Options:
 4. Other — specify manually
 ```
 
-**If user selects a non-English language, ask:**
-
 ```
-AskUserQuestion: What should be translated?
+AskUserQuestion: What artifact language should I use for generated files in this `/aif` run?
 
 Options:
-1. Communication only — AI responds in selected language, artifacts in English
-2. Communication and artifacts — Both AI responses and generated files in selected language
-3. Artifacts only — AI responds in English, generates files in selected language
+1. Same as `language.ui` (Recommended)
+2. English (en)
+3. Different language — specify manually
 ```
+
+**Language mapping notes:**
+- `language.ui != English` + `language.artifacts = English` → communication-only localization
+- `language.ui = English` + `language.artifacts != English` → artifacts-only localization
+- If only one language key was missing, ask only the question for that missing key
 
 **Git workflow detection (if `config.yaml` is missing or the `git:` section is incomplete):**
 
@@ -169,11 +186,13 @@ Options:
 2. Stay on the current branch - /aif-plan full still creates a rich full plan, but without creating a new branch
 ```
 
-**Store resolved settings in `.ai-factory/config.yaml`:**
+**Persist resolved settings in `.ai-factory/config.yaml`:**
 
 - Use `skills/aif/references/config-template.yaml` as the source template.
 - Preserve the inline comments so developers can edit `config.yaml` manually later.
 - Fill in the resolved values; do **not** replace the file with a stripped-down minimal YAML blob.
+- Write or update `.ai-factory/config.yaml` immediately after resolving the run-scoped language state.
+- This write MUST happen before writing the first setup artifact and before invoking `/aif-architecture`.
 
 ```yaml
 language:
@@ -219,36 +238,36 @@ rules:
 
 **Create `.ai-factory/rules/base.md` from codebase evidence:**
 
-After language resolution, analyze the codebase to detect:
+After language resolution and config write, analyze the codebase to detect:
 - Naming conventions (camelCase, snake_case, PascalCase)
 - Module boundaries (src/core/, src/cli/, src/utils/)
 - Error handling patterns (try/catch, error codes)
 - Logging patterns (console.log, winston, pino)
 - Test patterns (jest, mocha, vitest)
 
-Create `.ai-factory/rules/base.md` with detected conventions:
+Create `.ai-factory/rules/base.md` with detected conventions. Use resolved `language.artifacts` for all headings and service text in this file:
 
 ```markdown
-# Project Base Rules
+# [Localized title for project base rules in resolved artifacts language]
 
-> Auto-detected conventions from codebase analysis. Edit as needed.
+> [Localized note in resolved artifacts language: Auto-detected conventions from codebase analysis. Edit as needed.]
 
-## Naming Conventions
+## [Localized heading: Naming Conventions]
 
 - Files: [detected pattern]
 - Variables: [detected pattern]
 - Functions: [detected pattern]
 - Classes: [detected pattern]
 
-## Module Structure
+## [Localized heading: Module Structure]
 
 - [detected module boundaries]
 
-## Error Handling
+## [Localized heading: Error Handling]
 
 - [detected error handling pattern]
 
-## Logging
+## [Localized heading: Logging]
 
 - [detected logging pattern]
 ```
@@ -271,18 +290,18 @@ Read these files (if they exist):
 - `prisma/schema.prisma` → Database schema
 - Directory structure (`src/`, `app/`, `api/`, etc.)
 
-**Step 2: Generate .ai-factory/DESCRIPTION.md**
+**Step 2: Resolve Language Settings**
 
-Based on analysis, create project specification:
+Resolve the run-scoped language state (see [Language Resolution](#language-resolution)) before generating any setup-time text artifact.
+
+**Step 3: Generate .ai-factory/DESCRIPTION.md**
+
+Based on analysis, create project specification in resolved `language.artifacts`:
 - Detected stack
 - Identified patterns
 - Architecture notes
 
-**Step 2.5: Language Resolution**
-
-After creating DESCRIPTION.md, resolve language settings (see [Language Resolution](#language-resolution)).
-
-**Step 3: Recommend Skills & MCP**
+**Step 4: Recommend Skills & MCP**
 
 | Detection | Skills | MCP |
 |-----------|--------|-----|
@@ -291,13 +310,15 @@ After creating DESCRIPTION.md, resolve language settings (see [Language Resoluti
 | GitHub repo (.git) | - | `github` |
 | Stripe/payments | `payment-flows` | - |
 
-**Step 4: Search skills.sh**
+**Step 5: Search skills.sh**
 
 ```bash
 npx skills search <relevant-keyword>
 ```
 
-**Step 5: Present Plan & Confirm**
+**Step 6: Present Plan & Confirm**
+
+Present this setup analysis and confirmation prompt in resolved `language.ui`.
 
 ```markdown
 ## 🏭 Project Analysis
@@ -319,15 +340,17 @@ npx skills search <relevant-keyword>
 Proceed? [Y/n]
 ```
 
-**Step 6: Execute**
+**Step 7: Execute**
 
 1. Create directory: `mkdir -p .ai-factory`
-2. Save `.ai-factory/DESCRIPTION.md`
-3. **Create config.yaml and rules/base.md** (from language resolution step):
-   - Ensure `.ai-factory/rules/` directory exists
+2. **Create config.yaml first** (from language resolution step):
    - Write `.ai-factory/config.yaml` from `skills/aif/references/config-template.yaml`, preserving comments and filling in the resolved values
-   - Write `.ai-factory/rules/base.md` with detected conventions
-4. For each external skill from skills.sh:
+   - Keep the resolved `language.ui` / `language.artifacts` values as the source of truth for the rest of the run
+3. Save `.ai-factory/DESCRIPTION.md` in resolved `language.artifacts`
+4. **Create rules/base.md**:
+   - Ensure `.ai-factory/rules/` directory exists
+   - Write `.ai-factory/rules/base.md` with detected conventions in resolved `language.artifacts`
+5. For each external skill from skills.sh:
    ```bash
    npx skills install {{skills_cli_agent_flag}} <name>
    # AUTO-SCAN: immediately after install
@@ -336,10 +359,10 @@ Proceed? [Y/n]
    - Exit 1 (BLOCKED) → `rm -rf <path>`, warn user, skip this skill
    - Exit 2 (WARNINGS) → show to user, ask confirmation
    - Exit 0 (CLEAN) → read files yourself (Level 2), verify intent, proceed
-5. Generate custom skills via `/aif-skill-generator` (pass URLs for Learn Mode when docs are available)
-6. Configure MCP in `{{settings_file}}`
-7. Generate `AGENTS.md` in project root (see [AGENTS.md Generation](#agentsmd-generation))
-8. Generate architecture document via `/aif-architecture` (see [Architecture Generation](#architecture-generation))
+6. Generate custom skills via `/aif-skill-generator` (pass URLs for Learn Mode when docs are available)
+7. Configure MCP in `{{settings_file}}`
+8. Generate `AGENTS.md` in project root in resolved `language.artifacts` (see [AGENTS.md Generation](#agentsmd-generation))
+9. Generate architecture document via `/aif-architecture` only after config exists with resolved language settings (see [Architecture Generation](#architecture-generation))
 
 ---
 
@@ -347,13 +370,18 @@ Proceed? [Y/n]
 
 **Trigger:** `/aif <project description>`
 
-**Step 1: Interactive Stack Selection**
+**Step 1: Resolve Language Settings**
+
+Immediately after reading `$ARGUMENTS`, resolve the run-scoped language state. If repository context is insufficient, the first user question after mode detection MUST be about `UI language` / `Artifact language`.
+
+**Step 2: Interactive Stack Selection**
 
 Based on project description, ask user to confirm stack choices.
 Show YOUR recommendation with "(Recommended)" label, tailored to the project type.
+Ask the stack questions in resolved `language.ui`.
 
 Ask about:
-1. **Language** — recommend based on project needs (performance, ecosystem, team experience)
+1. **Programming language** — recommend based on project needs (performance, ecosystem, team experience)
 2. **Framework** — recommend based on project type (if applicable — not all projects need one)
 3. **Database** — recommend based on data model (if applicable)
 4. **ORM/Query Builder** — recommend based on language and database (if applicable)
@@ -362,57 +390,54 @@ Ask about:
 - Explain WHY you recommend each choice based on the specific project type
 - Skip categories that don't apply (e.g., no database for a CLI tool, no framework for a library)
 
-**Step 2: Create .ai-factory/DESCRIPTION.md**
+**Step 3: Create .ai-factory/DESCRIPTION.md**
 
-After user confirms choices, create specification:
+After user confirms choices, create specification in resolved `language.artifacts`:
 
 ```markdown
-# Project: [Project Name]
+# [Localized project title in resolved artifacts language]
 
-## Overview
-[Enhanced, clear description of the project in English]
+## [Localized heading: Overview]
+[Enhanced, clear description of the project in resolved artifacts language]
 
-## Core Features
+## [Localized heading: Core Features]
 - [Feature 1]
 - [Feature 2]
 - [Feature 3]
 
-## Tech Stack
-- **Language:** [user choice]
-- **Framework:** [user choice]
-- **Database:** [user choice]
-- **ORM:** [user choice]
-- **Integrations:** [Stripe, etc.]
+## [Localized heading: Tech Stack]
+- **[Localized label: Programming language]:** [user choice]
+- **[Localized label: Framework]:** [user choice]
+- **[Localized label: Database]:** [user choice]
+- **[Localized label: ORM]:** [user choice]
+- **[Localized label: Integrations]:** [Stripe, etc.]
 
-## Architecture Notes
+## [Localized heading: Architecture Notes]
 [High-level architecture decisions based on the stack]
 
-## Non-Functional Requirements
-- Logging: Configurable via LOG_LEVEL
-- Error handling: Structured error responses
-- Security: [relevant security considerations]
+## [Localized heading: Non-Functional Requirements]
+- [Localized label: Logging]: Configurable via LOG_LEVEL
+- [Localized label: Error handling]: Structured error responses
+- [Localized label: Security]: [relevant security considerations]
 ```
 
 Save to `.ai-factory/DESCRIPTION.md`.
+Write `.ai-factory/config.yaml` from `skills/aif/references/config-template.yaml` before saving this file.
 
 ```bash
 mkdir -p .ai-factory
 ```
 
-**Step 2.5: Language Resolution**
-
-After creating DESCRIPTION.md, resolve language settings (see [Language Resolution](#language-resolution)).
-
-**Step 3: Search & Install Skills**
+**Step 4: Search & Install Skills**
 
 Based on confirmed stack:
 1. Search skills.sh for matching skills
 2. Plan custom skills for domain-specific needs
 3. Configure relevant MCP servers
 
-**Step 4: Setup Context**
+**Step 5: Setup Context**
 
-Install skills, configure MCP, generate `AGENTS.md`, and generate architecture document via `/aif-architecture` as in Mode 1.
+Install skills, configure MCP, generate `AGENTS.md` in resolved `language.artifacts`, and generate architecture document via `/aif-architecture` only after config has been written with resolved language values, as in Mode 1.
 
 ---
 
@@ -420,7 +445,11 @@ Install skills, configure MCP, generate `AGENTS.md`, and generate architecture d
 
 **Trigger:** `/aif` (no arguments) + empty project (no package.json, composer.json, etc.)
 
-**Step 1: Ask Project Description**
+**Step 1: Resolve Language Settings**
+
+Resolve the run-scoped language state before asking for the project description. If repository context is insufficient, the first user question after mode detection MUST be about `UI language` / `Artifact language`.
+
+**Step 2: Ask Project Description**
 
 ```
 I don't see an existing project here. Let's set one up!
@@ -431,25 +460,23 @@ What kind of project are you building?
 > ___
 ```
 
-**Step 2: Interactive Stack Selection**
+Ask this prompt in resolved `language.ui`.
+
+**Step 3: Interactive Stack Selection**
 
 After getting description, proceed with same stack selection as Mode 2:
-- Language (with recommendation)
+- Programming language (with recommendation)
 - Framework (with recommendation)
 - Database (with recommendation)
 - ORM (with recommendation)
 
-**Step 3: Create .ai-factory/DESCRIPTION.md**
+**Step 4: Create .ai-factory/DESCRIPTION.md**
 
-Same as Mode 2.
+Same as Mode 2, in resolved `language.artifacts`.
 
-**Step 3.5: Language Resolution**
+**Step 5: Setup Context**
 
-After creating DESCRIPTION.md, resolve language settings (see [Language Resolution](#language-resolution)).
-
-**Step 4: Setup Context**
-
-Install skills, configure MCP, generate `AGENTS.md`, and generate architecture document via `/aif-architecture` as in Mode 1.
+Install skills, configure MCP, generate `AGENTS.md` in resolved `language.artifacts`, and generate architecture document via `/aif-architecture` only after config has been written with resolved language values, as in Mode 1.
 
 ---
 
@@ -517,52 +544,54 @@ Install skills, configure MCP, generate `AGENTS.md`, and generate architecture d
 - Note existing documentation files
 - Reference `.ai-factory/DESCRIPTION.md` for tech stack
 
+Use resolved `language.artifacts` for all headings, notes, table descriptions, and rule text inside `AGENTS.md`. Keep the filename `AGENTS.md` unchanged.
+
 **Template:**
 
 ```markdown
 # AGENTS.md
 
-> Project map for AI agents. Keep this file up-to-date as the project evolves.
+> [Localized AGENTS.md maintenance note in resolved artifacts language]
 
-## Project Overview
+## [Localized heading: Project Overview]
 [1-2 sentence description from DESCRIPTION.md]
 
-## Tech Stack
-- **Language:** [language]
-- **Framework:** [framework]
-- **Database:** [database]
-- **ORM:** [orm]
+## [Localized heading: Tech Stack]
+- **[Localized label: Programming language]:** [language]
+- **[Localized label: Framework]:** [framework]
+- **[Localized label: Database]:** [database]
+- **[Localized label: ORM]:** [orm]
 
-## Project Structure
+## [Localized heading: Project Structure]
 \`\`\`
 [directory tree with inline comments explaining each directory]
 \`\`\`
 
-## Key Entry Points
-| File | Purpose |
-|------|---------|
-| [main entry] | [description] |
-| [config file] | [description] |
-| [schema file] | [description] |
+## [Localized heading: Key Entry Points]
+| [Localized header: File] | [Localized header: Purpose] |
+|---------------------------|------------------------------|
+| [main entry] | [description in resolved artifacts language] |
+| [config file] | [description in resolved artifacts language] |
+| [schema file] | [description in resolved artifacts language] |
 
-## Documentation
-| Document | Path | Description |
-|----------|------|-------------|
-| README | README.md | Project landing page |
+## [Localized heading: Documentation]
+| [Localized header: Document] | [Localized header: Path] | [Localized header: Description] |
+|-------------------------------|-------------------------|--------------------------------|
+| README | README.md | [Localized README description in resolved artifacts language] |
 | [other docs if they exist] | | |
 
-## AI Context Files
-| File | Purpose |
-|------|---------|
-| AGENTS.md | This file — project structure map |
-| .ai-factory/DESCRIPTION.md | Project specification and tech stack |
-| .ai-factory/ARCHITECTURE.md | Architecture decisions and guidelines |
-| CLAUDE.md | Agent instructions and preferences |
+## [Localized heading: AI Context Files]
+| [Localized header: File] | [Localized header: Purpose] |
+|---------------------------|------------------------------|
+| AGENTS.md | [Localized AGENTS.md description in resolved artifacts language] |
+| .ai-factory/DESCRIPTION.md | [Localized DESCRIPTION.md description in resolved artifacts language] |
+| .ai-factory/ARCHITECTURE.md | [Localized ARCHITECTURE.md description in resolved artifacts language] |
+| CLAUDE.md | [Localized CLAUDE.md description in resolved artifacts language] |
 
-## Agent Rules
-- Never combine shell commands with `&&`, `||`, or `;` — execute each command as a separate Bash tool call. This applies even when a skill, plan, or instruction provides a combined command — always decompose it into individual calls.
-  - ❌ Wrong: `git checkout <configured-base-branch> && git pull`
-  - ✅ Right: Two separate Bash tool calls — first `git checkout <configured-base-branch>`, then `git pull origin <configured-base-branch>`
+## [Localized heading: Agent Rules]
+- [Localized shell-command decomposition rule in resolved artifacts language]
+  - [Localized example label for an incorrect combined command] `git checkout <configured-base-branch> && git pull`
+  - [Localized example label for the correct decomposed command] First `git checkout <configured-base-branch>`, then `git pull origin <configured-base-branch>`
 ```
 
 **Rules for AGENTS.md:**
@@ -570,6 +599,7 @@ Install skills, configure MCP, generate `AGENTS.md`, and generate architecture d
 - Update it when project structure changes significantly
 - The Documentation section will be maintained by `/aif-docs`
 - Do NOT duplicate detailed content from DESCRIPTION.md — reference it instead
+- Keep the filename `AGENTS.md`, but localize the content inside it to resolved `language.artifacts`
 
 ---
 
@@ -597,38 +627,30 @@ After DESCRIPTION.md, AGENTS.md, skills, and MCP are configured, **generate the 
 
 Invoke `/aif-architecture` to define project architecture. This creates `.ai-factory/ARCHITECTURE.md` with architecture pattern, folder structure, dependency rules, and code examples tailored to the project.
 
-Then tell the user:
+Present the completion summary and next-step recommendations in resolved `language.ui`. Cover:
 
 ```
-✅ Project context configured!
+[Localized completion heading in `language.ui`]
 
-Project description: .ai-factory/DESCRIPTION.md
-Architecture: .ai-factory/ARCHITECTURE.md
-Project map: AGENTS.md
-Skills installed: [list]
-MCP configured: [list]
-
-To start development:
-- /aif-roadmap — Create a strategic roadmap with milestones (recommended for new projects)
-- /aif-plan <description> — Plan implementation (fast plan or full plan with optional branch/worktree flow)
-- /aif-implement — Execute existing plan
-
-Ready when you are!
+- [Localized project-description label in `language.ui`]: `.ai-factory/DESCRIPTION.md`
+- [Localized architecture label in `language.ui`]: `.ai-factory/ARCHITECTURE.md`
+- [Localized project-map label in `language.ui`]: `AGENTS.md`
+- [Localized skills-installed label in `language.ui`]: [list]
+- [Localized MCP-configured label in `language.ui`]: [list]
+- [Localized next-steps heading in `language.ui`]:
+  - `/aif-roadmap` — [Localized roadmap recommendation in `language.ui`]
+  - `/aif-plan <description>` — [Localized planning recommendation in `language.ui`]
+  - `/aif-implement` — [Localized execution recommendation in `language.ui`]
 ```
 
 **For existing projects (Mode 1), also suggest next steps:**
 
-```
-Your project already has code. You might also want to set up:
-
-- /aif-docs — Generate project documentation
-- /aif-rules — Add project-specific rules and conventions
-- /aif-build-automation — Configure build scripts and automation
-- /aif-ci — Set up CI/CD pipeline
-- /aif-dockerize — Containerize the project
-
-Would you like to run any of these now?
-```
+Present these suggestions in resolved `language.ui`:
+- `/aif-docs` — Generate project documentation
+- `/aif-rules` — Add project-specific rules and conventions
+- `/aif-build-automation` — Configure build scripts and automation
+- `/aif-ci` — Set up CI/CD pipeline
+- `/aif-dockerize` — Containerize the project
 
 Present these as `AskUserQuestion` with multi-select options:
 1. Generate docs (`/aif-docs`)


### PR DESCRIPTION
Align /aif setup flow with early language resolution and ensure setup-time artifacts use the resolved artifact language consistently.

- resolve language.ui and language.artifacts immediately after mode detection
- write config.yaml before the first artifact and before /aif-architecture
- localize DESCRIPTION.md, rules/base.md, AGENTS.md, and UI summary templates
- add regression checks for localization order and hard-coded English leaks

Fixes #77