### PR TITLE
fix(aif): make config.yaml updates deterministic and preserve template comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ Artifact writers are command-scoped to prevent ownership conflicts:
 | Artifact                                                                                      | Primary writer command | Notes                                                                                            |
 |-----------------------------------------------------------------------------------------------|------------------------|--------------------------------------------------------------------------------------------------|
 | `.ai-factory/DESCRIPTION.md`                                                                  | `/aif`                 | `/aif-implement` may update only when implementation materially changed context facts            |
+| `.ai-factory/config.yaml`                                                                     | `/aif`                 | initial create uses the commented template; reruns refresh only managed keys and preserve comments/manual edits; `/aif-rules` owns `rules.<area>` |
 | `paths.architecture` (default: `.ai-factory/ARCHITECTURE.md`)                                 | `/aif-architecture`    | `/aif-implement` may update structure notes when structure changes                               |
 | `paths.roadmap` (default: `.ai-factory/ROADMAP.md`)                                           | `/aif-roadmap`         | `/aif-implement` may mark completed milestones with evidence                                     |
 | `paths.rules_file` (default: `.ai-factory/RULES.md`), `paths.rules/<area>.md`, `rules.<area>` | `/aif-rules`           | top-level conventions plus area-rule files and registration                                      |
@@ -129,7 +130,7 @@ Current config-agnostic built-ins:
 
 Current config keys in active use:
 
-- `paths.*` - artifact discovery for description, architecture, roadmap, research, RULES.md, plan files, fix plans, QA artifacts
+- `paths.*` - artifact discovery for description, architecture, roadmap, research, RULES.md, plan files, fix plans, QA artifacts,
   references, security state, patches, evolutions, loop state, and rules
 - `language.ui` / `language.artifacts` - prompt language vs generated artifact language
 - `git.enabled` / `git.base_branch` / `git.create_branches` / `git.branch_prefix` / `git.skip_push_after_commit` - planning, verification, and commit push behavior
@@ -175,6 +176,11 @@ Check: has arguments? has project files?
 │ Mode 3: Empty project (no args + no config files)           │
 │   → Ask "What are you building?" → Stack selection → Setup  │
 └─────────────────────────────────────────────────────────────┘
+    ↓
+/aif config.yaml contract
+    ↓
+Initial create → copy from `skills/aif/references/config-template.yaml` and set resolved values without dropping comments
+Rerun update → deterministic merge of managed keys only; preserve manual comments, unknown sections, and existing `rules.<area>`
     ↓
 /aif-architecture → Generate ARCHITECTURE.md
     ↓

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -16,9 +16,9 @@ Use it when you need to know:
 
 | Operation | Allowed writer | Scope |
 |-----------|----------------|-------|
-| Create the initial file | `/aif` | Whole file |
+| Create the initial file | `/aif` | Whole file from `skills/aif/references/config-template.yaml` |
 | Bootstrap config while adding the first area rule | `/aif-rules area:<name>` | Minimal config scaffold plus the new `rules.<area>` entry |
-| Refresh the file during setup reruns | `/aif` | Whole file |
+| Refresh the file during setup reruns | `/aif` | Managed keys only; preserve existing comments, manual edits outside targeted keys, unknown sections, and `rules.<area>` entries |
 | Register a new area rule | `/aif-rules area:<name>` | `rules.<area>` entry only |
 | Manual edits | Developer | Any key |
 
@@ -30,9 +30,10 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 
 - If both language keys already exist in `config.yaml`, `/aif` reuses them and does not ask again.
 - If only one language key exists, `/aif` keeps the existing value and resolves only the missing key via `config.yaml` → `AGENTS.md` → `CLAUDE.md` → `RULES.md` → user question.
-- When `.ai-factory/config.yaml` already exists, `/aif` merges the resolved `language.ui` / `language.artifacts` values into the existing file and preserves other sections such as `paths.*`, `git.*`, `workflow.*`, and `rules.*`.
 - `/aif` preserves an existing `language.technical_terms` value and defaults it to `keep` only when the key is missing.
-- After language resolution, `/aif` updates `config.yaml` from `skills/aif/references/config-template.yaml` before writing `.ai-factory/DESCRIPTION.md`, `.ai-factory/rules/base.md`, `AGENTS.md`, or invoking `/aif-architecture`.
+- Initial creation starts from the full commented template at `skills/aif/references/config-template.yaml`.
+- When `.ai-factory/config.yaml` already exists, `/aif` updates only the managed subset (`language.*`, `paths.*`, `workflow.*`, selected `git.*`, and `rules.base`) and preserves comments, unknown sections, manual edits outside targeted keys, and existing `rules.<area>` entries.
+- After language resolution, `/aif` updates `config.yaml` via `skills/aif/references/update-config.mjs` before writing `.ai-factory/DESCRIPTION.md`, `.ai-factory/rules/base.md`, `AGENTS.md`, or invoking `/aif-architecture`.
 - This ordering keeps all setup-time artifacts in a single run aligned to one `language.artifacts` value, while prompts, questions, summaries, and next-step guidance use `language.ui`.
 
 ## Schema Summary
@@ -102,7 +103,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
 | `rules.base` | `.ai-factory/rules/base.md` | `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-fix`, `/aif-evolve` | Base project rule file |
-| `rules.<area>` | none | `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-fix`, `/aif-evolve`; written by `/aif-rules area:<name>` | Named area rule entries like `rules.api`, `rules.frontend` |
+| `rules.<area>` | none | `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-fix`, `/aif-evolve`; written by `/aif-rules area:<name>` | Named area rule entries like `rules.api`, `rules.frontend`; preserved during `/aif` reruns |
 
 ## Skill Matrix
 
@@ -110,7 +111,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 
 | Skill | Reads config | Writes config | Write scope |
 |-------|--------------|---------------|-------------|
-| `/aif` | Yes | Yes | Creates or refreshes `config.yaml` during setup by merging resolved language values into any existing file after early language resolution and before the first setup artifact |
+| `/aif` | Yes | Yes | Creates the initial file from the commented template; reruns update only managed keys while preserving comments, custom edits outside targeted keys, unknown sections, and `rules.<area>` |
 | `/aif-rules` | Yes | Yes, limited | Adds or updates `rules.<area>` registrations when creating area rules; may bootstrap a minimal config file when the first area rule is created |
 
 ### Config Readers

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,12 @@ For the complete key-by-key schema plus the built-in skill read/write matrix, se
 - `.ai-factory.json` — CLI state (agents, installed skills, MCP config) — managed by ai-factory package
 - `config.yaml` — User preferences (language, paths, workflow) — edited by developers
 
+`/aif` creates the initial `config.yaml` from `skills/aif/references/config-template.yaml`, so the commented template structure is preserved instead of being rewritten as a minimal YAML blob.
+
+On setup reruns, `/aif` updates only the managed key subset it owns (`language.*`, `paths.*`, `workflow.*`, selected `git.*`, and `rules.base`). Existing comments, manual customizations outside the targeted keys, unknown sections, and `rules.<area>` registrations are preserved.
+
+Those comments are intentional: they are part of the human-editable experience for `config.yaml`, not disposable formatting noise.
+
 ```yaml
 # AI Factory Configuration
 # All sections are optional — defaults are used when not specified.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -4,6 +4,8 @@
 
 **Config-aware skills read `.ai-factory/config.yaml` at startup** to resolve paths, language settings, workflow preferences, and rules hierarchy. The current config-aware set is `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`, `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-security-checklist`, and `/aif-qa`.
 
+`/aif` is also the primary writer for `config.yaml`: the initial file comes from the commented template, and setup reruns update only managed keys while preserving comments, unrelated manual edits, and `rules.<area>` entries owned by `/aif-rules`.
+
 Config-agnostic built-ins in the current model: `/aif-best-practices`, `/aif-build-automation`, `/aif-ci`, `/aif-dockerize`, `/aif-grounded`, and `/aif-skill-generator`.
 
 Other skills are intentionally config-agnostic for now and rely on repository context, explicit arguments, or fixed non-configurable paths such as `skill-context`. See [Configuration](configuration.md) for the current schema and its limits.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -8,6 +8,8 @@ AI Factory has two phases: **configuration** (one-time project setup) and the **
 
 Run once per project. Sets up context files that all workflow skills depend on.
 
+During `/aif`, the initial `.ai-factory/config.yaml` is created from the commented template, and setup reruns refresh only the managed keys so manual comments and unrelated customizations survive.
+
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                       PROJECT CONFIGURATION                             │

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
       "types"
     ],
     "ignore": [
-      "examples/**"
+      "examples/**",
+      "skills/aif/references/update-config.mjs"
     ]
   },
   "engines": {

--- a/scripts/test-aif-config.sh
+++ b/scripts/test-aif-config.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+# Regression tests for the /aif config template updater helper.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="$ROOT_DIR/skills/aif/references/update-config.mjs"
+TEMPLATE="$ROOT_DIR/skills/aif/references/config-template.yaml"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  local hint="$3"
+  if ! grep -qE "$pattern" "$file"; then
+    echo "Assertion failed: $hint"
+    echo "Pattern: $pattern"
+    echo "--- file: $file ---"
+    cat "$file"
+    echo "-------------------"
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  local hint="$3"
+  if grep -qE "$pattern" "$file"; then
+    echo "Assertion failed: $hint"
+    echo "Pattern: $pattern"
+    echo "--- file: $file ---"
+    cat "$file"
+    echo "-------------------"
+    exit 1
+  fi
+}
+
+run_helper() {
+  local payload="$1"
+  local target="$2"
+  node "$HELPER" --template "$TEMPLATE" --target "$target" --payload "$payload"
+}
+
+CREATE_PAYLOAD="$TMPDIR/create-payload.json"
+cat > "$CREATE_PAYLOAD" <<'EOF'
+{
+  "mode": "create",
+  "set": {
+    "language.ui": "ru",
+    "language.artifacts": "ru",
+    "language.technical_terms": "keep",
+    "paths.description": ".ai-factory/DESCRIPTION.md",
+    "paths.architecture": ".ai-factory/ARCHITECTURE.md",
+    "paths.docs": "handbook/",
+    "paths.roadmap": ".ai-factory/ROADMAP.md",
+    "paths.research": ".ai-factory/RESEARCH.md",
+    "paths.rules_file": ".ai-factory/RULES.md",
+    "paths.plan": ".ai-factory/PLAN.md",
+    "paths.plans": ".ai-factory/plans/",
+    "paths.fix_plan": ".ai-factory/FIX_PLAN.md",
+    "paths.security": ".ai-factory/SECURITY.md",
+    "paths.references": ".ai-factory/references/",
+    "paths.patches": ".ai-factory/patches/",
+    "paths.evolutions": ".ai-factory/evolutions/",
+    "paths.evolution": ".ai-factory/evolution/",
+    "paths.specs": ".ai-factory/specs/",
+    "paths.rules": ".ai-factory/rules/",
+    "paths.qa": ".ai-factory/qa/",
+    "workflow.auto_create_dirs": true,
+    "workflow.plan_id_format": "slug",
+    "workflow.analyze_updates_architecture": true,
+    "workflow.architecture_updates_roadmap": true,
+    "workflow.verify_mode": "normal",
+    "git.enabled": true,
+    "git.base_branch": "2.x",
+    "git.create_branches": true,
+    "git.branch_prefix": "fix/",
+    "git.skip_push_after_commit": false,
+    "rules.base": ".ai-factory/rules/base.md"
+  },
+  "fillMissing": {}
+}
+EOF
+
+CREATE_TARGET="$TMPDIR/create/.ai-factory/config.yaml"
+mkdir -p "$(dirname "$CREATE_TARGET")"
+run_helper "$CREATE_PAYLOAD" "$CREATE_TARGET"
+
+assert_contains "$CREATE_TARGET" '^# AI Factory Configuration' "fresh create must preserve template header comments"
+assert_contains "$CREATE_TARGET" '^# Language Settings' "fresh create must preserve section comments"
+assert_contains "$CREATE_TARGET" '^  ui: ru$' "fresh create must set language.ui"
+assert_contains "$CREATE_TARGET" '^  docs: handbook/$' "fresh create must set overridden docs path"
+assert_contains "$CREATE_TARGET" '^  # QA artifacts root directory$' "fresh create must preserve QA path comments"
+assert_contains "$CREATE_TARGET" '^  qa: \.ai-factory/qa/$' "fresh create must set paths.qa"
+assert_contains "$CREATE_TARGET" '^  base_branch: 2.x$' "fresh create must set git.base_branch"
+assert_contains "$CREATE_TARGET" '^  branch_prefix: fix/$' "fresh create must set git.branch_prefix"
+assert_contains "$CREATE_TARGET" '^  # frontend: \.ai-factory/rules/frontend\.md$' "fresh create must preserve commented rules examples"
+
+MERGE_TARGET="$TMPDIR/merge/config.yaml"
+mkdir -p "$(dirname "$MERGE_TARGET")"
+cat > "$MERGE_TARGET" <<'EOF'
+# custom header
+
+paths:
+  docs: handbook/
+  qa: quality/
+
+git:
+  enabled: true
+  # keep this comment
+  base_branch: main # team-default
+  create_branches: true
+  skip_push_after_commit: false
+
+rules:
+  base: .ai-factory/rules/base.md
+  api: .ai-factory/rules/api.md
+
+custom:
+  owner: team
+EOF
+
+MERGE_PAYLOAD="$TMPDIR/merge-payload.json"
+cat > "$MERGE_PAYLOAD" <<'EOF'
+{
+  "mode": "merge",
+  "set": {
+    "git.base_branch": "trunk"
+  },
+  "fillMissing": {
+    "paths.docs": "docs/",
+    "paths.qa": ".ai-factory/qa/",
+    "git.branch_prefix": "feature/",
+    "rules.base": ".ai-factory/rules/base.md"
+  }
+}
+EOF
+
+run_helper "$MERGE_PAYLOAD" "$MERGE_TARGET"
+
+assert_contains "$MERGE_TARGET" '^# custom header$' "merge must preserve top-level custom comments"
+assert_contains "$MERGE_TARGET" '^  docs: handbook/$' "merge must preserve custom values not explicitly set"
+assert_contains "$MERGE_TARGET" '^  qa: quality/$' "merge must preserve custom paths.qa when not explicitly set"
+assert_contains "$MERGE_TARGET" '^  # keep this comment$' "merge must preserve comments above managed keys"
+assert_contains "$MERGE_TARGET" '^  base_branch: trunk # team-default$' "merge must preserve inline comments while updating the value"
+assert_contains "$MERGE_TARGET" '^  api: \.ai-factory/rules/api\.md$' "merge must preserve existing rules.<area> entries"
+assert_contains "$MERGE_TARGET" '^custom:$' "merge must preserve unknown sections"
+assert_contains "$MERGE_TARGET" '^  # Branch name prefix for new features$' "merge must backfill missing key comments from template"
+assert_contains "$MERGE_TARGET" '^  branch_prefix: feature/$' "merge must backfill missing managed keys"
+assert_not_contains "$MERGE_TARGET" '^  qa: \.ai-factory/qa/$' "merge fillMissing must not overwrite existing custom paths.qa"
+
+BACKFILL_TARGET="$TMPDIR/backfill/config.yaml"
+mkdir -p "$(dirname "$BACKFILL_TARGET")"
+cat > "$BACKFILL_TARGET" <<'EOF'
+paths:
+  docs: handbook/
+EOF
+
+BACKFILL_PAYLOAD="$TMPDIR/backfill-payload.json"
+cat > "$BACKFILL_PAYLOAD" <<'EOF'
+{
+  "mode": "merge",
+  "set": {},
+  "fillMissing": {
+    "paths.qa": ".ai-factory/qa/"
+  }
+}
+EOF
+
+run_helper "$BACKFILL_PAYLOAD" "$BACKFILL_TARGET"
+
+assert_contains "$BACKFILL_TARGET" '^  # QA artifacts root directory$' "merge must backfill paths.qa comments from template"
+assert_contains "$BACKFILL_TARGET" '^  qa: \.ai-factory/qa/$' "merge must backfill missing paths.qa"
+
+NOOP_TARGET="$TMPDIR/noop/config.yaml"
+mkdir -p "$(dirname "$NOOP_TARGET")"
+cp "$CREATE_TARGET" "$NOOP_TARGET"
+NOOP_BEFORE_HASH=$(node -e "const fs=require('fs');const crypto=require('crypto');const data=fs.readFileSync(process.argv[1]);process.stdout.write(crypto.createHash('sha256').update(data).digest('hex'))" "$NOOP_TARGET")
+NOOP_BEFORE_MTIME=$(node -e "const fs=require('fs');process.stdout.write(String(fs.statSync(process.argv[1]).mtimeMs))" "$NOOP_TARGET")
+run_helper "$CREATE_PAYLOAD" "$NOOP_TARGET"
+NOOP_AFTER_HASH=$(node -e "const fs=require('fs');const crypto=require('crypto');const data=fs.readFileSync(process.argv[1]);process.stdout.write(crypto.createHash('sha256').update(data).digest('hex'))" "$NOOP_TARGET")
+NOOP_AFTER_MTIME=$(node -e "const fs=require('fs');process.stdout.write(String(fs.statSync(process.argv[1]).mtimeMs))" "$NOOP_TARGET")
+
+if [[ "$NOOP_BEFORE_HASH" != "$NOOP_AFTER_HASH" ]]; then
+  echo "Assertion failed: noop merge must not rewrite file content"
+  exit 1
+fi
+
+if [[ "$NOOP_BEFORE_MTIME" != "$NOOP_AFTER_MTIME" ]]; then
+  echo "Assertion failed: noop merge must not touch mtime"
+  exit 1
+fi
+
+CRLF_TARGET="$TMPDIR/crlf/config.yaml"
+mkdir -p "$(dirname "$CRLF_TARGET")"
+node -e "const fs=require('fs');const source=fs.readFileSync(process.argv[1],'utf8');fs.writeFileSync(process.argv[2],source.replace(/\\n/g,'\\r\\n'));" "$MERGE_TARGET" "$CRLF_TARGET"
+run_helper "$MERGE_PAYLOAD" "$CRLF_TARGET"
+node -e "const fs=require('fs');const text=fs.readFileSync(process.argv[1],'utf8');if(!text.includes('\r\n'))process.exit(1);if(/(^|[^\r])\n/.test(text))process.exit(1);" "$CRLF_TARGET"
+
+UNSAFE_TARGET="$TMPDIR/unsafe/config.yaml"
+mkdir -p "$(dirname "$UNSAFE_TARGET")"
+cat > "$UNSAFE_TARGET" <<'EOF'
+git: { enabled: true }
+EOF
+
+UNSAFE_BEFORE=$(cat "$UNSAFE_TARGET")
+set +e
+node "$HELPER" --template "$TEMPLATE" --target "$UNSAFE_TARGET" --payload "$MERGE_PAYLOAD" > "$TMPDIR/unsafe.log" 2>&1
+UNSAFE_EXIT=$?
+set -e
+
+if [[ "$UNSAFE_EXIT" -ne 1 ]]; then
+  echo "Assertion failed: unsafe structure must fail with exit code 1"
+  cat "$TMPDIR/unsafe.log"
+  exit 1
+fi
+
+UNSAFE_AFTER=$(cat "$UNSAFE_TARGET")
+if [[ "$UNSAFE_BEFORE" != "$UNSAFE_AFTER" ]]; then
+  echo "Assertion failed: unsafe structure failure must not modify the target file"
+  exit 1
+fi
+
+assert_contains "$TMPDIR/unsafe.log" 'Unsupported target structure' "unsafe structure failure must explain the rejection"
+assert_not_contains "$MERGE_TARGET" '^  docs: docs/$' "merge fillMissing must not overwrite existing custom docs path"
+
+echo "aif config helper regression tests passed"

--- a/scripts/test-init.sh
+++ b/scripts/test-init.sh
@@ -108,6 +108,23 @@ EXPECTED_SUBAGENTS="$EXPECTED_SUBAGENTS" node -e "const fs=require('fs');const c
 echo "claude init smoke tests passed"
 
 # -------------------------------------------------------------------
+# Flat workflow install smoke: flat agents must receive references/
+# assets for workflow skills so helper scripts remain available after
+# installation.
+# -------------------------------------------------------------------
+
+FLAT_PROJECT_DIR="$TMPDIR/init-smoke-antigravity"
+mkdir -p "$FLAT_PROJECT_DIR"
+
+(cd "$FLAT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agents antigravity --skills aif > "$TMPDIR/init-antigravity.log" 2>&1)
+
+assert_exists "$FLAT_PROJECT_DIR/.agent/workflows/aif.md" "antigravity init must install aif as a flat workflow"
+assert_exists "$FLAT_PROJECT_DIR/.agent/workflows/references/update-config.mjs" "flat workflow installs must include the config helper in references/"
+assert_exists "$FLAT_PROJECT_DIR/.agent/workflows/references/config-template.yaml" "flat workflow installs must include config template references"
+
+echo "flat workflow init smoke tests passed"
+
+# -------------------------------------------------------------------
 # Extension agent files + dynamic runtime smoke: init should accept
 # extension-defined runtimes in --agents, install agentFiles for
 # built-in and dynamic runtimes, refresh them on extension update,

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -213,10 +213,20 @@ fi
 
 # /aif localization contract regression checks
 AIF_SKILL="$ROOT_DIR/skills/aif/SKILL.md"
-MODE2_DESCRIPTION_SECTION="$(awk '
-    /^\*\*Step 3: Create \.ai-factory\/DESCRIPTION\.md\*\*$/ { capture=1 }
+MODE1_SECTION="$(awk '
+    /^### Mode 1: Analyze Existing Project$/ { capture=1 }
     capture { print }
-    /^\*\*Step 4: Search & Install Skills\*\*$/ { if (capture) exit }
+    capture && /^---$/ { exit }
+' "$AIF_SKILL")"
+MODE2_SECTION="$(awk '
+    /^### Mode 2: New Project with Description$/ { capture=1 }
+    capture { print }
+    capture && /^---$/ { exit }
+' "$AIF_SKILL")"
+MODE3_SECTION="$(awk '
+    /^### Mode 3: Interactive New Project \(Empty Directory\)$/ { capture=1 }
+    capture { print }
+    capture && /^---$/ { exit }
 ' "$AIF_SKILL")"
 AGENTS_TEMPLATE_SECTION="$(awk '
     /^## AGENTS\.md Generation$/ { in_section=1 }
@@ -248,11 +258,19 @@ else
     fail "/aif config write ordering contract missing"
 fi
 
-if grep -Fq 'If `.ai-factory/config.yaml` already exists, merge the resolved language values into the existing file instead of replacing the rest of the document.' "$AIF_SKILL" \
-   && grep -Fq 'Preserve existing `paths.*`, `git.*`, `workflow.*`, `rules.*`, and any other non-language keys already present in the file.' "$AIF_SKILL"; then
-    pass "/aif preserves non-language config when updating resolved languages"
+if grep -Fq 'Never reconstruct `config.yaml` from memory or by free-writing YAML text.' "$AIF_SKILL" \
+   && grep -Fq 'Always use `skills/aif/references/update-config.mjs` with `skills/aif/references/config-template.yaml` as the canonical source.' "$AIF_SKILL" \
+   && grep -Fq 'If the helper reports an unsafe structure or invalid payload, STOP. Do **not** fall back to free-form YAML generation.' "$AIF_SKILL"; then
+    pass "/aif uses helper-only deterministic config updates"
 else
-    fail "/aif config merge contract missing for existing config"
+    fail "/aif helper-only config update contract missing"
+fi
+
+if grep -Fq '`paths.*` (including current schema keys such as `paths.qa`)' "$AIF_SKILL" \
+   && grep -Fq '"paths.qa": ".ai-factory/qa/"' "$AIF_SKILL"; then
+    pass "/aif helper contract includes current paths.qa schema"
+else
+    fail "/aif helper contract missing paths.qa coverage"
 fi
 
 if grep -Fq '`language.technical_terms` — preserve the existing value if it is already set; default to `keep` only when the key is missing' "$AIF_SKILL" \
@@ -281,28 +299,45 @@ else
     pass "no hard-coded English DESCRIPTION placeholder in /aif"
 fi
 
-if printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '# [Localized project title in resolved artifacts language]' \
-   && printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '## [Localized heading: Tech Stack]' \
-   && printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '**[Localized label: Programming language]:** [user choice]'; then
+if printf '%s\n' "$MODE2_SECTION" | grep -Fq '# [Localized project title in resolved artifacts language]' \
+   && printf '%s\n' "$MODE2_SECTION" | grep -Fq '## [Localized heading: Tech Stack]' \
+   && printf '%s\n' "$MODE2_SECTION" | grep -Fq '**[Localized label: Programming language]:** [user choice]'; then
     pass "/aif DESCRIPTION template uses localized artifact placeholders"
 else
     fail "/aif DESCRIPTION template localization placeholders missing"
 fi
 
-MODE2_CONFIG_LINE=$(printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -nF 'Write `.ai-factory/config.yaml` from `skills/aif/references/config-template.yaml` before saving this file.' | cut -d: -f1 | head -n1)
-MODE2_SAVE_LINE=$(printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -nF 'Save to `.ai-factory/DESCRIPTION.md`.' | cut -d: -f1 | head -n1)
-if [[ -n "$MODE2_CONFIG_LINE" && -n "$MODE2_SAVE_LINE" && "$MODE2_CONFIG_LINE" -lt "$MODE2_SAVE_LINE" ]]; then
-    pass "/aif Mode 2 writes config before saving DESCRIPTION.md"
+MODE1_PERSIST_LINE=$(printf '%s\n' "$MODE1_SECTION" | grep -nF '**Step 3: Persist config.yaml**' | cut -d: -f1 | head -n1)
+MODE1_DESCRIPTION_LINE=$(printf '%s\n' "$MODE1_SECTION" | grep -nF '**Step 4: Generate .ai-factory/DESCRIPTION.md**' | cut -d: -f1 | head -n1)
+if [[ -n "$MODE1_PERSIST_LINE" && -n "$MODE1_DESCRIPTION_LINE" && "$MODE1_PERSIST_LINE" -lt "$MODE1_DESCRIPTION_LINE" ]]; then
+    pass "/aif Mode 1 persists config before DESCRIPTION generation"
 else
-    fail "/aif Mode 2 DESCRIPTION/config ordering is wrong"
+    fail "/aif Mode 1 config/DESCRIPTION ordering is wrong"
 fi
 
-if printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '# Project: [Project Name]' \
-   || printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '## Overview' \
-   || printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '## Core Features' \
-   || printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '## Tech Stack' \
-   || printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '## Architecture Notes' \
-   || printf '%s\n' "$MODE2_DESCRIPTION_SECTION" | grep -Fq '## Non-Functional Requirements'; then
+MODE2_PERSIST_LINE=$(printf '%s\n' "$MODE2_SECTION" | grep -nF '**Step 2: Persist config.yaml**' | cut -d: -f1 | head -n1)
+MODE2_STACK_LINE=$(printf '%s\n' "$MODE2_SECTION" | grep -nF '**Step 3: Interactive Stack Selection**' | cut -d: -f1 | head -n1)
+MODE2_DESCRIPTION_LINE=$(printf '%s\n' "$MODE2_SECTION" | grep -nF '**Step 4: Create .ai-factory/DESCRIPTION.md**' | cut -d: -f1 | head -n1)
+if [[ -n "$MODE2_PERSIST_LINE" && -n "$MODE2_STACK_LINE" && -n "$MODE2_DESCRIPTION_LINE" && "$MODE2_PERSIST_LINE" -lt "$MODE2_STACK_LINE" && "$MODE2_STACK_LINE" -lt "$MODE2_DESCRIPTION_LINE" ]]; then
+    pass "/aif Mode 2 persists config immediately after language resolution"
+else
+    fail "/aif Mode 2 config timing is wrong"
+fi
+
+MODE3_PERSIST_LINE=$(printf '%s\n' "$MODE3_SECTION" | grep -nF '**Step 2: Persist config.yaml**' | cut -d: -f1 | head -n1)
+MODE3_ASK_LINE=$(printf '%s\n' "$MODE3_SECTION" | grep -nF '**Step 3: Ask Project Description**' | cut -d: -f1 | head -n1)
+if [[ -n "$MODE3_PERSIST_LINE" && -n "$MODE3_ASK_LINE" && "$MODE3_PERSIST_LINE" -lt "$MODE3_ASK_LINE" ]]; then
+    pass "/aif Mode 3 persists config immediately after language resolution"
+else
+    fail "/aif Mode 3 config timing is wrong"
+fi
+
+if printf '%s\n' "$MODE2_SECTION" | grep -Fq '# Project: [Project Name]' \
+   || printf '%s\n' "$MODE2_SECTION" | grep -Fq '## Overview' \
+   || printf '%s\n' "$MODE2_SECTION" | grep -Fq '## Core Features' \
+   || printf '%s\n' "$MODE2_SECTION" | grep -Fq '## Tech Stack' \
+   || printf '%s\n' "$MODE2_SECTION" | grep -Fq '## Architecture Notes' \
+   || printf '%s\n' "$MODE2_SECTION" | grep -Fq '## Non-Functional Requirements'; then
     fail "English DESCRIPTION template headings reintroduced in /aif"
 else
     pass "no English DESCRIPTION template headings in /aif"
@@ -492,8 +527,22 @@ else
 fi
 
 # ─────────────────────────────────────────────
-# Part 6: Update command smoke tests
+# Part 6: /aif config helper regression tests
 # ─────────────────────────────────────────────
+echo -e "\n${BOLD}=== /aif config helper regression tests ===${NC}\n"
+
+set +e
+CONFIG_HELPER_OUTPUT=$(bash "$ROOT_DIR/scripts/test-aif-config.sh" 2>&1)
+CONFIG_HELPER_EXIT=$?
+set -e
+
+if [[ $CONFIG_HELPER_EXIT -eq 0 ]]; then
+    pass "aif config helper regression tests"
+else
+    fail "aif config helper regression tests"
+    echo "$CONFIG_HELPER_OUTPUT" | sed 's/^/      /'
+fi
+
 echo -e "\n${BOLD}=== Update command smoke tests ===${NC}\n"
 
 set +e
@@ -509,7 +558,7 @@ else
 fi
 
 # ─────────────────────────────────────────────
-# Part 7: Init command smoke tests
+# Part 8: Init command smoke tests
 # ─────────────────────────────────────────────
 echo -e "\n${BOLD}=== Init command smoke tests ===${NC}\n"
 

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -2,7 +2,7 @@
 name: aif
 description: Set up agent context for a project. Analyzes tech stack, installs relevant skills from skills.sh, generates custom skills, and configures MCP servers. Use when starting new project, setting up AI context, or asking "set up project", "configure AI", "what skills do I need".
 argument-hint: "[project description]"
-allowed-tools: Read Glob Grep Write Bash(mkdir *) Bash(npx skills *) Bash(python *security-scan*) Bash(rm -rf *) Skill WebFetch AskUserQuestion Questions
+allowed-tools: Read Glob Grep Write Bash(mkdir *) Bash(node *update-config.mjs*) Bash(npx skills *) Bash(python *security-scan*) Bash(rm -rf *) Skill WebFetch AskUserQuestion Questions
 ---
 
 # AI Factory - Project Setup
@@ -189,56 +189,63 @@ Options:
 
 **Persist resolved settings in `.ai-factory/config.yaml`:**
 
-- Use `skills/aif/references/config-template.yaml` as the source template.
-- If `.ai-factory/config.yaml` already exists, merge the resolved language values into the existing file instead of replacing the rest of the document.
-- Replace only `language.ui` and `language.artifacts`; preserve existing `language.technical_terms` if it is already set, otherwise default it to `keep`.
-- Preserve existing `paths.*`, `git.*`, `workflow.*`, `rules.*`, and any other non-language keys already present in the file.
-- Preserve the inline comments from the template so developers can edit `config.yaml` manually later.
-- Fill in the resolved values; do **not** replace the file with a stripped-down minimal YAML blob.
+- Never reconstruct `config.yaml` from memory or by free-writing YAML text.
+- Always use `skills/aif/references/update-config.mjs` with `skills/aif/references/config-template.yaml` as the canonical source.
 - Write or update `.ai-factory/config.yaml` immediately after resolving the run-scoped language state.
 - This write MUST happen before writing the first setup artifact and before invoking `/aif-architecture`.
+- Ensure `.ai-factory/` exists before writing the payload or target file.
+- First write a temporary payload file (for example `.ai-factory/config.update.json`) via `Write`.
+- Then invoke the helper:
 
-```yaml
-language:
-  ui: <resolved-ui-language>
-  artifacts: <resolved-artifacts-language>
-  technical_terms: <existing-value-or-keep-when-missing>
-
-paths:
-  description: .ai-factory/DESCRIPTION.md
-  architecture: .ai-factory/ARCHITECTURE.md
-  docs: docs/
-  roadmap: .ai-factory/ROADMAP.md
-  research: .ai-factory/RESEARCH.md
-  rules_file: .ai-factory/RULES.md
-  plan: .ai-factory/PLAN.md
-  plans: .ai-factory/plans/
-  fix_plan: .ai-factory/FIX_PLAN.md
-  security: .ai-factory/SECURITY.md
-  references: .ai-factory/references/
-  patches: .ai-factory/patches/
-  evolutions: .ai-factory/evolutions/
-  evolution: .ai-factory/evolution/
-  specs: .ai-factory/specs/
-  rules: .ai-factory/rules/
-
-workflow:
-  auto_create_dirs: true
-  plan_id_format: slug
-  analyze_updates_architecture: true
-  architecture_updates_roadmap: true
-  verify_mode: normal
-
-git:
-  enabled: <true-if-git-detected-else-false>
-  base_branch: <detected-base-branch-or-main>
-  create_branches: <true-or-false-based-on-user-choice>
-  branch_prefix: feature/
-  skip_push_after_commit: false
-
-rules:
-  base: .ai-factory/rules/base.md
+```bash
+node ~/{{skills_dir}}/aif/references/update-config.mjs \
+  --template ~/{{skills_dir}}/aif/references/config-template.yaml \
+  --target .ai-factory/config.yaml \
+  --payload .ai-factory/config.update.json
 ```
+
+- Use `mode: "create"` when `.ai-factory/config.yaml` does not exist.
+- Use `mode: "merge"` when `.ai-factory/config.yaml` already exists.
+- Preserve `language.technical_terms` from existing config when present; otherwise set it to `keep` when writing config.
+- In `set`, include only values explicitly resolved in the current run and that must be written now.
+- In `fillMissing`, include canonical defaults that should be backfilled only when the key or section is missing or incomplete.
+- Managed keys for this helper are limited to:
+  - `language.ui`
+  - `language.artifacts`
+  - `language.technical_terms`
+  - `paths.*` (including current schema keys such as `paths.qa`)
+  - `workflow.*`
+  - `git.enabled`
+  - `git.base_branch`
+  - `git.create_branches`
+  - `git.branch_prefix`
+  - `git.skip_push_after_commit`
+  - `rules.base`
+- Never normalize or overwrite `rules.<area>` entries. Those belong to `/aif-rules`.
+- The helper must preserve comments, blank lines, section order, inline comments, unknown sections, custom user values outside targeted keys, and the commented `rules.*` examples from the template.
+- If the helper reports an unsafe structure or invalid payload, STOP. Do **not** fall back to free-form YAML generation.
+- After the helper succeeds, remove the temporary payload file.
+
+**Payload shape:**
+
+```json
+{
+  "mode": "create|merge",
+  "set": {
+    "language.ui": "en",
+    "language.artifacts": "en",
+    "language.technical_terms": "keep",
+    "paths.qa": ".ai-factory/qa/"
+  },
+  "fillMissing": {
+    "git.branch_prefix": "feature/",
+    "rules.base": ".ai-factory/rules/base.md"
+  }
+}
+```
+
+- Initial create: pass the resolved canonical values through `set`.
+- Rerun merge: use `set` only for values re-resolved in this run; use `fillMissing` for canonical defaults that should be restored only when absent or incomplete.
 
 **Create `.ai-factory/rules/base.md` from codebase evidence:**
 
@@ -298,14 +305,18 @@ Read these files (if they exist):
 
 Resolve the run-scoped language state (see [Language Resolution](#language-resolution)) before generating any setup-time text artifact.
 
-**Step 3: Generate .ai-factory/DESCRIPTION.md**
+**Step 3: Persist config.yaml**
+
+Immediately after language resolution, create `.ai-factory/` if needed and write `.ai-factory/config.yaml` via `update-config.mjs`.
+
+**Step 4: Generate .ai-factory/DESCRIPTION.md**
 
 Based on analysis, create project specification in resolved `language.artifacts`:
 - Detected stack
 - Identified patterns
 - Architecture notes
 
-**Step 4: Recommend Skills & MCP**
+**Step 5: Recommend Skills & MCP**
 
 | Detection | Skills | MCP |
 |-----------|--------|-----|
@@ -314,13 +325,13 @@ Based on analysis, create project specification in resolved `language.artifacts`
 | GitHub repo (.git) | - | `github` |
 | Stripe/payments | `payment-flows` | - |
 
-**Step 5: Search skills.sh**
+**Step 6: Search skills.sh**
 
 ```bash
 npx skills search <relevant-keyword>
 ```
 
-**Step 6: Present Plan & Confirm**
+**Step 7: Present Plan & Confirm**
 
 Present this setup analysis and confirmation prompt in resolved `language.ui`.
 
@@ -344,18 +355,17 @@ Present this setup analysis and confirmation prompt in resolved `language.ui`.
 Proceed? [Y/n]
 ```
 
-**Step 7: Execute**
+**Step 8: Execute**
 
 1. Create directory: `mkdir -p .ai-factory`
-2. **Create config.yaml first** (from language resolution step):
-   - Write `.ai-factory/config.yaml` from `skills/aif/references/config-template.yaml`, merging resolved language keys into any existing config while preserving comments and non-language sections
-   - Preserve existing `language.technical_terms` when present; default it to `keep` only if the key is missing
-   - Keep the resolved `language.ui` / `language.artifacts` values as the source of truth for the rest of the run
-3. Save `.ai-factory/DESCRIPTION.md` in resolved `language.artifacts`
-4. **Create rules/base.md**:
+2. Write `.ai-factory/config.update.json` with helper payload (`mode: "create"` if config is missing, `mode: "merge"` if it already exists)
+3. Run `node ~/{{skills_dir}}/aif/references/update-config.mjs --template ~/{{skills_dir}}/aif/references/config-template.yaml --target .ai-factory/config.yaml --payload .ai-factory/config.update.json`
+4. Delete `.ai-factory/config.update.json` after the helper succeeds
+5. Save `.ai-factory/DESCRIPTION.md` in resolved `language.artifacts`
+6. **Create rules/base.md**:
    - Ensure `.ai-factory/rules/` directory exists
    - Write `.ai-factory/rules/base.md` with detected conventions in resolved `language.artifacts`
-5. For each external skill from skills.sh:
+7. For each external skill from skills.sh:
    ```bash
    npx skills install {{skills_cli_agent_flag}} <name>
    # AUTO-SCAN: immediately after install
@@ -364,10 +374,10 @@ Proceed? [Y/n]
    - Exit 1 (BLOCKED) → `rm -rf <path>`, warn user, skip this skill
    - Exit 2 (WARNINGS) → show to user, ask confirmation
    - Exit 0 (CLEAN) → read files yourself (Level 2), verify intent, proceed
-6. Generate custom skills via `/aif-skill-generator` (pass URLs for Learn Mode when docs are available)
-7. Configure MCP in `{{settings_file}}`
-8. Generate `AGENTS.md` in project root in resolved `language.artifacts` (see [AGENTS.md Generation](#agentsmd-generation))
-9. Generate architecture document via `/aif-architecture` only after config exists with resolved language settings (see [Architecture Generation](#architecture-generation))
+8. Generate custom skills via `/aif-skill-generator` (pass URLs for Learn Mode when docs are available)
+9. Configure MCP in `{{settings_file}}`
+10. Generate `AGENTS.md` in project root in resolved `language.artifacts` (see [AGENTS.md Generation](#agentsmd-generation))
+11. Generate architecture document via `/aif-architecture` only after config exists with resolved language settings (see [Architecture Generation](#architecture-generation))
 
 ---
 
@@ -379,7 +389,11 @@ Proceed? [Y/n]
 
 Immediately after reading `$ARGUMENTS`, resolve the run-scoped language state. If repository context is insufficient, the first user question after mode detection MUST be about `UI language` / `Artifact language`.
 
-**Step 2: Interactive Stack Selection**
+**Step 2: Persist config.yaml**
+
+Immediately after language resolution, create `.ai-factory/` if needed and write `.ai-factory/config.yaml` via `update-config.mjs`.
+
+**Step 3: Interactive Stack Selection**
 
 Based on project description, ask user to confirm stack choices.
 Show YOUR recommendation with "(Recommended)" label, tailored to the project type.
@@ -395,7 +409,7 @@ Ask about:
 - Explain WHY you recommend each choice based on the specific project type
 - Skip categories that don't apply (e.g., no database for a CLI tool, no framework for a library)
 
-**Step 3: Create .ai-factory/DESCRIPTION.md**
+**Step 4: Create .ai-factory/DESCRIPTION.md**
 
 After user confirms choices, create specification in resolved `language.artifacts`:
 
@@ -426,23 +440,18 @@ After user confirms choices, create specification in resolved `language.artifact
 - [Localized label: Security]: [relevant security considerations]
 ```
 
-Write `.ai-factory/config.yaml` from `skills/aif/references/config-template.yaml` before saving this file.
 Save to `.ai-factory/DESCRIPTION.md`.
 
-```bash
-mkdir -p .ai-factory
-```
-
-**Step 4: Search & Install Skills**
+**Step 5: Search & Install Skills**
 
 Based on confirmed stack:
 1. Search skills.sh for matching skills
 2. Plan custom skills for domain-specific needs
 3. Configure relevant MCP servers
 
-**Step 5: Setup Context**
+**Step 6: Setup Context**
 
-Install skills, configure MCP, generate `AGENTS.md` in resolved `language.artifacts`, and generate architecture document via `/aif-architecture` only after config has been written with resolved language values, as in Mode 1.
+Install skills, configure MCP, generate `AGENTS.md` in resolved `language.artifacts`, and generate architecture document via `/aif-architecture` after the earlier helper-driven config write, as in Mode 1.
 
 ---
 
@@ -454,7 +463,11 @@ Install skills, configure MCP, generate `AGENTS.md` in resolved `language.artifa
 
 Resolve the run-scoped language state before asking for the project description. If repository context is insufficient, the first user question after mode detection MUST be about `UI language` / `Artifact language`.
 
-**Step 2: Ask Project Description**
+**Step 2: Persist config.yaml**
+
+Immediately after language resolution, create `.ai-factory/` if needed and write `.ai-factory/config.yaml` via `update-config.mjs`.
+
+**Step 3: Ask Project Description**
 
 ```
 I don't see an existing project here. Let's set one up!
@@ -467,7 +480,7 @@ What kind of project are you building?
 
 Ask this prompt in resolved `language.ui`.
 
-**Step 3: Interactive Stack Selection**
+**Step 4: Interactive Stack Selection**
 
 After getting description, proceed with same stack selection as Mode 2:
 - Programming language (with recommendation)
@@ -475,13 +488,13 @@ After getting description, proceed with same stack selection as Mode 2:
 - Database (with recommendation)
 - ORM (with recommendation)
 
-**Step 4: Create .ai-factory/DESCRIPTION.md**
+**Step 5: Create .ai-factory/DESCRIPTION.md**
 
 Same as Mode 2, in resolved `language.artifacts`.
 
-**Step 5: Setup Context**
+**Step 6: Setup Context**
 
-Install skills, configure MCP, generate `AGENTS.md` in resolved `language.artifacts`, and generate architecture document via `/aif-architecture` only after config has been written with resolved language values, as in Mode 1.
+Install skills, configure MCP, generate `AGENTS.md` in resolved `language.artifacts`, and generate architecture document via `/aif-architecture` after the earlier helper-driven config write, as in Mode 1.
 
 ---
 

--- a/skills/aif/references/update-config.mjs
+++ b/skills/aif/references/update-config.mjs
@@ -1,0 +1,676 @@
+#!/usr/bin/env node
+
+import fs from 'fs/promises';
+import path from 'path';
+
+const SECTION_KEYS = {
+  language: ['ui', 'artifacts', 'technical_terms'],
+  paths: [
+    'description',
+    'architecture',
+    'docs',
+    'roadmap',
+    'research',
+    'rules_file',
+    'plan',
+    'plans',
+    'fix_plan',
+    'security',
+    'references',
+    'patches',
+    'evolutions',
+    'evolution',
+    'specs',
+    'rules',
+    'qa',
+  ],
+  workflow: ['auto_create_dirs', 'plan_id_format', 'analyze_updates_architecture', 'architecture_updates_roadmap', 'verify_mode'],
+  git: ['enabled', 'base_branch', 'create_branches', 'branch_prefix', 'skip_push_after_commit'],
+  rules: ['base'],
+};
+
+const SECTION_ORDER = Object.keys(SECTION_KEYS);
+const ALLOWED_PATHS = new Set(
+  SECTION_ORDER.flatMap(section => SECTION_KEYS[section].map(key => `${section}.${key}`)),
+);
+
+function fail(code, message) {
+  console.error(message);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const args = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+
+    if (!flag.startsWith('--')) {
+      fail(3, `Unknown argument: ${flag}`);
+    }
+
+    if (!value || value.startsWith('--')) {
+      fail(3, `Missing value for ${flag}`);
+    }
+
+    if (flag === '--template') {
+      args.template = value;
+    } else if (flag === '--target') {
+      args.target = value;
+    } else if (flag === '--payload') {
+      args.payload = value;
+    } else {
+      fail(3, `Unknown argument: ${flag}`);
+    }
+
+    index += 1;
+  }
+
+  if (!args.template || !args.target || !args.payload) {
+    fail(3, 'Usage: update-config.mjs --template <path> --target <path> --payload <path>');
+  }
+
+  return args;
+}
+
+function normalizeNewlines(text) {
+  return text.replace(/\r\n/g, '\n');
+}
+
+function splitLines(text) {
+  const normalized = normalizeNewlines(text);
+  const lines = normalized.split('\n');
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+  return lines;
+}
+
+function joinLines(lines) {
+  return `${lines.join('\n')}\n`;
+}
+
+function detectEol(text) {
+  return text.includes('\r\n') ? '\r\n' : '\n';
+}
+
+function convertEol(text, eol) {
+  return eol === '\n' ? text : text.replace(/\n/g, eol);
+}
+
+function isBlank(line) {
+  return line.trim() === '';
+}
+
+function isComment(line) {
+  return /^\s*#/.test(line);
+}
+
+function isIndentedComment(line) {
+  return /^  #/.test(line);
+}
+
+function matchTopLevelHeader(line) {
+  if (/^\s/.test(line)) {
+    return null;
+  }
+
+  return line.match(/^([A-Za-z_][A-Za-z0-9_-]*)\s*:(.*)$/);
+}
+
+function matchManagedKey(line) {
+  return line.match(/^  ([A-Za-z_][A-Za-z0-9_]*)\s*:(.*)$/);
+}
+
+function findBlockStart(lines, index) {
+  let start = index;
+  while (start > 0) {
+    const previous = lines[start - 1];
+    if (isBlank(previous)) {
+      break;
+    }
+    if (!isComment(previous)) {
+      break;
+    }
+    start -= 1;
+  }
+  return start;
+}
+
+function splitInlineComment(valuePart) {
+  let quote = null;
+
+  for (let index = 0; index < valuePart.length; index += 1) {
+    const char = valuePart[index];
+    const previous = index > 0 ? valuePart[index - 1] : '';
+
+    if (quote) {
+      if (char === quote && previous !== '\\') {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === '\'') {
+      quote = char;
+      continue;
+    }
+
+    if (char === '#') {
+      let start = index;
+      while (start > 0 && /\s/.test(valuePart[start - 1])) {
+        start -= 1;
+      }
+      return {
+        value: valuePart.slice(0, start).trimEnd(),
+        comment: valuePart.slice(start).replace(/\s+$/, ''),
+      };
+    }
+  }
+
+  return {
+    value: valuePart.trimEnd(),
+    comment: '',
+  };
+}
+
+function isUnsafeScalar(value) {
+  return (
+    value === '|' ||
+    value === '>' ||
+    value === '|-' ||
+    value === '>-' ||
+    value === '|+' ||
+    value === '>+' ||
+    value.startsWith('{') ||
+    value.startsWith('[')
+  );
+}
+
+function isIncompleteScalar(value) {
+  return value === '' || value === 'null' || value === 'Null' || value === 'NULL' || value === '~' || value === '""' || value === '\'\'';
+}
+
+function formatScalar(value) {
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  return String(value);
+}
+
+function parsePayload(rawText) {
+  let payload;
+  try {
+    payload = JSON.parse(rawText);
+  } catch (error) {
+    fail(3, `Invalid payload JSON: ${error.message}`);
+  }
+
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    fail(3, 'Payload must be a JSON object');
+  }
+
+  if (payload.mode !== 'create' && payload.mode !== 'merge') {
+    fail(3, 'Payload mode must be "create" or "merge"');
+  }
+
+  return {
+    mode: payload.mode,
+    set: validateValueMap('set', payload.set ?? {}),
+    fillMissing: validateValueMap('fillMissing', payload.fillMissing ?? {}),
+  };
+}
+
+function validateValueMap(label, value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    fail(3, `${label} must be an object`);
+  }
+
+  const result = {};
+  for (const [keyPath, entry] of Object.entries(value)) {
+    if (!ALLOWED_PATHS.has(keyPath)) {
+      fail(3, `Unknown managed key path: ${keyPath}`);
+    }
+
+    if (typeof entry !== 'string' && typeof entry !== 'boolean') {
+      fail(3, `Unsupported value type for ${keyPath}; expected string or boolean`);
+    }
+
+    result[keyPath] = entry;
+  }
+
+  return result;
+}
+
+function collectTopLevelHeaders(lines) {
+  const headers = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = matchTopLevelHeader(lines[index]);
+    if (!match) {
+      continue;
+    }
+
+    headers.push({
+      name: match[1],
+      lineIndex: index,
+      valuePart: match[2].trim(),
+      blockStart: findBlockStart(lines, index),
+    });
+  }
+
+  for (let index = 0; index < headers.length; index += 1) {
+    headers[index].blockEnd = index + 1 < headers.length ? headers[index + 1].blockStart : lines.length;
+  }
+
+  return headers;
+}
+
+function hasNestedManagedValue(lines, keyLineIndex, sectionEnd) {
+  for (let index = keyLineIndex + 1; index < sectionEnd; index += 1) {
+    const line = lines[index];
+
+    if (isBlank(line) || isComment(line)) {
+      continue;
+    }
+
+    if (matchManagedKey(line)) {
+      return false;
+    }
+
+    if (/^[A-Za-z_][A-Za-z0-9_-]*\s*:/.test(line)) {
+      return false;
+    }
+
+    if (/^\s/.test(line)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  return false;
+}
+
+function parseSection(lines, header, sectionName) {
+  const sectionEnd = header.blockEnd;
+  const keys = {};
+
+  for (let index = header.lineIndex + 1; index < sectionEnd; index += 1) {
+    const match = matchManagedKey(lines[index]);
+    if (!match) {
+      continue;
+    }
+
+    const key = match[1];
+    if (!SECTION_KEYS[sectionName].includes(key)) {
+      continue;
+    }
+
+    if (keys[key]) {
+      fail(1, `Unsupported target structure: duplicate managed key ${sectionName}.${key}`);
+    }
+
+    const commentSplit = splitInlineComment(match[2]);
+    const value = commentSplit.value.trim();
+
+    if (isUnsafeScalar(value) || hasNestedManagedValue(lines, index, sectionEnd)) {
+      fail(1, `Unsupported target structure for managed key ${sectionName}.${key}`);
+    }
+
+    let blockStart = index;
+    while (blockStart > header.lineIndex + 1 && isIndentedComment(lines[blockStart - 1])) {
+      blockStart -= 1;
+    }
+
+    let blockEnd = index + 1;
+    while (blockEnd < sectionEnd && isBlank(lines[blockEnd])) {
+      blockEnd += 1;
+    }
+
+    keys[key] = {
+      section: sectionName,
+      key,
+      lineIndex: index,
+      blockStart,
+      blockEnd,
+      value,
+      comment: commentSplit.comment,
+      incomplete: isIncompleteScalar(value),
+    };
+  }
+
+  return {
+    name: sectionName,
+    start: header.lineIndex,
+    blockStart: header.blockStart,
+    end: sectionEnd,
+    keys,
+  };
+}
+
+function parseDocument(rawText) {
+  const lines = splitLines(rawText);
+  const headers = collectTopLevelHeaders(lines);
+  const sections = {};
+
+  for (const header of headers) {
+    if (!SECTION_ORDER.includes(header.name)) {
+      continue;
+    }
+
+    if (sections[header.name]) {
+      fail(1, `Unsupported target structure: duplicate managed section ${header.name}`);
+    }
+
+    if (header.valuePart !== '' && !header.valuePart.startsWith('#')) {
+      fail(1, `Unsupported target structure for managed section ${header.name}`);
+    }
+
+    sections[header.name] = parseSection(lines, header, header.name);
+  }
+
+  return {
+    lines,
+    headers,
+    sections,
+  };
+}
+
+function parseTemplate(rawText) {
+  const document = parseDocument(rawText);
+  const sections = {};
+
+  for (const sectionName of SECTION_ORDER) {
+    const section = document.sections[sectionName];
+    if (!section) {
+      fail(3, `Template is missing managed section ${sectionName}`);
+    }
+
+    const keyEntries = {};
+    for (const key of SECTION_KEYS[sectionName]) {
+      const entry = section.keys[key];
+      if (!entry) {
+        fail(3, `Template is missing managed key ${sectionName}.${key}`);
+      }
+
+      keyEntries[key] = {
+        ...entry,
+        relativeLineIndex: entry.lineIndex - entry.blockStart,
+        blockLines: document.lines.slice(entry.blockStart, entry.blockEnd),
+      };
+    }
+
+    sections[sectionName] = {
+      ...section,
+      blockLines: document.lines.slice(section.blockStart, section.end),
+      keys: keyEntries,
+    };
+  }
+
+  return {
+    lines: document.lines,
+    sections,
+  };
+}
+
+function buildKeyBlock(templateMeta, keyPath, value) {
+  const [sectionName, keyName] = keyPath.split('.');
+  const templateKey = templateMeta.sections[sectionName].keys[keyName];
+  const blockLines = [...templateKey.blockLines];
+  blockLines[templateKey.relativeLineIndex] = `  ${keyName}: ${formatScalar(value)}`;
+  return blockLines;
+}
+
+function buildSectionBlock(templateMeta, sectionName, overrides) {
+  const section = templateMeta.sections[sectionName];
+  const blockLines = [...section.blockLines];
+
+  for (const [keyPath, value] of Object.entries(overrides)) {
+    const [, keyName] = keyPath.split('.');
+    const templateKey = section.keys[keyName];
+    blockLines[templateKey.lineIndex - section.blockStart] = `  ${keyName}: ${formatScalar(value)}`;
+  }
+
+  return blockLines;
+}
+
+function normalizeInsertedBlock(blockLines, previousLine, nextLine) {
+  const normalized = [...blockLines];
+
+  while (
+    normalized.length > 0 &&
+    isBlank(normalized[0]) &&
+    (!previousLine || isBlank(previousLine))
+  ) {
+    normalized.shift();
+  }
+
+  while (
+    normalized.length > 0 &&
+    isBlank(normalized[normalized.length - 1]) &&
+    (!nextLine || isBlank(nextLine))
+  ) {
+    normalized.pop();
+  }
+
+  if (
+    normalized.length > 0 &&
+    previousLine &&
+    !isBlank(previousLine) &&
+    !isBlank(normalized[0])
+  ) {
+    normalized.unshift('');
+  }
+
+  if (
+    normalized.length > 0 &&
+    nextLine &&
+    !isBlank(nextLine) &&
+    !isBlank(normalized[normalized.length - 1])
+  ) {
+    normalized.push('');
+  }
+
+  return normalized;
+}
+
+function insertLines(lines, index, blockLines) {
+  const previousLine = index > 0 ? lines[index - 1] : null;
+  const nextLine = index < lines.length ? lines[index] : null;
+  const normalizedBlock = normalizeInsertedBlock(blockLines, previousLine, nextLine);
+  lines.splice(index, 0, ...normalizedBlock);
+}
+
+function updateExistingKeyLine(lines, entry, value) {
+  const commentSuffix = entry.comment ? entry.comment : '';
+  lines[entry.lineIndex] = `  ${entry.key}: ${formatScalar(value)}${commentSuffix}`;
+}
+
+function findSectionInsertIndex(parsed, sectionName) {
+  const targetIndex = SECTION_ORDER.indexOf(sectionName);
+
+  for (let index = targetIndex - 1; index >= 0; index -= 1) {
+    const previous = parsed.sections[SECTION_ORDER[index]];
+    if (previous) {
+      return previous.end;
+    }
+  }
+
+  for (let index = targetIndex + 1; index < SECTION_ORDER.length; index += 1) {
+    const next = parsed.sections[SECTION_ORDER[index]];
+    if (next) {
+      return next.blockStart;
+    }
+  }
+
+  return parsed.lines.length;
+}
+
+function findInitialSectionInsertIndex(section, lines) {
+  let index = section.start + 1;
+  while (index < section.end && (isIndentedComment(lines[index]) || isBlank(lines[index]))) {
+    index += 1;
+  }
+  return index;
+}
+
+function findKeyInsertIndex(parsed, templateMeta, sectionName, keyName) {
+  const section = parsed.sections[sectionName];
+  const keyOrder = SECTION_KEYS[sectionName];
+  const targetIndex = keyOrder.indexOf(keyName);
+
+  for (let index = targetIndex - 1; index >= 0; index -= 1) {
+    const previousKey = section.keys[keyOrder[index]];
+    if (previousKey) {
+      return previousKey.blockEnd;
+    }
+  }
+
+  for (let index = targetIndex + 1; index < keyOrder.length; index += 1) {
+    const nextKey = section.keys[keyOrder[index]];
+    if (nextKey) {
+      return nextKey.blockStart;
+    }
+  }
+
+  return findInitialSectionInsertIndex(section, parsed.lines) || templateMeta.sections[sectionName].start + 1;
+}
+
+function ensureSection(parsed, templateMeta, sectionName, payload) {
+  if (parsed.sections[sectionName]) {
+    return parsed;
+  }
+
+  const targetedOverrides = {};
+  for (const keyName of SECTION_KEYS[sectionName]) {
+    const keyPath = `${sectionName}.${keyName}`;
+    if (Object.hasOwn(payload.set, keyPath)) {
+      targetedOverrides[keyPath] = payload.set[keyPath];
+    } else if (Object.hasOwn(payload.fillMissing, keyPath)) {
+      targetedOverrides[keyPath] = payload.fillMissing[keyPath];
+    }
+  }
+
+  if (Object.keys(targetedOverrides).length === 0) {
+    return parsed;
+  }
+
+  const insertIndex = findSectionInsertIndex(parsed, sectionName);
+  const sectionBlock = buildSectionBlock(templateMeta, sectionName, targetedOverrides);
+  insertLines(parsed.lines, insertIndex, sectionBlock);
+  return parseDocument(joinLines(parsed.lines));
+}
+
+function upsertManagedKey(parsed, templateMeta, keyPath, value, mode) {
+  const [sectionName, keyName] = keyPath.split('.');
+  const section = parsed.sections[sectionName];
+  const entry = section.keys[keyName];
+
+  if (entry) {
+    if (mode === 'fillMissing' && !entry.incomplete) {
+      return parsed;
+    }
+
+    updateExistingKeyLine(parsed.lines, entry, value);
+    return parseDocument(joinLines(parsed.lines));
+  }
+
+  const insertIndex = findKeyInsertIndex(parsed, templateMeta, sectionName, keyName);
+  const blockLines = buildKeyBlock(templateMeta, keyPath, value);
+  insertLines(parsed.lines, insertIndex, blockLines);
+  return parseDocument(joinLines(parsed.lines));
+}
+
+function applyUpdates(baseText, templateMeta, payload) {
+  let parsed = parseDocument(baseText);
+
+  for (const sectionName of SECTION_ORDER) {
+    parsed = ensureSection(parsed, templateMeta, sectionName, payload);
+  }
+
+  for (const sectionName of SECTION_ORDER) {
+    for (const keyName of SECTION_KEYS[sectionName]) {
+      const keyPath = `${sectionName}.${keyName}`;
+
+      if (Object.hasOwn(payload.set, keyPath)) {
+        parsed = upsertManagedKey(parsed, templateMeta, keyPath, payload.set[keyPath], 'set');
+      }
+
+      if (Object.hasOwn(payload.fillMissing, keyPath)) {
+        parsed = upsertManagedKey(parsed, templateMeta, keyPath, payload.fillMissing[keyPath], 'fillMissing');
+      }
+    }
+  }
+
+  return joinLines(parsed.lines);
+}
+
+async function readText(filePath, label) {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    fail(2, `Unable to read ${label}: ${error.message}`);
+  }
+}
+
+async function readOptionalText(filePath) {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null;
+    }
+    fail(2, `Unable to read target: ${error.message}`);
+  }
+}
+
+async function writeIfChanged(targetPath, nextTextLf, existingRawText, eol) {
+  const currentLf = existingRawText === null ? null : normalizeNewlines(existingRawText);
+
+  if (currentLf === nextTextLf) {
+    return false;
+  }
+
+  try {
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.writeFile(targetPath, convertEol(nextTextLf, eol), 'utf8');
+  } catch (error) {
+    fail(2, `Unable to write target: ${error.message}`);
+  }
+
+  return true;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const templateRawText = await readText(args.template, 'template');
+  const payloadRawText = await readText(args.payload, 'payload');
+  const payload = parsePayload(payloadRawText);
+  const templateMeta = parseTemplate(templateRawText);
+
+  if (payload.mode === 'create') {
+    const existingRawText = await readOptionalText(args.target);
+    const targetEol = existingRawText ? detectEol(existingRawText) : detectEol(templateRawText);
+    const nextTextLf = applyUpdates(joinLines(templateMeta.lines), templateMeta, {
+      mode: 'create',
+      set: payload.set,
+      fillMissing: {},
+    });
+    await writeIfChanged(args.target, nextTextLf, existingRawText, targetEol);
+    return;
+  }
+
+  const existingRawText = await readOptionalText(args.target);
+  if (existingRawText === null) {
+    fail(2, `Unable to read target: ${args.target} does not exist`);
+  }
+
+  const targetEol = detectEol(existingRawText);
+  const nextTextLf = applyUpdates(existingRawText, templateMeta, payload);
+  await writeIfChanged(args.target, nextTextLf, existingRawText, targetEol);
+}
+
+await main();


### PR DESCRIPTION
## Summary

This PR fixes `/aif` config generation so `.ai-factory/config.yaml` is no longer rewritten as a free-form YAML blob.

### What changed

- added a deterministic zero-dependency helper at `skills/aif/references/update-config.mjs`
- switched `/aif` to helper-driven `create` / `merge` updates instead of reconstructing `config.yaml` from memory
- preserved template comments, blank lines, section order, inline comments, unknown sections, and existing `rules.<area>` entries on rerun
- synced the helper, docs, and tests with the current `2.x` config schema, including `paths.qa` and `/aif-qa`
- moved `config.yaml` persistence to immediately after language resolution in all three `/aif` modes
- added regression coverage for create, merge, comment preservation, `rules.<area>`, `paths.qa`, CRLF, no-op writes, unsafe structures, and flat-install availability
- added a narrow `knip` ignore for the runtime-only helper

## Why

`config.yaml` is a user-editable file, and its comments are part of the intended editing experience. This change makes `/aif` deterministic and preserves manual edits instead of stripping the file down to minimal YAML on reruns.

## Validation

- `npm run build`
- `npm test`
- `npm run lint`

Fixes #76
