### PR TITLE
follow-up: harden /aif-qa slug contract, scoped analysis, and smoke coverage

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,7 +163,7 @@ Current config-agnostic built-ins include `/aif-best-practices`, `/aif-build-aut
 - `git.skip_push_after_commit: true` makes `/aif-commit` stop after local commit without showing push prompt.
 - `paths.plan` remains the default fast-plan file. If you prefer fast plans inside `paths.plans/`, change `paths.plan` manually in `config.yaml`.
 - `paths.docs` controls where `/aif-docs` writes the detailed documentation pages. `README.md` remains the landing page in the project root.
-- `paths.qa` controls where `/aif-qa` stores QA artifacts. A derived branch slug is appended automatically: `<paths.qa>/<branch-slug>/change-summary.md`, `test-plan.md`, `test-cases.md`. The slug is an injective encoding of the branch name — see `skills/aif-qa/SKILL.md` for the full algorithm.
+- `paths.qa` controls where `/aif-qa` stores QA artifacts. A derived branch slug is appended automatically: `<paths.qa>/<branch-slug>/change-summary.md`, `test-plan.md`, `test-cases.md`. The slug is a deterministic, filesystem-safe, stable derived value with a short hash suffix for collision resistance — see `skills/aif-qa/SKILL.md` for the full algorithm.
 
 **Current schema limits:** `config.yaml` still leaves `.ai-factory/skill-context/` fixed by command contract. `README.md` and `docs-html/` remain fixed by current documentation workflow.
 

--- a/scripts/test-aif-qa.sh
+++ b/scripts/test-aif-qa.sh
@@ -26,6 +26,19 @@ fail() {
     echo -e "  ${RED}FAIL${NC} $1"
 }
 
+assert_exact_line() {
+    local file="$1"
+    local expected="$2"
+    local success_message="$3"
+    local failure_message="$4"
+
+    if grep -Fqx "$expected" "$file"; then
+        pass "$success_message"
+    else
+        fail "$failure_message"
+    fi
+}
+
 # Reference implementation of the branch-slug algorithm documented in
 # skills/aif-qa/SKILL.md Step 0.2. Kept in lock-step with the skill's
 # three-step spec: safe_slug, 8-char hash of the original branch name, combine.
@@ -143,18 +156,18 @@ change_summary_ref="$SKILL_DIR/references/CHANGE-SUMMARY.md"
 test_plan_ref="$SKILL_DIR/references/TEST-PLAN.md"
 test_cases_ref="$SKILL_DIR/references/TEST-CASES.md"
 
-# Contract: follow-up handoff commands keep the resolved branch placeholder intact
-if grep -q '/aif-qa test-plan <resolved_branch>' "$change_summary_ref"; then
-    pass "CHANGE-SUMMARY.md keeps exact test-plan handoff"
-else
-    fail "CHANGE-SUMMARY.md must contain '/aif-qa test-plan <resolved_branch>'"
-fi
+# Contract: follow-up handoff commands keep the exact prompt option lines intact
+assert_exact_line \
+    "$change_summary_ref" \
+    '1. Yes - run /aif-qa test-plan <resolved_branch>' \
+    "CHANGE-SUMMARY.md keeps exact test-plan handoff line" \
+    "CHANGE-SUMMARY.md must contain the exact handoff line '1. Yes - run /aif-qa test-plan <resolved_branch>'"
 
-if grep -q '/aif-qa test-cases <resolved_branch>' "$test_plan_ref"; then
-    pass "TEST-PLAN.md keeps exact test-cases handoff"
-else
-    fail "TEST-PLAN.md must contain '/aif-qa test-cases <resolved_branch>'"
-fi
+assert_exact_line \
+    "$test_plan_ref" \
+    '1. Yes — run /aif-qa test-cases <resolved_branch>' \
+    "TEST-PLAN.md keeps exact test-cases handoff line" \
+    "TEST-PLAN.md must contain the exact handoff line '1. Yes — run /aif-qa test-cases <resolved_branch>'"
 
 # Contract: final-stage guidance still carries the resolved branch context
 if [[ -f "$test_cases_ref" ]] && grep -q 'resolved_branch' "$test_cases_ref"; then
@@ -163,14 +176,24 @@ else
     fail "TEST-CASES.md must reference resolved_branch"
 fi
 
-# Contract: reduced commit scope must also narrow diff scope through analysis_base
-if grep -q 'analysis_base' "$change_summary_ref" && \
-   grep -q 'git diff <analysis_base>...<resolved_branch> --name-status' "$change_summary_ref" && \
-   grep -q 'git diff <analysis_base>...<resolved_branch>' "$change_summary_ref"; then
-    pass "CHANGE-SUMMARY.md uses analysis_base for both diff commands"
+# Contract: reduced commit scope must also narrow diff scope through exact analysis_base command lines
+if grep -Fq 'analysis_base' "$change_summary_ref"; then
+    pass "CHANGE-SUMMARY.md defines analysis_base"
 else
-    fail "CHANGE-SUMMARY.md must drive both diff commands from analysis_base"
+    fail "CHANGE-SUMMARY.md must define analysis_base"
 fi
+
+assert_exact_line \
+    "$change_summary_ref" \
+    'git diff <analysis_base>...<resolved_branch> --name-status' \
+    "CHANGE-SUMMARY.md keeps exact name-status diff line" \
+    "CHANGE-SUMMARY.md must contain the exact line 'git diff <analysis_base>...<resolved_branch> --name-status'"
+
+assert_exact_line \
+    "$change_summary_ref" \
+    'git diff <analysis_base>...<resolved_branch>' \
+    "CHANGE-SUMMARY.md keeps exact full diff line" \
+    "CHANGE-SUMMARY.md must contain the exact line 'git diff <analysis_base>...<resolved_branch>'"
 
 if grep -q 'reduced commit scope and diff scope aligned' "$change_summary_ref"; then
     pass "CHANGE-SUMMARY.md explicitly links reduced commit scope to diff scope"

--- a/scripts/test-aif-qa.sh
+++ b/scripts/test-aif-qa.sh
@@ -18,12 +18,12 @@ FAILED=0
 
 pass() {
     PASSED=$((PASSED + 1))
-    echo -e "  ${GREEN}✓${NC} $1"
+    echo -e "  ${GREEN}OK${NC} $1"
 }
 
 fail() {
     FAILED=$((FAILED + 1))
-    echo -e "  ${RED}✗${NC} $1"
+    echo -e "  ${RED}FAIL${NC} $1"
 }
 
 # Reference implementation of the branch-slug algorithm documented in
@@ -42,22 +42,22 @@ aif_qa_slug() {
     printf '%s-%s\n' "$safe_slug" "$hash8"
 }
 
-# ─────────────────────────────────────────────
-# Part 1: branch-slug algorithm (branch-key uniqueness)
-# ─────────────────────────────────────────────
+# ---------------------------------------------
+# Part 1: branch-slug algorithm behavior
+# ---------------------------------------------
 echo -e "\n${BOLD}=== /aif-qa branch-slug algorithm ===${NC}\n"
 
-# Test 1: classic collision case that motivated the P1 fix in PR #68
+# Test 1: classic collision case that motivated the follow-up
 s1=$(aif_qa_slug "feature/foo")
 s2=$(aif_qa_slug "feature-foo")
 if [[ "$s1" != "$s2" ]]; then
-    pass "feature/foo vs feature-foo are distinct ($s1 ≠ $s2)"
+    pass "feature/foo vs feature-foo are distinct ($s1 != $s2)"
 else
     fail "feature/foo and feature-foo collapsed to $s1"
 fi
 
-# Test 2: multi-way injectivity — 4 branches that all share the same safe_slug
-# 'feat-x', plus two that differ on safe_slug. All 6 must produce unique slugs.
+# Test 2: several branches that normalize toward the same readable slug
+# still resolve to distinct derived slugs once the hash suffix is applied.
 branches=('feat/x' 'feat-x' 'feat x' 'feat--x' 'feat.x' 'feat_x')
 slugs=()
 for b in "${branches[@]}"; do
@@ -65,11 +65,11 @@ for b in "${branches[@]}"; do
 done
 unique_count=$(printf '%s\n' "${slugs[@]}" | sort -u | wc -l | tr -d ' ')
 if [[ "$unique_count" -eq "${#branches[@]}" ]]; then
-    pass "${#branches[@]} colliding branches → ${#branches[@]} unique slugs"
+    pass "${#branches[@]} representative branches -> ${#branches[@]} unique derived slugs"
 else
     fail "expected ${#branches[@]} unique slugs, got $unique_count"
     for i in "${!branches[@]}"; do
-        echo "      '${branches[$i]}' → ${slugs[$i]}"
+        echo "      '${branches[$i]}' -> ${slugs[$i]}"
     done
 fi
 
@@ -97,7 +97,7 @@ else
     fail "slug missing 8-char hex hash suffix: $s"
 fi
 
-# Test 6: deterministic — same input always produces the same slug
+# Test 6: deterministic - same input always produces the same slug
 s1=$(aif_qa_slug "feature/x")
 s2=$(aif_qa_slug "feature/x")
 if [[ "$s1" == "$s2" ]]; then
@@ -106,16 +106,16 @@ else
     fail "non-deterministic slug: $s1 vs $s2"
 fi
 
-# ─────────────────────────────────────────────
-# Part 2: skill contract (explicit-branch flow, --all mode, stage handoff)
-# ─────────────────────────────────────────────
+# ---------------------------------------------
+# Part 2: skill contract
+# ---------------------------------------------
 echo -e "\n${BOLD}=== /aif-qa skill contract ===${NC}\n"
 
-# Contract: SKILL.md documents the injective slug encoding
-if grep -qi 'injective' "$SKILL_DIR/SKILL.md"; then
-    pass "SKILL.md documents injective branch-slug encoding"
+# Contract: SKILL.md documents the deterministic, collision-resistant slug contract
+if grep -qi 'collision-resistant' "$SKILL_DIR/SKILL.md" && grep -qi 'filesystem-safe' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md documents a filesystem-safe, collision-resistant branch slug"
 else
-    fail "SKILL.md must mention 'injective' branch-slug encoding"
+    fail "SKILL.md must describe the branch slug as filesystem-safe and collision-resistant"
 fi
 
 # Contract: SKILL.md specifies git hash-object as the hash step
@@ -139,15 +139,44 @@ else
     fail "SKILL.md must document --all mode"
 fi
 
-# Contract: stage references propagate resolved_branch across all three stages
-for stage in CHANGE-SUMMARY TEST-PLAN TEST-CASES; do
-    ref_file="$SKILL_DIR/references/${stage}.md"
-    if [[ -f "$ref_file" ]] && grep -q 'resolved_branch' "$ref_file"; then
-        pass "references/${stage}.md uses resolved_branch for stage handoff"
-    else
-        fail "references/${stage}.md must reference resolved_branch"
-    fi
-done
+change_summary_ref="$SKILL_DIR/references/CHANGE-SUMMARY.md"
+test_plan_ref="$SKILL_DIR/references/TEST-PLAN.md"
+test_cases_ref="$SKILL_DIR/references/TEST-CASES.md"
+
+# Contract: follow-up handoff commands keep the resolved branch placeholder intact
+if grep -q '/aif-qa test-plan <resolved_branch>' "$change_summary_ref"; then
+    pass "CHANGE-SUMMARY.md keeps exact test-plan handoff"
+else
+    fail "CHANGE-SUMMARY.md must contain '/aif-qa test-plan <resolved_branch>'"
+fi
+
+if grep -q '/aif-qa test-cases <resolved_branch>' "$test_plan_ref"; then
+    pass "TEST-PLAN.md keeps exact test-cases handoff"
+else
+    fail "TEST-PLAN.md must contain '/aif-qa test-cases <resolved_branch>'"
+fi
+
+# Contract: final-stage guidance still carries the resolved branch context
+if [[ -f "$test_cases_ref" ]] && grep -q 'resolved_branch' "$test_cases_ref"; then
+    pass "TEST-CASES.md preserves resolved_branch context"
+else
+    fail "TEST-CASES.md must reference resolved_branch"
+fi
+
+# Contract: reduced commit scope must also narrow diff scope through analysis_base
+if grep -q 'analysis_base' "$change_summary_ref" && \
+   grep -q 'git diff <analysis_base>...<resolved_branch> --name-status' "$change_summary_ref" && \
+   grep -q 'git diff <analysis_base>...<resolved_branch>' "$change_summary_ref"; then
+    pass "CHANGE-SUMMARY.md uses analysis_base for both diff commands"
+else
+    fail "CHANGE-SUMMARY.md must drive both diff commands from analysis_base"
+fi
+
+if grep -q 'reduced commit scope and diff scope aligned' "$change_summary_ref"; then
+    pass "CHANGE-SUMMARY.md explicitly links reduced commit scope to diff scope"
+else
+    fail "CHANGE-SUMMARY.md must explicitly state that reduced commit scope and diff scope stay aligned"
+fi
 
 # Contract: allowed-tools covers both Bash(git *) and Bash(mkdir *)
 # (an earlier PR review caught a mismatch between instructions and permissions)
@@ -158,9 +187,9 @@ else
     fail "SKILL.md allowed-tools must include Bash(git *) and Bash(mkdir *)"
 fi
 
-# ─────────────────────────────────────────────
+# ---------------------------------------------
 # Summary
-# ─────────────────────────────────────────────
+# ---------------------------------------------
 TOTAL=$((PASSED + FAILED))
 echo ""
 echo -e "${BOLD}Total:${NC} $TOTAL, ${GREEN}Passed:${NC} $PASSED, ${RED}Failed:${NC} $FAILED"

--- a/scripts/test-aif-qa.sh
+++ b/scripts/test-aif-qa.sh
@@ -18,12 +18,12 @@ FAILED=0
 
 pass() {
     PASSED=$((PASSED + 1))
-    echo -e "  ${GREEN}OK${NC} $1"
+    echo -e "  ${GREEN}✓${NC} $1"
 }
 
 fail() {
     FAILED=$((FAILED + 1))
-    echo -e "  ${RED}FAIL${NC} $1"
+    echo -e "  ${RED}✗${NC} $1"
 }
 
 assert_exact_line() {
@@ -55,16 +55,16 @@ aif_qa_slug() {
     printf '%s-%s\n' "$safe_slug" "$hash8"
 }
 
-# ---------------------------------------------
+# ─────────────────────────────────────────────
 # Part 1: branch-slug algorithm behavior
-# ---------------------------------------------
+# ─────────────────────────────────────────────
 echo -e "\n${BOLD}=== /aif-qa branch-slug algorithm ===${NC}\n"
 
 # Test 1: classic collision case that motivated the follow-up
 s1=$(aif_qa_slug "feature/foo")
 s2=$(aif_qa_slug "feature-foo")
 if [[ "$s1" != "$s2" ]]; then
-    pass "feature/foo vs feature-foo are distinct ($s1 != $s2)"
+    pass "feature/foo vs feature-foo are distinct ($s1 ≠ $s2)"
 else
     fail "feature/foo and feature-foo collapsed to $s1"
 fi
@@ -78,11 +78,11 @@ for b in "${branches[@]}"; do
 done
 unique_count=$(printf '%s\n' "${slugs[@]}" | sort -u | wc -l | tr -d ' ')
 if [[ "$unique_count" -eq "${#branches[@]}" ]]; then
-    pass "${#branches[@]} representative branches -> ${#branches[@]} unique derived slugs"
+    pass "${#branches[@]} representative branches → ${#branches[@]} unique derived slugs"
 else
     fail "expected ${#branches[@]} unique slugs, got $unique_count"
     for i in "${!branches[@]}"; do
-        echo "      '${branches[$i]}' -> ${slugs[$i]}"
+        echo "      '${branches[$i]}' → ${slugs[$i]}"
     done
 fi
 
@@ -110,7 +110,7 @@ else
     fail "slug missing 8-char hex hash suffix: $s"
 fi
 
-# Test 6: deterministic - same input always produces the same slug
+# Test 6: deterministic — same input always produces the same slug
 s1=$(aif_qa_slug "feature/x")
 s2=$(aif_qa_slug "feature/x")
 if [[ "$s1" == "$s2" ]]; then
@@ -119,9 +119,9 @@ else
     fail "non-deterministic slug: $s1 vs $s2"
 fi
 
-# ---------------------------------------------
+# ─────────────────────────────────────────────
 # Part 2: skill contract
-# ---------------------------------------------
+# ─────────────────────────────────────────────
 echo -e "\n${BOLD}=== /aif-qa skill contract ===${NC}\n"
 
 # Contract: SKILL.md documents the deterministic, collision-resistant slug contract
@@ -159,9 +159,9 @@ test_cases_ref="$SKILL_DIR/references/TEST-CASES.md"
 # Contract: follow-up handoff commands keep the exact prompt option lines intact
 assert_exact_line \
     "$change_summary_ref" \
-    '1. Yes - run /aif-qa test-plan <resolved_branch>' \
+    '1. Yes — run /aif-qa test-plan <resolved_branch>' \
     "CHANGE-SUMMARY.md keeps exact test-plan handoff line" \
-    "CHANGE-SUMMARY.md must contain the exact handoff line '1. Yes - run /aif-qa test-plan <resolved_branch>'"
+    "CHANGE-SUMMARY.md must contain the exact handoff line '1. Yes — run /aif-qa test-plan <resolved_branch>'"
 
 assert_exact_line \
     "$test_plan_ref" \
@@ -210,9 +210,9 @@ else
     fail "SKILL.md allowed-tools must include Bash(git *) and Bash(mkdir *)"
 fi
 
-# ---------------------------------------------
+# ─────────────────────────────────────────────
 # Summary
-# ---------------------------------------------
+# ─────────────────────────────────────────────
 TOTAL=$((PASSED + FAILED))
 echo ""
 echo -e "${BOLD}Total:${NC} $TOTAL, ${GREEN}Passed:${NC} $PASSED, ${RED}Failed:${NC} $FAILED"

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -260,6 +260,11 @@ AIF_ARCH_CONFIRM_SECTION="$(awk '
     capture { print }
     /^## Artifact Ownership$/ { if (capture) exit }
 ' "$AIF_ARCH_SKILL")"
+AIF_ARCH_OWNERSHIP_SECTION="$(awk '
+    /^## Artifact Ownership$/ { capture=1 }
+    capture { print }
+    capture && /^---$/ { exit }
+' "$AIF_ARCH_SKILL")"
 
 if grep -Fq 'Immediately after determining Mode 1, Mode 2, or Mode 3, resolve the project language settings for the entire `/aif` run.' "$AIF_SKILL"; then
     pass "/aif resolves language immediately after mode detection"
@@ -457,6 +462,19 @@ if printf '%s\n' "$AIF_ARCH_CONFIRM_SECTION" | grep -Fq 'Architecture document g
     fail "English default-path confirmation text reintroduced in /aif-architecture"
 else
     pass "no English default-path confirmation text in /aif-architecture"
+fi
+
+if printf '%s\n' "$AIF_ARCH_OWNERSHIP_SECTION" | grep -Fq 'resolved DESCRIPTION path from `config.yaml`' \
+   && printf '%s\n' "$AIF_ARCH_OWNERSHIP_SECTION" | grep -Fq 'architecture row in `AGENTS.md` context table.'; then
+    pass "/aif-architecture Artifact Ownership keeps companion updates path-aware"
+else
+    fail "/aif-architecture Artifact Ownership companion update contract missing"
+fi
+
+if printf '%s\n' "$AIF_ARCH_OWNERSHIP_SECTION" | grep -Fq '.ai-factory/DESCRIPTION.md'; then
+    fail "default DESCRIPTION path leaked into /aif-architecture Artifact Ownership"
+else
+    pass "no default DESCRIPTION path leak in /aif-architecture Artifact Ownership"
 fi
 
 # No hardcoded agent-specific values (must use {{template_vars}})

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -213,6 +213,7 @@ fi
 
 # /aif localization contract regression checks
 AIF_SKILL="$ROOT_DIR/skills/aif/SKILL.md"
+AIF_ARCH_SKILL="$ROOT_DIR/skills/aif-architecture/SKILL.md"
 MODE2_DESCRIPTION_SECTION="$(awk '
     /^\*\*Step 3: Create \.ai-factory\/DESCRIPTION\.md\*\*$/ { capture=1 }
     capture { print }
@@ -234,6 +235,21 @@ EXISTING_PROJECT_SUGGESTIONS_SECTION="$(awk '
     capture { print }
     /^Present these as `AskUserQuestion` with multi-select options:$/ { if (capture) exit }
 ' "$AIF_SKILL")"
+AIF_ARCH_DESCRIPTION_SECTION="$(awk '
+    /^### Step 3: Update DESCRIPTION\.md$/ { capture=1 }
+    capture { print }
+    /^### Step 4: Update AGENTS\.md$/ { if (capture) exit }
+' "$AIF_ARCH_SKILL")"
+AIF_ARCH_AGENTS_SECTION="$(awk '
+    /^### Step 4: Update AGENTS\.md$/ { capture=1 }
+    capture { print }
+    /^### Step 5: Confirm$/ { if (capture) exit }
+' "$AIF_ARCH_SKILL")"
+AIF_ARCH_CONFIRM_SECTION="$(awk '
+    /^### Step 5: Confirm$/ { capture=1 }
+    capture { print }
+    /^## Artifact Ownership$/ { if (capture) exit }
+' "$AIF_ARCH_SKILL")"
 
 if grep -Fq 'Immediately after determining Mode 1, Mode 2, or Mode 3, resolve the project language settings for the entire `/aif` run.' "$AIF_SKILL"; then
     pass "/aif resolves language immediately after mode detection"
@@ -364,6 +380,50 @@ else
     pass "no English existing-project suggestions in /aif"
 fi
 
+if printf '%s\n' "$AIF_ARCH_DESCRIPTION_SECTION" | grep -Fq 'resolved `language.artifacts`' \
+   && printf '%s\n' "$AIF_ARCH_DESCRIPTION_SECTION" | grep -Fq 'Use the resolved architecture path from config, not the default path literal.' \
+   && printf '%s\n' "$AIF_ARCH_DESCRIPTION_SECTION" | grep -Fq '## [Localized heading: Architecture]' \
+   && printf '%s\n' "$AIF_ARCH_DESCRIPTION_SECTION" | grep -Fq '[Localized sentence in resolved artifacts language referencing the resolved architecture artifact path for detailed architecture guidelines.]'; then
+    pass "/aif-architecture keeps DESCRIPTION companion update path-aware and localized"
+else
+    fail "/aif-architecture DESCRIPTION companion update contract missing"
+fi
+
+if printf '%s\n' "$AIF_ARCH_DESCRIPTION_SECTION" | grep -Fq '## Architecture' \
+   || printf '%s\n' "$AIF_ARCH_DESCRIPTION_SECTION" | grep -Fq 'Pattern: [chosen pattern name]'; then
+    fail "English DESCRIPTION companion update reintroduced in /aif-architecture"
+else
+    pass "no English DESCRIPTION companion update in /aif-architecture"
+fi
+
+if printf '%s\n' "$AIF_ARCH_AGENTS_SECTION" | grep -Fq 'resolved `language.artifacts`' \
+   && printf '%s\n' "$AIF_ARCH_AGENTS_SECTION" | grep -Fq '| [resolved-architecture-path] | [Localized architecture artifact description in resolved artifacts language] |' \
+   && printf '%s\n' "$AIF_ARCH_AGENTS_SECTION" | grep -Fq 'Only add if the resolved architecture path is not already present.'; then
+    pass "/aif-architecture keeps AGENTS companion update path-aware and localized"
+else
+    fail "/aif-architecture AGENTS companion update contract missing"
+fi
+
+if printf '%s\n' "$AIF_ARCH_CONFIRM_SECTION" | grep -Fq 'resolved `language.ui`' \
+   && printf '%s\n' "$AIF_ARCH_CONFIRM_SECTION" | grep -Fq '[Localized pattern label in `language.ui`]: [chosen pattern]' \
+   && printf '%s\n' "$AIF_ARCH_CONFIRM_SECTION" | grep -Fq '[Localized file label in `language.ui`]: [resolved architecture path]' \
+   && printf '%s\n' "$AIF_ARCH_CONFIRM_SECTION" | grep -Fq '[Localized success heading in `language.ui`]' \
+   && printf '%s\n' "$AIF_ARCH_CONFIRM_SECTION" | grep -Fq '[Localized closing sentence in `language.ui` about workflow skills following these architecture guidelines.]'; then
+    pass "/aif-architecture confirmation uses resolved UI language and path"
+else
+    fail "/aif-architecture confirmation localization/path contract missing"
+fi
+
+if printf '%s\n' "$AIF_ARCH_CONFIRM_SECTION" | grep -Fq 'Architecture document generated!' \
+   || printf '%s\n' "$AIF_ARCH_CONFIRM_SECTION" | grep -Fq 'Pattern: [chosen pattern]' \
+   || printf '%s\n' "$AIF_ARCH_CONFIRM_SECTION" | grep -Fq 'File: .ai-factory/ARCHITECTURE.md' \
+   || printf '%s\n' "$AIF_ARCH_CONFIRM_SECTION" | grep -Fq 'Key rules:' \
+   || printf '%s\n' "$AIF_ARCH_CONFIRM_SECTION" | grep -Fq 'All workflow skills (/aif-plan, /aif-implement) will now follow these architecture guidelines.'; then
+    fail "English default-path confirmation text reintroduced in /aif-architecture"
+else
+    pass "no English default-path confirmation text in /aif-architecture"
+fi
+
 # No hardcoded agent-specific values (must use {{template_vars}})
 # skills_dir patterns
 HARDCODED_SKILLS_DIR=$(grep -rE '\.(claude|cursor|codex|github|gemini|junie|qwen|windsurf|warp)/skills' "$ROOT_DIR/skills/" "$ROOT_DIR/subagents/" --include='*.md' 2>/dev/null | grep -v '{{' | wc -l | tr -d ' ' || true)
@@ -398,7 +458,8 @@ fi
 echo -e "\n${BOLD}=== Subagent integrity checks ===${NC}\n"
 
 set +e
-SUBAGENT_LINT_OUTPUT=$(ROOT_DIR="$ROOT_DIR" node --input-type=module <<'EOF' 2>&1
+SUBAGENT_LINT_OUTPUT=$(
+ROOT_DIR="$ROOT_DIR" node --input-type=module - 2>&1 <<'EOF'
 import fs from 'fs';
 import path from 'path';
 
@@ -415,7 +476,7 @@ const errors = [];
 function getFrontmatter(content, file) {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) {
-    errors.push(`${file}: missing frontmatter`);
+    errors.push(file + ': missing frontmatter');
     return '';
   }
   return match[1];
@@ -436,19 +497,19 @@ for (const file of files) {
   const hasWriterTools = /\bWrite\b|\bEdit\b/.test(tools);
 
   if (name !== expectedName) {
-    errors.push(`${file}: frontmatter name "${name}" does not match filename "${expectedName}"`);
+    errors.push(file + ': frontmatter name "' + name + '" does not match filename "' + expectedName + '"');
   }
 
   if (background && hasWriterTools) {
-    errors.push(`${file}: background agents must be read-only`);
+    errors.push(file + ': background agents must be read-only');
   }
 
-  if (docsContent.includes(`\`${expectedName}\``) === false) {
-    errors.push(`${file}: missing from docs/subagents.md inventory`);
+  if (docsContent.includes('`' + expectedName + '`') === false) {
+    errors.push(file + ': missing from docs/subagents.md inventory');
   }
 
-  if (refsContent.includes(`\`${expectedName}\``) === false) {
-    errors.push(`${file}: missing from .references/CLAUDE-SUBAGENTS.md inventory`);
+  if (refsContent.includes('`' + expectedName + '`') === false) {
+    errors.push(file + ': missing from .references/CLAUDE-SUBAGENTS.md inventory');
   }
 }
 

--- a/skills/aif-architecture/SKILL.md
+++ b/skills/aif-architecture/SKILL.md
@@ -160,43 +160,46 @@ Generate the resolved architecture artifact (default: `.ai-factory/ARCHITECTURE.
 
 ### Step 3: Update DESCRIPTION.md
 
-If the resolved DESCRIPTION.md path exists, add an `## Architecture` section (or update if it already exists):
+If the resolved DESCRIPTION.md path exists, add or update an architecture-pointer section in resolved `language.artifacts`.
+Use the resolved architecture path from config, not the default path literal.
 
 ```markdown
-## Architecture
-See the configured architecture artifact for detailed architecture guidelines.
-Pattern: [chosen pattern name]
+## [Localized heading: Architecture]
+[Localized sentence in resolved artifacts language referencing the resolved architecture artifact path for detailed architecture guidelines.]
+[Localized label: Pattern]: [chosen pattern name]
 ```
 
 ### Step 4: Update AGENTS.md
 
-If `AGENTS.md` exists in the project root, add `.ai-factory/ARCHITECTURE.md` to the "AI Context Files" table:
+If `AGENTS.md` exists in the project root, add the resolved architecture artifact path to the localized "AI Context Files" table in resolved `language.artifacts`:
 
 ```markdown
-| .ai-factory/ARCHITECTURE.md | Architecture decisions and guidelines |
+| [resolved-architecture-path] | [Localized architecture artifact description in resolved artifacts language] |
 ```
 
-Only add if not already present.
+Only add if the resolved architecture path is not already present.
 
 ### Step 5: Confirm
 
+Present the confirmation in resolved `language.ui` and report the resolved architecture path:
+
 ```
-✅ Architecture document generated!
+[Localized success heading in `language.ui`]
 
-Pattern: [chosen pattern]
-File: .ai-factory/ARCHITECTURE.md
+[Localized pattern label in `language.ui`]: [chosen pattern]
+[Localized file label in `language.ui`]: [resolved architecture path]
 
-Key rules:
+[Localized key-rules heading in `language.ui`]:
 - [rule 1]
 - [rule 2]
 - [rule 3]
 
-All workflow skills (/aif-plan, /aif-implement) will now follow these architecture guidelines.
+[Localized closing sentence in `language.ui` about workflow skills following these architecture guidelines.]
 ```
 
 ## Artifact Ownership
 
-- Primary ownership: `.ai-factory/ARCHITECTURE.md`.
+- Primary ownership: the resolved architecture artifact path (default: `.ai-factory/ARCHITECTURE.md`).
 - Respect config overrides: write to the resolved architecture path from `config.yaml` when provided.
 - Allowed companion updates: architecture pointer in `.ai-factory/DESCRIPTION.md`, architecture row in `AGENTS.md` context table.
 - Read-only context: roadmap, rules, research, and plan artifacts unless user explicitly requests otherwise.

--- a/skills/aif-architecture/SKILL.md
+++ b/skills/aif-architecture/SKILL.md
@@ -201,7 +201,7 @@ Present the confirmation in resolved `language.ui` and report the resolved archi
 
 - Primary ownership: the resolved architecture artifact path (default: `.ai-factory/ARCHITECTURE.md`).
 - Respect config overrides: write to the resolved architecture path from `config.yaml` when provided.
-- Allowed companion updates: architecture pointer in `.ai-factory/DESCRIPTION.md`, architecture row in `AGENTS.md` context table.
+- Allowed companion updates: architecture pointer in the resolved DESCRIPTION path from `config.yaml`, architecture row in `AGENTS.md` context table.
 - Read-only context: roadmap, rules, research, and plan artifacts unless user explicitly requests otherwise.
 
 ---

--- a/skills/aif-qa/SKILL.md
+++ b/skills/aif-qa/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read Write Grep Glob Bash(git *) Bash(mkdir *) AskUserQuestion Ta
 disable-model-invocation: false
 ---
 
-# QA - Implementation Testing
+# QA — Implementation Testing
 
 Generates change summaries, produces test plans, and describes test scenarios for a feature or task implementation.
 
@@ -53,7 +53,7 @@ If config.yaml doesn't exist, use defaults:
 
 Use this context when generating summaries, test plans, and test cases.
 
-**Read `.ai-factory/skill-context/aif-qa/SKILL.md`** - MANDATORY if the file exists.
+**Read `.ai-factory/skill-context/aif-qa/SKILL.md`** — MANDATORY if the file exists.
 
 This file contains project-specific rules accumulated by `/aif-evolve` from patches,
 codebase conventions, and tech-stack analysis. These rules are tailored to the current project.
@@ -68,50 +68,50 @@ codebase conventions, and tech-stack analysis. These rules are tailored to the c
 
 Parse `$ARGUMENTS` fully before doing anything else:
 
-1. **Detect `--all` flag** - if present, set `all_mode = true` and remove the flag from arguments
-2. **Detect mode** - first word matching `change-summary`, `test-plan`, or `test-cases`; remove it from arguments
-3. **Detect branch** - remaining text (if any) is the target branch name
+1. **Detect `--all` flag** — if present, set `all_mode = true` and remove the flag from arguments
+2. **Detect mode** — first word matching `change-summary`, `test-plan`, or `test-cases`; remove it from arguments
+3. **Detect branch** — remaining text (if any) is the target branch name
 
 **Resolve the working branch:**
 
 ```text
-If branch was provided in arguments -> use it as the resolved branch
-Otherwise -> run: git branch --show-current
+If branch was provided in arguments → use it as the resolved branch
+Otherwise → run: git branch --show-current
 ```
 
 Store both values for use in all reference files:
-- `resolved_branch` - the branch being analyzed (used to locate/save artifacts)
-- `artifact_dir` - `<resolved paths.qa>/<branch-slug>`, where `branch-slug` is a deterministic, filesystem-safe, collision-resistant slug derived from `resolved_branch`. Compute it in three steps:
+- `resolved_branch` — the branch being analyzed (used to locate/save artifacts)
+- `artifact_dir` — `<resolved paths.qa>/<branch-slug>`, where `branch-slug` is a deterministic, filesystem-safe, collision-resistant slug derived from `resolved_branch`. Compute it in three steps:
   1. **Safe slug.** Take `resolved_branch` and replace every character that is not in `[A-Za-z0-9._-]` with `-`, collapse runs of consecutive `-` into a single `-`, and trim leading/trailing `-`. If the result is empty, use `branch`. Optionally truncate to 40 characters. Call this `safe_slug`.
   2. **Hash suffix.** Run `git hash-object --stdin <<< "<resolved_branch>"` and take the **first 8 hex characters** of the output. Call this `hash8`. The hash is derived from the **original, unnormalized** branch name so branches that collapse to the same `safe_slug` still produce different derived slugs in normal use.
   3. **Combine:** `branch-slug = "<safe_slug>-<hash8>"`.
 
-  **Why the hash:** a readable slug alone is lossy - `feature/foo` and `feature-foo` normalize to the same `safe_slug` and would overwrite each other's artifacts. Appending a short hash of the full original name keeps the derived slug stable, readable, and collision-resistant for practical branch naming.
+  **Why the hash:** a readable slug alone is lossy — `feature/foo` and `feature-foo` normalize to the same `safe_slug` and would overwrite each other's artifacts. Appending a short hash of the full original name keeps the derived slug stable, readable, and collision-resistant for practical branch naming.
 
   **Examples:**
-  - `feature/foo` -> `safe_slug=feature-foo`, `hash8=a72ccce7` -> `feature-foo-a72ccce7`
-  - `feature-foo` -> `safe_slug=feature-foo`, `hash8=6f80dfc6` -> `feature-foo-6f80dfc6`
-  - `main` -> `safe_slug=main`, `hash8=<computed>` -> `main-<hash8>`
-- `all_mode` - whether to skip inter-stage prompts
+  - `feature/foo` → `safe_slug=feature-foo`, `hash8=a72ccce7` → `feature-foo-a72ccce7`
+  - `feature-foo` → `safe_slug=feature-foo`, `hash8=6f80dfc6` → `feature-foo-6f80dfc6`
+  - `main` → `safe_slug=main`, `hash8=<computed>` → `main-<hash8>`
+- `all_mode` — whether to skip inter-stage prompts
 
-**If no mode was provided and `all_mode = false` - ask the user:**
+**If no mode was provided and `all_mode = false` — ask the user:**
 
 ```text
 AskUserQuestion: Which QA mode would you like to run?
 
 Options:
-1. Change summary (change-summary) - analyze what changed, assess risks, produce a summary
-2. Test plan (test-plan) - create a structured test plan based on the change summary
-3. Test cases (test-cases) - describe concrete test scenarios based on the plan
-4. Full pipeline (--all) - run all three modes in sequence
+1. Change summary (change-summary) — analyze what changed, assess risks, produce a summary
+2. Test plan (test-plan) — create a structured test plan based on the change summary
+3. Test cases (test-cases) — describe concrete test scenarios based on the plan
+4. Full pipeline (--all) — run all three modes in sequence
 ```
 
 ### Step 1: Execute the Selected Mode
 
-The skill runs **strictly sequentially** - each stage uses the artifact from the previous one:
+The skill runs **strictly sequentially** — each stage uses the artifact from the previous one:
 
 ```text
-change-summary -> test-plan -> test-cases
+change-summary → test-plan → test-cases
 ```
 
 Read the detailed instructions for the selected mode:
@@ -131,16 +131,16 @@ Read `references/TEST-CASES.md`
 #### Full Pipeline (--all)
 
 Run all three modes in sequence. After each stage completes successfully,
-proceed to the next automatically - **do NOT show the inter-stage `AskUserQuestion`**.
+proceed to the next automatically — **do NOT show the inter-stage `AskUserQuestion`**.
 
 ```text
-1. Execute change-summary (references/CHANGE-SUMMARY.md) -> save artifact
-2. Execute test-plan      (references/TEST-PLAN.md)      -> save artifact
-3. Execute test-cases     (references/TEST-CASES.md)     -> save artifact
+1. Execute change-summary (references/CHANGE-SUMMARY.md) → save artifact
+2. Execute test-plan      (references/TEST-PLAN.md)      → save artifact
+3. Execute test-cases     (references/TEST-CASES.md)     → save artifact
 4. Show context cleanup prompt (Step 6 of TEST-CASES.md)
 ```
 
-If any stage fails (e.g. git error, diff too large and user cancels) - stop the pipeline and report which stage failed.
+If any stage fails (e.g. git error, diff too large and user cancels) — stop the pipeline and report which stage failed.
 
 ---
 
@@ -152,9 +152,9 @@ If any stage fails (e.g. git error, diff too large and user cancels) - stop the 
 - Use the repository code only to the extent needed for the change analysis, test plan, and test cases
 - Write steps clearly enough that any tester can execute the test without knowledge of the codebase
 - Specify concrete test data, not abstract "enter valid data"
-- Prioritize - not everything is equally important
+- Prioritize — not everything is equally important
 - Think about adjacent systems, integrations, and dependencies
-- Include negative scenarios and edge cases - they catch most bugs
+- Include negative scenarios and edge cases — they catch most bugs
 - Ask clarifying questions when business logic is not obvious from the code
 
 ### DO NOT:
@@ -162,7 +162,7 @@ If any stage fails (e.g. git error, diff too large and user cancels) - stop the 
 - Suggest automated tests or mention testing frameworks
 - Make assumptions about business logic without reading the code
 - Skip negative scenarios
-- Write test cases for everything - focus on risky areas
+- Write test cases for everything — focus on risky areas
 - Ignore data edge cases
 
 ---
@@ -177,7 +177,7 @@ If any stage fails (e.g. git error, diff too large and user cancels) - stop the 
 
 ## Artifact Ownership and Config Policy
 
-- Primary ownership: QA artifacts under `<paths.qa>/<branch-slug>/` - specifically `change-summary.md`, `test-plan.md`, and `test-cases.md`. The `--all` flag respects the same boundary.
+- Primary ownership: QA artifacts under `<paths.qa>/<branch-slug>/` — specifically `change-summary.md`, `test-plan.md`, and `test-cases.md`. The `--all` flag respects the same boundary.
 - Write policy: persistent writes are limited to the three owned artifacts above; no other files are created or modified.
 - Config policy: config-aware, read-only. Reads `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, and `git.base_branch`; never writes `config.yaml`.
 

--- a/skills/aif-qa/SKILL.md
+++ b/skills/aif-qa/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read Write Grep Glob Bash(git *) Bash(mkdir *) AskUserQuestion Ta
 disable-model-invocation: false
 ---
 
-# QA — Implementation Testing
+# QA - Implementation Testing
 
 Generates change summaries, produces test plans, and describes test scenarios for a feature or task implementation.
 
@@ -53,7 +53,7 @@ If config.yaml doesn't exist, use defaults:
 
 Use this context when generating summaries, test plans, and test cases.
 
-**Read `.ai-factory/skill-context/aif-qa/SKILL.md`** — MANDATORY if the file exists.
+**Read `.ai-factory/skill-context/aif-qa/SKILL.md`** - MANDATORY if the file exists.
 
 This file contains project-specific rules accumulated by `/aif-evolve` from patches,
 codebase conventions, and tech-stack analysis. These rules are tailored to the current project.
@@ -68,50 +68,50 @@ codebase conventions, and tech-stack analysis. These rules are tailored to the c
 
 Parse `$ARGUMENTS` fully before doing anything else:
 
-1. **Detect `--all` flag** — if present, set `all_mode = true` and remove the flag from arguments
-2. **Detect mode** — first word matching `change-summary`, `test-plan`, or `test-cases`; remove it from arguments
-3. **Detect branch** — remaining text (if any) is the target branch name
+1. **Detect `--all` flag** - if present, set `all_mode = true` and remove the flag from arguments
+2. **Detect mode** - first word matching `change-summary`, `test-plan`, or `test-cases`; remove it from arguments
+3. **Detect branch** - remaining text (if any) is the target branch name
 
 **Resolve the working branch:**
 
-```
-If branch was provided in arguments → use it as the resolved branch
-Otherwise → run: git branch --show-current
+```text
+If branch was provided in arguments -> use it as the resolved branch
+Otherwise -> run: git branch --show-current
 ```
 
 Store both values for use in all reference files:
-- `resolved_branch` — the branch being analyzed (used to locate/save artifacts)
-- `artifact_dir` — `<resolved paths.qa>/<branch-slug>`, where `branch-slug` is an **injective** encoding of `resolved_branch`. Compute it in three steps:
+- `resolved_branch` - the branch being analyzed (used to locate/save artifacts)
+- `artifact_dir` - `<resolved paths.qa>/<branch-slug>`, where `branch-slug` is a deterministic, filesystem-safe, collision-resistant slug derived from `resolved_branch`. Compute it in three steps:
   1. **Safe slug.** Take `resolved_branch` and replace every character that is not in `[A-Za-z0-9._-]` with `-`, collapse runs of consecutive `-` into a single `-`, and trim leading/trailing `-`. If the result is empty, use `branch`. Optionally truncate to 40 characters. Call this `safe_slug`.
-  2. **Hash suffix.** Run `git hash-object --stdin <<< "<resolved_branch>"` and take the **first 8 hex characters** of the output. Call this `hash8`. The hash is derived from the **original, unnormalized** branch name — this is what guarantees uniqueness.
+  2. **Hash suffix.** Run `git hash-object --stdin <<< "<resolved_branch>"` and take the **first 8 hex characters** of the output. Call this `hash8`. The hash is derived from the **original, unnormalized** branch name so branches that collapse to the same `safe_slug` still produce different derived slugs in normal use.
   3. **Combine:** `branch-slug = "<safe_slug>-<hash8>"`.
 
-  **Why the hash:** a readable slug alone is lossy — `feature/foo` and `feature-foo` normalize to the same `safe_slug` and would overwrite each other's artifacts. Appending a hash of the full original name makes the mapping injective: different branches always resolve to different directories.
+  **Why the hash:** a readable slug alone is lossy - `feature/foo` and `feature-foo` normalize to the same `safe_slug` and would overwrite each other's artifacts. Appending a short hash of the full original name keeps the derived slug stable, readable, and collision-resistant for practical branch naming.
 
   **Examples:**
-  - `feature/foo` → `safe_slug=feature-foo`, `hash8=a72ccce7` → `feature-foo-a72ccce7`
-  - `feature-foo` → `safe_slug=feature-foo`, `hash8=6f80dfc6` → `feature-foo-6f80dfc6`
-  - `main` → `safe_slug=main`, `hash8=<computed>` → `main-<hash8>`
-- `all_mode` — whether to skip inter-stage prompts
+  - `feature/foo` -> `safe_slug=feature-foo`, `hash8=a72ccce7` -> `feature-foo-a72ccce7`
+  - `feature-foo` -> `safe_slug=feature-foo`, `hash8=6f80dfc6` -> `feature-foo-6f80dfc6`
+  - `main` -> `safe_slug=main`, `hash8=<computed>` -> `main-<hash8>`
+- `all_mode` - whether to skip inter-stage prompts
 
-**If no mode was provided and `all_mode = false` — ask the user:**
+**If no mode was provided and `all_mode = false` - ask the user:**
 
-```
+```text
 AskUserQuestion: Which QA mode would you like to run?
 
 Options:
-1. Change summary (change-summary) — analyze what changed, assess risks, produce a summary
-2. Test plan (test-plan) — create a structured test plan based on the change summary
-3. Test cases (test-cases) — describe concrete test scenarios based on the plan
-4. Full pipeline (--all) — run all three modes in sequence
+1. Change summary (change-summary) - analyze what changed, assess risks, produce a summary
+2. Test plan (test-plan) - create a structured test plan based on the change summary
+3. Test cases (test-cases) - describe concrete test scenarios based on the plan
+4. Full pipeline (--all) - run all three modes in sequence
 ```
 
 ### Step 1: Execute the Selected Mode
 
-The skill runs **strictly sequentially** — each stage uses the artifact from the previous one:
+The skill runs **strictly sequentially** - each stage uses the artifact from the previous one:
 
-```
-change-summary → test-plan → test-cases
+```text
+change-summary -> test-plan -> test-cases
 ```
 
 Read the detailed instructions for the selected mode:
@@ -131,16 +131,16 @@ Read `references/TEST-CASES.md`
 #### Full Pipeline (--all)
 
 Run all three modes in sequence. After each stage completes successfully,
-proceed to the next automatically — **do NOT show the inter-stage `AskUserQuestion`**.
+proceed to the next automatically - **do NOT show the inter-stage `AskUserQuestion`**.
 
-```
-1. Execute change-summary (references/CHANGE-SUMMARY.md) → save artifact
-2. Execute test-plan      (references/TEST-PLAN.md)      → save artifact
-3. Execute test-cases     (references/TEST-CASES.md)     → save artifact
+```text
+1. Execute change-summary (references/CHANGE-SUMMARY.md) -> save artifact
+2. Execute test-plan      (references/TEST-PLAN.md)      -> save artifact
+3. Execute test-cases     (references/TEST-CASES.md)     -> save artifact
 4. Show context cleanup prompt (Step 6 of TEST-CASES.md)
 ```
 
-If any stage fails (e.g. git error, diff too large and user cancels) — stop the pipeline and report which stage failed.
+If any stage fails (e.g. git error, diff too large and user cancels) - stop the pipeline and report which stage failed.
 
 ---
 
@@ -152,9 +152,9 @@ If any stage fails (e.g. git error, diff too large and user cancels) — stop th
 - Use the repository code only to the extent needed for the change analysis, test plan, and test cases
 - Write steps clearly enough that any tester can execute the test without knowledge of the codebase
 - Specify concrete test data, not abstract "enter valid data"
-- Prioritize — not everything is equally important
+- Prioritize - not everything is equally important
 - Think about adjacent systems, integrations, and dependencies
-- Include negative scenarios and edge cases — they catch most bugs
+- Include negative scenarios and edge cases - they catch most bugs
 - Ask clarifying questions when business logic is not obvious from the code
 
 ### DO NOT:
@@ -162,7 +162,7 @@ If any stage fails (e.g. git error, diff too large and user cancels) — stop th
 - Suggest automated tests or mention testing frameworks
 - Make assumptions about business logic without reading the code
 - Skip negative scenarios
-- Write test cases for everything — focus on risky areas
+- Write test cases for everything - focus on risky areas
 - Ignore data edge cases
 
 ---
@@ -177,7 +177,7 @@ If any stage fails (e.g. git error, diff too large and user cancels) — stop th
 
 ## Artifact Ownership and Config Policy
 
-- Primary ownership: QA artifacts under `<paths.qa>/<branch-slug>/` — specifically `change-summary.md`, `test-plan.md`, and `test-cases.md`. The `--all` flag respects the same boundary.
+- Primary ownership: QA artifacts under `<paths.qa>/<branch-slug>/` - specifically `change-summary.md`, `test-plan.md`, and `test-cases.md`. The `--all` flag respects the same boundary.
 - Write policy: persistent writes are limited to the three owned artifacts above; no other files are created or modified.
 - Config policy: config-aware, read-only. Reads `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, and `git.base_branch`; never writes `config.yaml`.
 

--- a/skills/aif-qa/references/CHANGE-SUMMARY.md
+++ b/skills/aif-qa/references/CHANGE-SUMMARY.md
@@ -1,6 +1,6 @@
 # Reference: Change Summary (change-summary)
 
-> **When to use:** When invoked with the `change-summary` argument (or as the first stage of `--all`). Also run this mode first when the change context is unknown — before writing a test plan or test cases.
+> **When to use:** When invoked with the `change-summary` argument (or as the first stage of `--all`). Also run this mode first when the change context is unknown - before writing a test plan or test cases.
 
 ---
 
@@ -14,17 +14,19 @@ Use the `resolved_branch` and `artifact_dir` resolved in SKILL.md Step 0.2.
 > If `resolved_branch` IS the base branch, set `effective_base = <resolved_branch>~1`.
 > Otherwise, set `effective_base = <base_branch>`.
 >
-> Use `effective_base` for all git commands below. This ensures the log and diff are always consistent and anchored to `resolved_branch`, not to the current checkout.
+> Build the full commit range from `effective_base..<resolved_branch>`.
+> Start with `analysis_base = <effective_base>`.
+> This special case stays anchored to `resolved_branch`, not to the current checkout.
 
-**Get commit list:**
+**Get the full commit list:**
 
 ```bash
 git log <effective_base>..<resolved_branch> --oneline
 ```
 
-**Check commit count — if more than 20, ask before proceeding:**
+**Check commit count - if more than 20, ask before proceeding:**
 
-```
+```text
 AskUserQuestion: Found <N> commits to analyze. Processing all of them may consume significant context. How to proceed?
 
 Options:
@@ -34,32 +36,40 @@ Options:
 ```
 
 Based on choice:
-- "Analyze all" → continue with the full commit list
-- "Analyze only the last 20" → truncate to the 20 most recent
-- "Cancel" → **STOP**
+- "Analyze all" -> keep `analysis_base = <effective_base>`
+- "Analyze only the last 20" -> select the 20 most recent commits from the full range, find the oldest commit in that subset, and set `analysis_base = <oldest_selected_commit>^`
+- "Cancel" -> **STOP**
+
+**Finalize the scoped commit list:**
+
+```bash
+git log <analysis_base>..<resolved_branch> --oneline
+```
+
+Use `analysis_base` for the final commit list and for both diff commands below. This keeps the reduced commit scope and diff scope aligned.
 
 **Get changed files and diff:**
 
 ```bash
-git diff <effective_base>...<resolved_branch> --name-status
-git diff <effective_base>...<resolved_branch>
+git diff <analysis_base>...<resolved_branch> --name-status
+git diff <analysis_base>...<resolved_branch>
 ```
 
-**Check diff size — if the diff exceeds ~1000 lines, warn before proceeding:**
+**Check diff size - if the diff exceeds ~1000 lines, warn before proceeding:**
 
-```
+```text
 AskUserQuestion: The diff is large (<N> lines). Reading it in full will consume significant context. How to proceed?
 
 Options:
-1. Continue — read the full diff
+1. Continue - read the full diff
 2. Read changed files individually instead (recommended for large diffs)
 3. Cancel
 ```
 
 Based on choice:
-- "Continue" → use the full diff as-is
-- "Read files individually" → skip the raw diff; proceed to Step 2 where Explore agents will read the files
-- "Cancel" → **STOP**
+- "Continue" -> use the full diff as-is
+- "Read files individually" -> skip the raw diff; proceed to Step 2 where Explore agents will read the files
+- "Cancel" -> **STOP**
 
 ## Step 2: Explore Key Changed Files
 
@@ -68,16 +78,16 @@ This keeps the main context clean and speeds up analysis on large diffs.
 
 From the `--name-status` output, identify the most important changed files (focus on business logic, skip lock files, generated files, and formatting-only changes).
 
-Launch 1–2 Explore agents simultaneously:
+Launch 1-2 Explore agents simultaneously:
 
-```
-Agent 1 — Core changes:
+```text
+Agent 1 - Core changes:
 Task(subagent_type: Explore, model: sonnet, prompt:
   "Read and summarize the key changed files: [list of most important files].
    Focus on: what logic changed, what inputs/outputs changed, what side effects are possible.
    Thoroughness: medium. Be concise.")
 
-Agent 2 — Integration points (if needed):
+Agent 2 - Integration points (if needed):
 Task(subagent_type: Explore, model: sonnet, prompt:
   "Find all callers and consumers of [changed modules/functions].
    Identify what adjacent functionality might be affected.
@@ -131,14 +141,14 @@ Save the result to `<artifact_dir>/change-summary.md`.
 
 ## Step 6: Next Step
 
-**If `all_mode = true`** — do NOT show the prompt. Proceed directly to `references/TEST-PLAN.md`.
+**If `all_mode = true`** - do NOT show the prompt. Proceed directly to `references/TEST-PLAN.md`.
 
 **Otherwise:**
 
-```
+```text
 AskUserQuestion: Change summary saved. Proceed to writing the test plan?
 
 Options:
-1. Yes — run /aif-qa test-plan <resolved_branch>
-2. No — stop here
+1. Yes - run /aif-qa test-plan <resolved_branch>
+2. No - stop here
 ```

--- a/skills/aif-qa/references/CHANGE-SUMMARY.md
+++ b/skills/aif-qa/references/CHANGE-SUMMARY.md
@@ -38,6 +38,7 @@ Options:
 Based on choice:
 - "Analyze all" -> keep `analysis_base = <effective_base>`
 - "Analyze only the last 20" -> select the 20 most recent commits from the full range, find the oldest commit in that subset, and set `analysis_base = <oldest_selected_commit>^`
+  - This `^` shorthand uses Git's first-parent semantics for the selected oldest commit.
 - "Cancel" -> **STOP**
 
 **Finalize the scoped commit list:**

--- a/skills/aif-qa/references/CHANGE-SUMMARY.md
+++ b/skills/aif-qa/references/CHANGE-SUMMARY.md
@@ -1,6 +1,6 @@
 # Reference: Change Summary (change-summary)
 
-> **When to use:** When invoked with the `change-summary` argument (or as the first stage of `--all`). Also run this mode first when the change context is unknown - before writing a test plan or test cases.
+> **When to use:** When invoked with the `change-summary` argument (or as the first stage of `--all`). Also run this mode first when the change context is unknown — before writing a test plan or test cases.
 
 ---
 
@@ -24,7 +24,7 @@ Use the `resolved_branch` and `artifact_dir` resolved in SKILL.md Step 0.2.
 git log <effective_base>..<resolved_branch> --oneline
 ```
 
-**Check commit count - if more than 20, ask before proceeding:**
+**Check commit count — if more than 20, ask before proceeding:**
 
 ```text
 AskUserQuestion: Found <N> commits to analyze. Processing all of them may consume significant context. How to proceed?
@@ -36,10 +36,10 @@ Options:
 ```
 
 Based on choice:
-- "Analyze all" -> keep `analysis_base = <effective_base>`
-- "Analyze only the last 20" -> select the 20 most recent commits from the full range, find the oldest commit in that subset, and set `analysis_base = <oldest_selected_commit>^`
+- "Analyze all" → keep `analysis_base = <effective_base>`
+- "Analyze only the last 20" → select the 20 most recent commits from the full range, find the oldest commit in that subset, and set `analysis_base = <oldest_selected_commit>^`
   - This `^` shorthand uses Git's first-parent semantics for the selected oldest commit.
-- "Cancel" -> **STOP**
+- "Cancel" → **STOP**
 
 **Finalize the scoped commit list:**
 
@@ -56,21 +56,21 @@ git diff <analysis_base>...<resolved_branch> --name-status
 git diff <analysis_base>...<resolved_branch>
 ```
 
-**Check diff size - if the diff exceeds ~1000 lines, warn before proceeding:**
+**Check diff size — if the diff exceeds ~1000 lines, warn before proceeding:**
 
 ```text
 AskUserQuestion: The diff is large (<N> lines). Reading it in full will consume significant context. How to proceed?
 
 Options:
-1. Continue - read the full diff
+1. Continue — read the full diff
 2. Read changed files individually instead (recommended for large diffs)
 3. Cancel
 ```
 
 Based on choice:
-- "Continue" -> use the full diff as-is
-- "Read files individually" -> skip the raw diff; proceed to Step 2 where Explore agents will read the files
-- "Cancel" -> **STOP**
+- "Continue" → use the full diff as-is
+- "Read files individually" → skip the raw diff; proceed to Step 2 where Explore agents will read the files
+- "Cancel" → **STOP**
 
 ## Step 2: Explore Key Changed Files
 
@@ -79,16 +79,16 @@ This keeps the main context clean and speeds up analysis on large diffs.
 
 From the `--name-status` output, identify the most important changed files (focus on business logic, skip lock files, generated files, and formatting-only changes).
 
-Launch 1-2 Explore agents simultaneously:
+Launch 1–2 Explore agents simultaneously:
 
 ```text
-Agent 1 - Core changes:
+Agent 1 — Core changes:
 Task(subagent_type: Explore, model: sonnet, prompt:
   "Read and summarize the key changed files: [list of most important files].
    Focus on: what logic changed, what inputs/outputs changed, what side effects are possible.
    Thoroughness: medium. Be concise.")
 
-Agent 2 - Integration points (if needed):
+Agent 2 — Integration points (if needed):
 Task(subagent_type: Explore, model: sonnet, prompt:
   "Find all callers and consumers of [changed modules/functions].
    Identify what adjacent functionality might be affected.
@@ -142,7 +142,7 @@ Save the result to `<artifact_dir>/change-summary.md`.
 
 ## Step 6: Next Step
 
-**If `all_mode = true`** - do NOT show the prompt. Proceed directly to `references/TEST-PLAN.md`.
+**If `all_mode = true`** — do NOT show the prompt. Proceed directly to `references/TEST-PLAN.md`.
 
 **Otherwise:**
 
@@ -150,6 +150,6 @@ Save the result to `<artifact_dir>/change-summary.md`.
 AskUserQuestion: Change summary saved. Proceed to writing the test plan?
 
 Options:
-1. Yes - run /aif-qa test-plan <resolved_branch>
-2. No - stop here
+1. Yes — run /aif-qa test-plan <resolved_branch>
+2. No — stop here
 ```

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -477,7 +477,7 @@ After getting description, proceed with same stack selection as Mode 2:
 
 **Step 4: Create .ai-factory/DESCRIPTION.md**
 
-Same as Mode 2, in resolved `language.artifacts`.
+Same as Mode 2, in resolved `language.artifacts`, including creating `.ai-factory` before writing `config.yaml` or `DESCRIPTION.md`.
 
 **Step 5: Setup Context**
 

--- a/skills/aif/references/config-template.yaml
+++ b/skills/aif/references/config-template.yaml
@@ -107,8 +107,9 @@ paths:
 
   # QA artifacts root directory
   # /aif-qa stores change-summary, test-plan, and test-cases here,
-  # using a derived branch slug as a subdirectory: <qa>/<branch-slug>/
-  # The slug is an injective encoding of the branch name (see
+  # using a deterministic, filesystem-safe derived branch slug as a
+  # subdirectory: <qa>/<branch-slug>/
+  # The slug uses a short hash suffix for collision resistance (see
   # skills/aif-qa/SKILL.md for the exact algorithm).
   # Default: .ai-factory/qa/
   qa: .ai-factory/qa/


### PR DESCRIPTION
## PR goal

Make follow-up without expanding product scope:

1. bring the `branch-slug` contract in line with the actual implementation;
2. remove misleading-behavior from the “Analyze only the last 20” option;
3. strengthen smoke coverage so that it actually catches regressions in handoff and scoped analysis. 

## The solution we choose in this PR

This follow-up **should not** invent a new reversible/injective encoder branch name. As part of this PR, we leave the current idea of `safe_slug + short hash suffix`, but honestly describe it as **deterministic, filesystem-safe, collision-resistant slug**, and not as injective encoding. This is a minimal and understandable fix for an already confused contract that does not require extending tool permissions and does not break the artifact path contract already described<paths.qa >/<branch-slug>/...`. 