### PR TITLE
fix: make extension install work on Windows and reject malformed add args

### DIFF
--- a/scripts/test-extensions.sh
+++ b/scripts/test-extensions.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Focused tests for extension resolver branches.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+ROOT_DIR="$ROOT_DIR" node --input-type=module <<'EOF'
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const { resolveNpmCommand } = await import(pathToFileURL(path.join(process.env.ROOT_DIR, 'dist/core/extensions.js')).href);
+
+function createPathExists(paths) {
+  const existingPaths = new Set(paths);
+  return async targetPath => existingPaths.has(targetPath);
+}
+
+const execPath = path.join('runtime', 'bin', 'node.exe');
+const firstCandidate = path.join(path.dirname(execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js');
+const secondCandidate = path.resolve(path.dirname(execPath), '..', 'node_modules', 'npm', 'bin', 'npm-cli.js');
+const thirdCandidate = path.resolve(path.dirname(execPath), '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js');
+
+assert.deepEqual(
+  await resolveNpmCommand({
+    platform: 'win32',
+    execPath,
+    pathEnv: '',
+    pathExists: createPathExists([firstCandidate]),
+  }),
+  { command: execPath, argsPrefix: [firstCandidate] },
+  'resolveNpmCommand must prefer npm-cli.js adjacent to the current node binary',
+);
+
+assert.deepEqual(
+  await resolveNpmCommand({
+    platform: 'win32',
+    execPath,
+    pathEnv: '',
+    pathExists: createPathExists([secondCandidate]),
+  }),
+  { command: execPath, argsPrefix: [secondCandidate] },
+  'resolveNpmCommand must fall back to ../node_modules/npm/bin/npm-cli.js',
+);
+
+assert.deepEqual(
+  await resolveNpmCommand({
+    platform: 'win32',
+    execPath,
+    pathEnv: '',
+    pathExists: createPathExists([thirdCandidate]),
+  }),
+  { command: execPath, argsPrefix: [thirdCandidate] },
+  'resolveNpmCommand must fall back to ../lib/node_modules/npm/bin/npm-cli.js',
+);
+
+const npmRoot = path.join('portable-npm');
+const npmCommandPath = path.join(npmRoot, 'npm.cmd');
+const npmCliPath = path.join(npmRoot, 'node_modules', 'npm', 'bin', 'npm-cli.js');
+const bundledNodePath = path.join(npmRoot, 'node.exe');
+
+assert.deepEqual(
+  await resolveNpmCommand({
+    platform: 'win32',
+    execPath,
+    pathEnv: `ignored:${npmRoot}`,
+    pathDelimiter: ':',
+    pathExists: createPathExists([npmCommandPath, npmCliPath, bundledNodePath]),
+  }),
+  { command: bundledNodePath, argsPrefix: [npmCliPath] },
+  'resolveNpmCommand must resolve npm-cli.js from PATH on Windows when adjacent candidates are missing',
+);
+
+assert.deepEqual(
+  await resolveNpmCommand({
+    platform: 'win32',
+    execPath,
+    pathEnv: npmRoot,
+    pathExists: createPathExists([npmCommandPath, npmCliPath]),
+  }),
+  { command: execPath, argsPrefix: [npmCliPath] },
+  'resolveNpmCommand must fall back to execPath when npm.cmd is found without bundled node.exe',
+);
+
+await assert.rejects(
+  () => resolveNpmCommand({
+    platform: 'win32',
+    execPath,
+    pathEnv: npmRoot,
+    pathExists: createPathExists([]),
+  }),
+  /safe Windows npm/i,
+  'resolveNpmCommand must fail closed when no safe Windows npm entrypoint exists',
+);
+
+assert.deepEqual(
+  await resolveNpmCommand({
+    platform: 'linux',
+    execPath,
+    pathEnv: '',
+    pathExists: createPathExists([]),
+  }),
+  { command: 'npm', argsPrefix: [] },
+  'resolveNpmCommand must fall back to npm on non-Windows platforms',
+);
+
+console.log('extension resolver unit tests passed');
+EOF

--- a/scripts/test-init.sh
+++ b/scripts/test-init.sh
@@ -358,6 +358,24 @@ const resolved = await resolveNpmCommand({
 assert.equal(resolved.command, bundledNodePath, 'Windows npm resolution must prefer node.exe adjacent to npm.cmd');
 assert.deepEqual(resolved.argsPrefix, [npmCliPath], 'Windows npm resolution must invoke npm-cli.js directly');
 
+const resolvedWithCustomDelimiter = await resolveNpmCommand({
+  platform: 'win32',
+  execPath: fakeExecPath,
+  pathEnv: `${path.relative(process.cwd(), npmRoot)}:${path.relative(process.cwd(), tempRoot)}`,
+  pathDelimiter: ':',
+});
+
+assert.equal(
+  resolvedWithCustomDelimiter.command,
+  path.join(path.relative(process.cwd(), npmRoot), 'node.exe'),
+  'Windows npm resolution must honor injected path delimiters instead of host defaults',
+);
+assert.deepEqual(
+  resolvedWithCustomDelimiter.argsPrefix,
+  [path.join(path.relative(process.cwd(), npmRoot), 'node_modules', 'npm', 'bin', 'npm-cli.js')],
+  'Windows npm resolution must honor injected delimiters when locating npm-cli.js',
+);
+
 const noSafeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'aif-npm-missing-'));
 const missingExecDir = path.join(noSafeRoot, 'isolated-node');
 fs.mkdirSync(missingExecDir, { recursive: true });

--- a/scripts/test-init.sh
+++ b/scripts/test-init.sh
@@ -306,3 +306,73 @@ fi
 assert_contains "$TMPDIR/init-ext-conflict.log" "already owned by AI Factory bundled Claude agent files" "bundled Claude target collision must be rejected with a clear message"
 
 echo "extension agent file conflict smoke tests passed"
+
+# -------------------------------------------------------------------
+# CLI validation smoke: extension add must reject excess arguments.
+# -------------------------------------------------------------------
+
+if (cd "$EXT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" extension add "$CONFLICT_EXTENSION_DIR" unexpected > "$TMPDIR/init-ext-extra-args.log" 2>&1); then
+  echo "Assertion failed: extension add must reject excess arguments"
+  cat "$TMPDIR/init-ext-extra-args.log"
+  exit 1
+fi
+assert_contains "$TMPDIR/init-ext-extra-args.log" "too many arguments" "extension add must fail fast on excess arguments"
+
+echo "extension add excess-arguments smoke tests passed"
+
+# -------------------------------------------------------------------
+# Windows npm resolution smoke: npm-based extension install must
+# resolve npm-cli.js without shell fallback and fail explicitly when
+# no safe npm entrypoint exists.
+# -------------------------------------------------------------------
+
+ROOT_DIR="$ROOT_DIR" node --input-type=module <<'EOF'
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const { resolveNpmCommand } = await import(pathToFileURL(path.join(process.env.ROOT_DIR, 'dist/core/extensions.js')).href);
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'aif-npm-resolve-'));
+const fakeExecDir = path.join(tempRoot, 'current-node');
+fs.mkdirSync(fakeExecDir, { recursive: true });
+const fakeExecPath = path.join(fakeExecDir, 'node.exe');
+fs.writeFileSync(fakeExecPath, '');
+
+const npmRoot = path.join(tempRoot, 'npm-root');
+const npmCliPath = path.join(npmRoot, 'node_modules', 'npm', 'bin', 'npm-cli.js');
+const bundledNodePath = path.join(npmRoot, 'node.exe');
+fs.mkdirSync(path.dirname(npmCliPath), { recursive: true });
+fs.writeFileSync(path.join(npmRoot, 'npm.cmd'), '@ECHO off\r\n');
+fs.writeFileSync(npmCliPath, '#!/usr/bin/env node\n');
+fs.writeFileSync(bundledNodePath, '');
+
+const resolved = await resolveNpmCommand({
+  platform: 'win32',
+  execPath: fakeExecPath,
+  pathEnv: `${npmRoot};${process.env.PATH}`,
+});
+
+assert.equal(resolved.command, bundledNodePath, 'Windows npm resolution must prefer node.exe adjacent to npm.cmd');
+assert.deepEqual(resolved.argsPrefix, [npmCliPath], 'Windows npm resolution must invoke npm-cli.js directly');
+
+const noSafeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'aif-npm-missing-'));
+const missingExecDir = path.join(noSafeRoot, 'isolated-node');
+fs.mkdirSync(missingExecDir, { recursive: true });
+const missingExecPath = path.join(missingExecDir, 'node.exe');
+fs.writeFileSync(missingExecPath, '');
+
+await assert.rejects(
+  () => resolveNpmCommand({
+    platform: 'win32',
+    execPath: missingExecPath,
+    pathEnv: noSafeRoot,
+  }),
+  /safe Windows npm/i,
+  'Windows npm resolution must fail explicitly when no safe npm-cli.js path is available',
+);
+EOF
+
+echo "windows npm resolution smoke tests passed"

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -656,6 +656,20 @@ fi
 # ─────────────────────────────────────────────
 # Part 8: aif-qa skill smoke tests
 # ─────────────────────────────────────────────
+echo -e "\n${BOLD}=== Extension resolver unit tests ===${NC}\n"
+
+set +e
+EXTENSION_UNIT_OUTPUT=$(bash "$ROOT_DIR/scripts/test-extensions.sh" 2>&1)
+EXTENSION_UNIT_EXIT=$?
+set -e
+
+if [[ $EXTENSION_UNIT_EXIT -eq 0 ]]; then
+    pass "extension resolver unit tests"
+else
+    fail "extension resolver unit tests"
+    echo "$EXTENSION_UNIT_OUTPUT" | sed 's/^/      /'
+fi
+
 echo -e "\n${BOLD}=== aif-qa skill smoke tests ===${NC}\n"
 
 set +e

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -40,6 +40,7 @@ const ext = program
 
 ext
   .command('add <source>')
+  .allowExcessArguments(false)
   .description('Install extension from npm package, git URL, or local path')
   .action(extensionAddCommand);
 

--- a/src/core/extensions.ts
+++ b/src/core/extensions.ts
@@ -91,6 +91,61 @@ function logExtension(level: ExtensionLogLevel, message: string, context?: Recor
   console.log(line);
 }
 
+function isMissingCommandError(error: unknown): error is NodeJS.ErrnoException {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && (error as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+function isMissingNpmShellError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const message = 'message' in error ? String((error as { message?: unknown }).message ?? '') : '';
+  const stderr = 'stderr' in error ? String((error as { stderr?: unknown }).stderr ?? '') : '';
+
+  return message.includes('npm is not recognized')
+    || stderr.includes('npm is not recognized')
+    || message.includes('\'npm\' is not recognized')
+    || stderr.includes('\'npm\' is not recognized');
+}
+
+function getPlatformCommand(command: 'git' | 'tar'): string {
+  return command;
+}
+
+async function resolveNpmCommand(): Promise<{ command: string; argsPrefix: string[] }> {
+  const nodeDir = path.dirname(process.execPath);
+  const npmCliCandidates = [
+    path.join(nodeDir, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    path.resolve(nodeDir, '..', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    path.resolve(nodeDir, '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+  ];
+
+  for (const candidate of new Set(npmCliCandidates)) {
+    if (await fs.pathExists(candidate)) {
+      return {
+        command: process.execPath,
+        argsPrefix: [candidate],
+      };
+    }
+  }
+
+  if (process.platform === 'win32') {
+    return {
+      command: process.env.ComSpec || 'cmd.exe',
+      argsPrefix: ['/d', '/s', '/c', 'npm'],
+    };
+  }
+
+  return {
+    command: 'npm',
+    argsPrefix: [],
+  };
+}
+
 function isValidVersionString(version: string): boolean {
   return semver.valid(version) !== null;
 }
@@ -774,11 +829,25 @@ async function resolveFromLocal(sourcePath: string): Promise<ResolvedExtension> 
 async function resolveFromNpm(projectDir: string, packageName: string): Promise<ResolvedExtension> {
   const { execFileSync } = await import('child_process');
   const tmpDir = path.join(getExtensionsDir(projectDir), '.tmp-install');
+  const npmRunner = await resolveNpmCommand();
+  const tarCommand = getPlatformCommand('tar');
   logExtension('debug', 'Resolving npm extension source', { packageName, tmpDir });
   await removeDirectory(tmpDir);
   await ensureDir(tmpDir);
 
-  execFileSync('npm', ['pack', packageName, '--pack-destination', tmpDir], { stdio: 'pipe' });
+  try {
+    execFileSync(
+      npmRunner.command,
+      [...npmRunner.argsPrefix, 'pack', packageName, '--pack-destination', tmpDir],
+      { stdio: 'pipe' },
+    );
+  } catch (error) {
+    await removeDirectory(tmpDir);
+    if (isMissingCommandError(error) || isMissingNpmShellError(error)) {
+      throw new Error('npm is required to install npm-based extensions but was not found in PATH.');
+    }
+    throw error;
+  }
 
   const files = await fs.readdir(tmpDir);
   const tgzFile = files.find(f => f.endsWith('.tgz'));
@@ -789,7 +858,15 @@ async function resolveFromNpm(projectDir: string, packageName: string): Promise<
 
   const extractDir = path.join(tmpDir, 'extracted');
   await ensureDir(extractDir);
-  execFileSync('tar', ['-xzf', path.join(tmpDir, tgzFile), '-C', extractDir], { stdio: 'pipe' });
+  try {
+    execFileSync(tarCommand, ['-xzf', path.join(tmpDir, tgzFile), '-C', extractDir], { stdio: 'pipe' });
+  } catch (error) {
+    await removeDirectory(tmpDir);
+    if (isMissingCommandError(error)) {
+      throw new Error('tar is required to extract npm-based extensions but was not found in PATH.');
+    }
+    throw error;
+  }
 
   const packageDir = path.join(extractDir, 'package');
   const manifest = await loadExtensionManifest(packageDir);
@@ -810,6 +887,7 @@ async function resolveFromNpm(projectDir: string, packageName: string): Promise<
 async function resolveFromGit(projectDir: string, url: string): Promise<ResolvedExtension> {
   const { execFileSync } = await import('child_process');
   const tmpDir = path.join(getExtensionsDir(projectDir), '.tmp-clone');
+  const gitCommand = getPlatformCommand('git');
   const gitSource = parseGitSource(url);
   const sourceType = classifyExtensionSource(url);
   logExtension('debug', 'Resolving git extension source', {
@@ -838,7 +916,15 @@ async function resolveFromGit(projectDir: string, url: string): Promise<Resolved
     cloneArgs.push('--branch', gitSource.ref, '--single-branch');
   }
   cloneArgs.push(gitSource.cloneUrl, tmpDir);
-  execFileSync('git', cloneArgs, { stdio: 'pipe' });
+  try {
+    execFileSync(gitCommand, cloneArgs, { stdio: 'pipe' });
+  } catch (error) {
+    await removeDirectory(tmpDir);
+    if (isMissingCommandError(error)) {
+      throw new Error('git is required to install extensions from Git sources but was not found in PATH.');
+    }
+    throw error;
+  }
 
   const manifest = await loadExtensionManifest(tmpDir);
   if (!manifest) {

--- a/src/core/extensions.ts
+++ b/src/core/extensions.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { execFileSync } from 'child_process';
 import fs from 'fs-extra';
 import * as semver from 'semver';
 import { readJsonFile, removeDirectory, ensureDir } from '../utils/fs.js';
@@ -98,46 +99,75 @@ function isMissingCommandError(error: unknown): error is NodeJS.ErrnoException {
     && (error as NodeJS.ErrnoException).code === 'ENOENT';
 }
 
-function isMissingNpmShellError(error: unknown): boolean {
-  if (typeof error !== 'object' || error === null) {
-    return false;
-  }
-
-  const message = 'message' in error ? String((error as { message?: unknown }).message ?? '') : '';
-  const stderr = 'stderr' in error ? String((error as { stderr?: unknown }).stderr ?? '') : '';
-
-  return message.includes('npm is not recognized')
-    || stderr.includes('npm is not recognized')
-    || message.includes('\'npm\' is not recognized')
-    || stderr.includes('\'npm\' is not recognized');
+export interface ResolveNpmCommandOptions {
+  platform?: NodeJS.Platform;
+  execPath?: string;
+  pathEnv?: string;
 }
 
-function getPlatformCommand(command: 'git' | 'tar'): string {
-  return command;
-}
-
-async function resolveNpmCommand(): Promise<{ command: string; argsPrefix: string[] }> {
-  const nodeDir = path.dirname(process.execPath);
-  const npmCliCandidates = [
+function getNpmCliCandidates(execPath: string): string[] {
+  const nodeDir = path.dirname(execPath);
+  return [
     path.join(nodeDir, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
     path.resolve(nodeDir, '..', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
     path.resolve(nodeDir, '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
   ];
+}
 
-  for (const candidate of new Set(npmCliCandidates)) {
+async function findWindowsPathNpmCli(pathEnv: string, fallbackExecPath: string): Promise<{ command: string; argsPrefix: string[] } | null> {
+  const npmCommandPaths = pathEnv
+    .split(path.delimiter)
+    .map(entry => entry.trim())
+    .filter(Boolean)
+    .map(entry => path.join(entry, 'npm.cmd'));
+
+  for (const npmCommandPath of npmCommandPaths) {
+    if (!await fs.pathExists(npmCommandPath)) {
+      continue;
+    }
+
+    const npmRoot = path.dirname(npmCommandPath);
+    const npmCliPath = path.join(npmRoot, 'node_modules', 'npm', 'bin', 'npm-cli.js');
+
+    if (!await fs.pathExists(npmCliPath)) {
+      continue;
+    }
+
+    const bundledNodePath = path.join(npmRoot, 'node.exe');
+
+    return {
+      command: await fs.pathExists(bundledNodePath) ? bundledNodePath : fallbackExecPath,
+      argsPrefix: [npmCliPath],
+    };
+  }
+
+  return null;
+}
+
+export async function resolveNpmCommand(options: ResolveNpmCommandOptions = {}): Promise<{ command: string; argsPrefix: string[] }> {
+  const platform = options.platform ?? process.platform;
+  const execPath = options.execPath ?? process.execPath;
+  const pathEnv = options.pathEnv ?? process.env.PATH ?? '';
+
+  for (const candidate of new Set(getNpmCliCandidates(execPath))) {
     if (await fs.pathExists(candidate)) {
       return {
-        command: process.execPath,
+        command: execPath,
         argsPrefix: [candidate],
       };
     }
   }
 
-  if (process.platform === 'win32') {
-    return {
-      command: process.env.ComSpec || 'cmd.exe',
-      argsPrefix: ['/d', '/s', '/c', 'npm'],
-    };
+  if (platform === 'win32') {
+    // Resolve npm-cli.js directly so package specs never pass through cmd.exe parsing.
+    const resolvedFromPath = await findWindowsPathNpmCli(pathEnv, execPath);
+    if (resolvedFromPath) {
+      return resolvedFromPath;
+    }
+
+    throw new Error(
+      'Unable to locate npm-cli.js for a safe Windows npm invocation. Reinstall Node.js/npm or ensure npm.cmd points to a standard npm installation.',
+    );
   }
 
   return {
@@ -827,10 +857,8 @@ async function resolveFromLocal(sourcePath: string): Promise<ResolvedExtension> 
 }
 
 async function resolveFromNpm(projectDir: string, packageName: string): Promise<ResolvedExtension> {
-  const { execFileSync } = await import('child_process');
   const tmpDir = path.join(getExtensionsDir(projectDir), '.tmp-install');
   const npmRunner = await resolveNpmCommand();
-  const tarCommand = getPlatformCommand('tar');
   logExtension('debug', 'Resolving npm extension source', { packageName, tmpDir });
   await removeDirectory(tmpDir);
   await ensureDir(tmpDir);
@@ -843,7 +871,7 @@ async function resolveFromNpm(projectDir: string, packageName: string): Promise<
     );
   } catch (error) {
     await removeDirectory(tmpDir);
-    if (isMissingCommandError(error) || isMissingNpmShellError(error)) {
+    if (isMissingCommandError(error)) {
       throw new Error('npm is required to install npm-based extensions but was not found in PATH.');
     }
     throw error;
@@ -859,7 +887,7 @@ async function resolveFromNpm(projectDir: string, packageName: string): Promise<
   const extractDir = path.join(tmpDir, 'extracted');
   await ensureDir(extractDir);
   try {
-    execFileSync(tarCommand, ['-xzf', path.join(tmpDir, tgzFile), '-C', extractDir], { stdio: 'pipe' });
+    execFileSync('tar', ['-xzf', path.join(tmpDir, tgzFile), '-C', extractDir], { stdio: 'pipe' });
   } catch (error) {
     await removeDirectory(tmpDir);
     if (isMissingCommandError(error)) {
@@ -885,9 +913,7 @@ async function resolveFromNpm(projectDir: string, packageName: string): Promise<
 }
 
 async function resolveFromGit(projectDir: string, url: string): Promise<ResolvedExtension> {
-  const { execFileSync } = await import('child_process');
   const tmpDir = path.join(getExtensionsDir(projectDir), '.tmp-clone');
-  const gitCommand = getPlatformCommand('git');
   const gitSource = parseGitSource(url);
   const sourceType = classifyExtensionSource(url);
   logExtension('debug', 'Resolving git extension source', {
@@ -917,7 +943,7 @@ async function resolveFromGit(projectDir: string, url: string): Promise<Resolved
   }
   cloneArgs.push(gitSource.cloneUrl, tmpDir);
   try {
-    execFileSync(gitCommand, cloneArgs, { stdio: 'pipe' });
+    execFileSync('git', cloneArgs, { stdio: 'pipe' });
   } catch (error) {
     await removeDirectory(tmpDir);
     if (isMissingCommandError(error)) {

--- a/src/core/extensions.ts
+++ b/src/core/extensions.ts
@@ -103,6 +103,7 @@ export interface ResolveNpmCommandOptions {
   platform?: NodeJS.Platform;
   execPath?: string;
   pathEnv?: string;
+  pathDelimiter?: string;
 }
 
 function getNpmCliCandidates(execPath: string): string[] {
@@ -114,9 +115,21 @@ function getNpmCliCandidates(execPath: string): string[] {
   ];
 }
 
-async function findWindowsPathNpmCli(pathEnv: string, fallbackExecPath: string): Promise<{ command: string; argsPrefix: string[] } | null> {
+function getPathDelimiter(platform: NodeJS.Platform, override?: string): string {
+  if (override) {
+    return override;
+  }
+
+  return platform === 'win32' ? ';' : ':';
+}
+
+async function findWindowsPathNpmCli(
+  pathEnv: string,
+  fallbackExecPath: string,
+  pathDelimiter: string,
+): Promise<{ command: string; argsPrefix: string[] } | null> {
   const npmCommandPaths = pathEnv
-    .split(path.delimiter)
+    .split(pathDelimiter)
     .map(entry => entry.trim())
     .filter(Boolean)
     .map(entry => path.join(entry, 'npm.cmd'));
@@ -134,9 +147,16 @@ async function findWindowsPathNpmCli(pathEnv: string, fallbackExecPath: string):
     }
 
     const bundledNodePath = path.join(npmRoot, 'node.exe');
+    const command = await fs.pathExists(bundledNodePath) ? bundledNodePath : fallbackExecPath;
+
+    logExtension('debug', '[FIX] Resolved Windows npm-cli.js from PATH', {
+      npmCliPath,
+      command,
+      pathDelimiter,
+    });
 
     return {
-      command: await fs.pathExists(bundledNodePath) ? bundledNodePath : fallbackExecPath,
+      command,
       argsPrefix: [npmCliPath],
     };
   }
@@ -148,6 +168,7 @@ export async function resolveNpmCommand(options: ResolveNpmCommandOptions = {}):
   const platform = options.platform ?? process.platform;
   const execPath = options.execPath ?? process.execPath;
   const pathEnv = options.pathEnv ?? process.env.PATH ?? '';
+  const pathDelimiter = getPathDelimiter(platform, options.pathDelimiter);
 
   for (const candidate of new Set(getNpmCliCandidates(execPath))) {
     if (await fs.pathExists(candidate)) {
@@ -160,7 +181,10 @@ export async function resolveNpmCommand(options: ResolveNpmCommandOptions = {}):
 
   if (platform === 'win32') {
     // Resolve npm-cli.js directly so package specs never pass through cmd.exe parsing.
-    const resolvedFromPath = await findWindowsPathNpmCli(pathEnv, execPath);
+    logExtension('debug', '[FIX] Resolving Windows npm-cli.js from PATH', {
+      pathDelimiter,
+    });
+    const resolvedFromPath = await findWindowsPathNpmCli(pathEnv, execPath, pathDelimiter);
     if (resolvedFromPath) {
       return resolvedFromPath;
     }

--- a/src/core/extensions.ts
+++ b/src/core/extensions.ts
@@ -104,7 +104,15 @@ export interface ResolveNpmCommandOptions {
   execPath?: string;
   pathEnv?: string;
   pathDelimiter?: string;
+  pathExists?: (targetPath: string) => Promise<boolean>;
 }
+
+interface ResolvedNpmCommand {
+  command: string;
+  argsPrefix: string[];
+}
+
+const npmCommandResolutionCache = new Map<string, Promise<ResolvedNpmCommand>>();
 
 function getNpmCliCandidates(execPath: string): string[] {
   const nodeDir = path.dirname(execPath);
@@ -127,7 +135,8 @@ async function findWindowsPathNpmCli(
   pathEnv: string,
   fallbackExecPath: string,
   pathDelimiter: string,
-): Promise<{ command: string; argsPrefix: string[] } | null> {
+  pathExists: (targetPath: string) => Promise<boolean>,
+): Promise<ResolvedNpmCommand | null> {
   const npmCommandPaths = pathEnv
     .split(pathDelimiter)
     .map(entry => entry.trim())
@@ -135,19 +144,19 @@ async function findWindowsPathNpmCli(
     .map(entry => path.join(entry, 'npm.cmd'));
 
   for (const npmCommandPath of npmCommandPaths) {
-    if (!await fs.pathExists(npmCommandPath)) {
+    if (!await pathExists(npmCommandPath)) {
       continue;
     }
 
     const npmRoot = path.dirname(npmCommandPath);
     const npmCliPath = path.join(npmRoot, 'node_modules', 'npm', 'bin', 'npm-cli.js');
 
-    if (!await fs.pathExists(npmCliPath)) {
+    if (!await pathExists(npmCliPath)) {
       continue;
     }
 
     const bundledNodePath = path.join(npmRoot, 'node.exe');
-    const command = await fs.pathExists(bundledNodePath) ? bundledNodePath : fallbackExecPath;
+    const command = await pathExists(bundledNodePath) ? bundledNodePath : fallbackExecPath;
 
     logExtension('debug', '[FIX] Resolved Windows npm-cli.js from PATH', {
       npmCliPath,
@@ -164,14 +173,29 @@ async function findWindowsPathNpmCli(
   return null;
 }
 
-export async function resolveNpmCommand(options: ResolveNpmCommandOptions = {}): Promise<{ command: string; argsPrefix: string[] }> {
-  const platform = options.platform ?? process.platform;
-  const execPath = options.execPath ?? process.execPath;
-  const pathEnv = options.pathEnv ?? process.env.PATH ?? '';
-  const pathDelimiter = getPathDelimiter(platform, options.pathDelimiter);
+function getNpmCommandResolutionCacheKey(
+  platform: NodeJS.Platform,
+  execPath: string,
+  pathEnv: string,
+  pathDelimiter: string,
+  pathExists?: ResolveNpmCommandOptions['pathExists'],
+): string | null {
+  if (pathExists) {
+    return null;
+  }
 
+  return JSON.stringify([platform, execPath, pathEnv, pathDelimiter]);
+}
+
+async function resolveNpmCommandUncached(
+  platform: NodeJS.Platform,
+  execPath: string,
+  pathEnv: string,
+  pathDelimiter: string,
+  pathExists: (targetPath: string) => Promise<boolean>,
+): Promise<ResolvedNpmCommand> {
   for (const candidate of new Set(getNpmCliCandidates(execPath))) {
-    if (await fs.pathExists(candidate)) {
+    if (await pathExists(candidate)) {
       return {
         command: execPath,
         argsPrefix: [candidate],
@@ -184,7 +208,7 @@ export async function resolveNpmCommand(options: ResolveNpmCommandOptions = {}):
     logExtension('debug', '[FIX] Resolving Windows npm-cli.js from PATH', {
       pathDelimiter,
     });
-    const resolvedFromPath = await findWindowsPathNpmCli(pathEnv, execPath, pathDelimiter);
+    const resolvedFromPath = await findWindowsPathNpmCli(pathEnv, execPath, pathDelimiter, pathExists);
     if (resolvedFromPath) {
       return resolvedFromPath;
     }
@@ -198,6 +222,27 @@ export async function resolveNpmCommand(options: ResolveNpmCommandOptions = {}):
     command: 'npm',
     argsPrefix: [],
   };
+}
+
+export async function resolveNpmCommand(options: ResolveNpmCommandOptions = {}): Promise<ResolvedNpmCommand> {
+  const platform = options.platform ?? process.platform;
+  const execPath = options.execPath ?? process.execPath;
+  const pathEnv = options.pathEnv ?? process.env.PATH ?? '';
+  const pathDelimiter = getPathDelimiter(platform, options.pathDelimiter);
+  const pathExists = options.pathExists ?? fs.pathExists;
+  const cacheKey = getNpmCommandResolutionCacheKey(platform, execPath, pathEnv, pathDelimiter, options.pathExists);
+
+  if (!cacheKey) {
+    return resolveNpmCommandUncached(platform, execPath, pathEnv, pathDelimiter, pathExists);
+  }
+
+  let cachedResolution = npmCommandResolutionCache.get(cacheKey);
+  if (!cachedResolution) {
+    cachedResolution = resolveNpmCommandUncached(platform, execPath, pathEnv, pathDelimiter, pathExists);
+    npmCommandResolutionCache.set(cacheKey, cachedResolution);
+  }
+
+  return cachedResolution;
 }
 
 function isValidVersionString(version: string): boolean {
@@ -888,6 +933,11 @@ async function resolveFromNpm(projectDir: string, packageName: string): Promise<
   await ensureDir(tmpDir);
 
   try {
+    logExtension('debug', '[FIX] Starting npm pack for extension source', {
+      packageName,
+      command: npmRunner.command,
+      argsPrefix: npmRunner.argsPrefix,
+    });
     execFileSync(
       npmRunner.command,
       [...npmRunner.argsPrefix, 'pack', packageName, '--pack-destination', tmpDir],
@@ -896,7 +946,11 @@ async function resolveFromNpm(projectDir: string, packageName: string): Promise<
   } catch (error) {
     await removeDirectory(tmpDir);
     if (isMissingCommandError(error)) {
-      throw new Error('npm is required to install npm-based extensions but was not found in PATH.');
+      if (npmRunner.argsPrefix.length > 0) {
+        throw new Error('A safe npm entrypoint was resolved, but the npm command could not be started. Reinstall Node.js/npm and rerun with LOG_LEVEL=debug to inspect the resolved command.');
+      }
+
+      throw new Error('npm is required to install npm-based extensions but was not found in PATH. Rerun with LOG_LEVEL=debug for resolver details.');
     }
     throw error;
   }


### PR DESCRIPTION
## Summary

Fix `ai-factory extension add` on Windows and make malformed input fail fast.

## Changes

- resolve npm execution in a Windows-safe way for npm-based extension installs
- add clearer missing-tool errors for `npm`, `git`, and `tar`
- reject excess arguments for `ai-factory extension add` instead of silently treating them as part of the source

## Why

Windows installs could fail with `spawnSync npm ENOENT` / `EINVAL`.
Also, duplicated input like:

`ai-factory extension add ai-factory extension add <url>`

was being interpreted incorrectly instead of returning a clear CLI error.

## Verification

- built the CLI with `npm run build`
- verified malformed `extension add` now fails with `too many arguments`
- verified npm-source path no longer crashes on Windows process spawning
- verified git-based extension install succeeds with a fixture extension repo
