### PR TITLE
feat(quality): add aif-rules-check read-only gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 **AI Factory** (v2) is an npm package + skill system that automates AI agent context setup for projects. It provides:
 
 1. **CLI tool** (`ai-factory init/update/upgrade`) — installs skills and configures MCP
-2. **Built-in skills** (24 skills, all `aif-*` prefixed) — workflow commands for spec-driven development
+2. **Built-in skills** (25 skills, all `aif-*` prefixed) — workflow commands for spec-driven development
 3. **Spec-driven workflow** — structured approach: plan → implement → commit
 4. **Multi-agent support** — 15 agents (Claude Code, Cursor, Windsurf, Roo Code, Kilo Code, Antigravity, OpenCode, Warp,
    Zencoder, Codex CLI, GitHub Copilot, Gemini CLI, Junie, Qwen Code, Universal)
@@ -43,6 +43,7 @@ ai-factory/
 │   ├── aif-review/             # Code review
 │   ├── aif-roadmap/            # Strategic project roadmap
 │   ├── aif-rules/              # Project rules and conventions
+│   ├── aif-rules-check/        # Standalone rules compliance gate
 │   ├── aif-qa/                 # QA workflow: change summary → test plan → test cases
 │   ├── aif-security-checklist/ # Security audit
 │   ├── aif-skill-generator/    # Generate new skills
@@ -102,7 +103,7 @@ Artifact writers are command-scoped to prevent ownership conflicts:
 | `.ai-factory/evolution/*` artifacts                                                           | `/aif-loop`            | loop state ownership                                                                             |
 | `paths.qa` (default: `.ai-factory/qa/<branch-slug>/`)                                         | `/aif-qa`              | change-summary, test-plan, test-cases artifacts; branch slug used as subdirectory                |
 
-Quality commands (`/aif-commit`, `/aif-review`, `/aif-verify`) are read-only for context artifacts by default.
+Quality commands (`/aif-rules-check`, `/aif-commit`, `/aif-review`, `/aif-verify`) are read-only for context artifacts by default.
 
 The locations shown in the ownership table are the default paths. `config.yaml` may relocate plan, fix, reference,
 documentation, security, evolution, and other AI Factory artifacts; ownership stays with the same command even when the path changes.
@@ -113,13 +114,15 @@ Context gate policy for quality commands:
 - Roadmap mismatch is warning-first in normal mode, blocking in strict mode when mismatch is clear.
 - Missing roadmap milestone linkage for `feat`/`fix`/`perf` is warning-first by default, even in strict verify when a
   roadmap exists.
+- `/aif-rules-check` is the standalone rules-only companion and uses `PASS` / `WARN` / `FAIL`; `/aif-commit`,
+  `/aif-review`, and `/aif-verify` keep `WARN` / `ERROR`.
 
 ### Config-Aware Skills
 
 `config.yaml` is not universal yet. The current config-aware skills are:
 
 - Core workflow and quality: `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`,
-  `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`
+  `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`
 - Additional utility: `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`,
   `/aif-security-checklist`, `/aif-qa`
 
@@ -193,6 +196,23 @@ No `area:` prefix → append/update project-wide axioms in configured `paths.rul
     ↓
 Workflow skills resolve conventions with the same hierarchy:
 `rules.<area>` → `rules/base.md` → `paths.rules_file`
+
+/aif-rules-check [git ref]
+    ↓
+Reads resolved rules hierarchy from `config.yaml` with fallback to `.ai-factory/RULES.md`
+    ↓
+Collects changed files from staged diff, working tree, or `<git ref>...HEAD`
+    ↓
+Optionally reads the active plan only to disambiguate scope/area relevance
+    ↓
+Evaluates rules in read-only mode
+    ↓
+Reports standalone verdict:
+    - PASS → applicable rules checked and no clear violations found
+    - WARN → missing/ambiguous rules or no changed files
+    - FAIL → explicit hard-rule violation tied to diff evidence
+    ↓
+Suggests `/aif-rules` when rules need to be added or clarified
 
 /aif-roadmap [vision or requirements]
     ↓

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -52,7 +52,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
-| `language.ui` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-reference`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa` | UI language for prompts, questions, and summaries; `/aif` resolves it before downstream setup questions |
+| `language.ui` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-reference`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa` | UI language for prompts, questions, and summaries; `/aif` resolves it before downstream setup questions |
 | `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-roadmap`, `/aif-implement`, `/aif-loop`, `/aif-docs`, `/aif-evolve` | Language for generated artifacts; `/aif` locks it before the first setup artifact so DESCRIPTION/rules base/AGENTS/ARCHITECTURE stay aligned in one run |
 | `language.technical_terms` | `keep` | No dedicated built-in reader yet | Present in schema and template; `/aif` preserves an existing value when present and otherwise writes the default `keep`, while the wider translation policy stays reserved for future use |
 
@@ -65,9 +65,9 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | `paths.docs` | `docs/` | `/aif-docs` | Detailed docs directory; `README.md` stays fixed in project root |
 | `paths.roadmap` | `.ai-factory/ROADMAP.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-loop` | Strategic roadmap artifact |
 | `paths.research` | `.ai-factory/RESEARCH.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-improve`, `/aif-loop` | Persisted exploration context |
-| `paths.rules_file` | `.ai-factory/RULES.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-rules`, `/aif-reference`, `/aif-loop` | Top-level rules artifact |
-| `paths.plan` | `.ai-factory/PLAN.md` | `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-loop` | Fast-plan path |
-| `paths.plans` | `.ai-factory/plans/` | `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-loop` | Full-plan directory |
+| `paths.rules_file` | `.ai-factory/RULES.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-rules`, `/aif-reference`, `/aif-loop` | Top-level rules artifact |
+| `paths.plan` | `.ai-factory/PLAN.md` | `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-loop` | Fast-plan path |
+| `paths.plans` | `.ai-factory/plans/` | `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-loop` | Full-plan directory |
 | `paths.fix_plan` | `.ai-factory/FIX_PLAN.md` | `/aif-fix`, `/aif-improve`, `/aif-implement`, `/aif-verify` | Fix-plan path |
 | `paths.security` | `.ai-factory/SECURITY.md` | `/aif-security-checklist` | Security ignore-state artifact |
 | `paths.references` | `.ai-factory/references/` | `/aif-reference` | Knowledge reference storage |
@@ -75,7 +75,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | `paths.evolutions` | `.ai-factory/evolutions/` | `/aif-plan`, `/aif-evolve` | Evolution logs and patch cursor |
 | `paths.evolution` | `.ai-factory/evolution/` | `/aif-loop` | Reflex loop state root |
 | `paths.specs` | `.ai-factory/specs/` | `/aif-plan`, `/aif-verify` | Specs / archived plan support |
-| `paths.rules` | `.ai-factory/rules/` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-rules` | Area-rules directory and relative rule resolution base |
+| `paths.rules` | `.ai-factory/rules/` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-rules` | Area-rules directory and relative rule resolution base |
 | `paths.qa` | `.ai-factory/qa/` | `/aif-qa` | QA artifacts root; branch slug is appended as subdirectory (`<paths.qa>/<branch-slug>/`) |
 
 ### `workflow`
@@ -92,8 +92,8 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
-| `git.enabled` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify` | Disables branch/worktree assumptions when false |
-| `git.base_branch` | `main` with auto-detect fallback | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-review` | Target branch for diff, merge, and verification guidance |
+| `git.enabled` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check` | Disables branch/worktree assumptions when false |
+| `git.base_branch` | `main` with auto-detect fallback | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check` | Target branch for diff, merge, and verification guidance |
 | `git.create_branches` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify` | Full plans may still exist when false; they just skip auto branch creation |
 | `git.branch_prefix` | `feature/` | `/aif`, `/aif-plan` | Prefix for auto-created full-plan branches |
 | `git.skip_push_after_commit` | `false` | `/aif-commit` | When true, `/aif-commit` skips push prompt and ends after local commit |
@@ -102,8 +102,8 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
-| `rules.base` | `.ai-factory/rules/base.md` | `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-fix`, `/aif-evolve` | Base project rule file |
-| `rules.<area>` | none | `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-fix`, `/aif-evolve`; written by `/aif-rules area:<name>` | Named area rule entries like `rules.api`, `rules.frontend`; preserved during `/aif` reruns |
+| `rules.base` | `.ai-factory/rules/base.md` | `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-evolve` | Base project rule file |
+| `rules.<area>` | none | `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-evolve`; written by `/aif-rules area:<name>` | Named area rule entries like `rules.api`, `rules.frontend`; preserved during `/aif` reruns |
 
 ## Skill Matrix
 
@@ -125,6 +125,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | `/aif-improve` | Yes | No | `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.research`, `paths.description`, `paths.patches`, `language.ui`, `git.enabled`, `git.base_branch`, `git.create_branches` |
 | `/aif-implement` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.research`, `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.patches`, `paths.rules`, `language.ui`, `language.artifacts`, `git.enabled`, `git.base_branch`, `git.create_branches`, `rules.base`, `rules.<area>` |
 | `/aif-verify` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.specs`, `paths.rules`, `workflow.verify_mode`, `git.enabled`, `git.base_branch`, `git.create_branches`, `rules.base`, `rules.<area>` |
+| `/aif-rules-check` | Yes | No | `paths.rules_file`, `paths.rules`, `paths.plan`, `paths.plans`, `language.ui`, `git.enabled`, `git.base_branch`, `rules.base`, `rules.<area>` |
 | `/aif-commit` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.rules`, `language.ui`, `git.skip_push_after_commit`, `rules.base`, `rules.<area>` |
 | `/aif-review` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.rules`, `language.ui`, `git.base_branch` |
 | `/aif-loop` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.research`, `paths.plan`, `paths.plans`, `paths.evolution`, `language.ui`, `language.artifacts` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,7 +155,7 @@ rules:
 ```
 
 **Current config-aware skills** read `config.yaml` at Step 0. This currently includes:
-- Core workflow and quality commands: `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`
+- Core workflow and quality commands: `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`
 - Additional utility commands: `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-security-checklist`, `/aif-qa`
 
 Other skills are config-agnostic for now and rely on repository context, explicit arguments, or fixed non-configurable paths such as `skill-context`.
@@ -164,7 +164,7 @@ Current config-agnostic built-ins include `/aif-best-practices`, `/aif-build-aut
 
 **Git workflow semantics:**
 - `git.enabled: false` disables branch/worktree assumptions entirely. `/aif-plan full` still creates a rich full plan, but it stores it in `paths.plans/<slug>.md` without running git commands.
-- `git.base_branch` is the branch used for diff, review, verify, and merge guidance. Skills must not hardcode `main`.
+- `git.base_branch` is the branch used for diff, review, verify, rules-check, and merge guidance. Skills must not hardcode `main`.
 - `git.create_branches: false` keeps git awareness enabled but disables automatic branch creation. This lets teams keep full plans without forcing branch-per-feature flow.
 - `git.skip_push_after_commit: true` makes `/aif-commit` stop after local commit without showing push prompt.
 - `paths.plan` remains the default fast-plan file. If you prefer fast plans inside `paths.plans/`, change `paths.plan` manually in `config.yaml`.
@@ -329,7 +329,7 @@ For full phase contracts and stop conditions, see [Reflex Loop](loop.md).
 
 ### Artifact Ownership and Context Gates
 - Keep context artifact ownership command-scoped (roadmap by `/aif-roadmap`, rules by `/aif-rules`, architecture by `/aif-architecture`, research by `/aif-explore`).
-- Treat `/aif-commit`, `/aif-review`, and `/aif-verify` as read-only consumers of context artifacts by default.
+- Treat `/aif-rules-check`, `/aif-commit`, `/aif-review`, and `/aif-verify` as read-only consumers of context artifacts by default.
 - Use `WARN` for non-blocking gate findings (missing optional files, ambiguous mapping) and `ERROR` for blocking violations.
 
 ### Logging

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,7 +2,7 @@
 
 # Core Skills
 
-**Config-aware skills read `.ai-factory/config.yaml` at startup** to resolve paths, language settings, workflow preferences, and rules hierarchy. The current config-aware set is `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`, `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-security-checklist`, and `/aif-qa`.
+**Config-aware skills read `.ai-factory/config.yaml` at startup** to resolve paths, language settings, workflow preferences, and rules hierarchy. The current config-aware set is `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`, `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-security-checklist`, and `/aif-qa`.
 
 `/aif` is also the primary writer for `config.yaml`: the initial file comes from the commented template, and setup reruns update only managed keys while preserving comments, unrelated manual edits, and `rules.<area>` entries owned by `/aif-rules`.
 
@@ -414,6 +414,22 @@ Reviews staged changes or PR diffs:
 - Checks correctness, security, performance, and maintainability
 - Adds read-only context-gate findings (architecture/roadmap/rules) to review output
 - Uses `WARN` for non-blocking context drift and `ERROR` only for explicitly blocking review criteria
+- If you only need the rules gate, use `/aif-rules-check`
+
+### `/aif-rules-check [git ref]`
+Runs a standalone read-only rules compliance gate:
+```
+/aif-rules-check
+/aif-rules-check main
+```
+- Reads `.ai-factory/config.yaml` for `paths.rules_file`, `paths.rules`, `paths.plan`, `paths.plans`, `language.ui`, `git.enabled`, `git.base_branch`, `rules.base`, and any named `rules.<area>`
+- Resolves rules with graceful fallback: if `paths.rules_file` is omitted, it defaults to `.ai-factory/RULES.md`
+- Checks staged changes, working-tree diff, or a provided git ref against the resolved rules hierarchy
+- Uses standalone verdicts: `PASS` when checked rules are satisfied, `WARN` when rules are missing/ambiguous or no changed files are available, `FAIL` only for explicit hard-rule violations tied to rule text
+- Output sections: overall verdict, files checked, gate results, blocking violations, suggested fixes, suggested rule updates
+- Remains read-only; if rules need to change, route that through `/aif-rules`
+
+- Config policy: config-aware; reads rule paths, optional active plan context, and git diff defaults from `config.yaml`
 
 ### `/aif-reference <url|path> [url2|path2] [--name <ref-name>] [--update]`
 Creates knowledge references from external sources for AI agents:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -176,6 +176,7 @@ Optional conventions step: use `/aif-rules` to append or refine project-wide axi
 | `/aif-loop` | Iterative generation with quality gates and phase-based cycles | No | No (uses `paths.evolution`, default `.ai-factory/evolution/`) |
 | `/aif-reference` | Create knowledge refs from URLs/docs for AI agents | No | No (`paths.references`, default `.ai-factory/references/`) |
 | `/aif-fix` | Bug fixes, errors, hotfixes | No | Optional (`paths.fix_plan`, default `.ai-factory/FIX_PLAN.md`) |
+| `/aif-rules-check` | Standalone read-only rules compliance gate for staged work, working tree, or a git ref | No | No (reads existing rules and optional plan context) |
 | `/aif-verify` | Post-implementation quality check | No | No (reads existing) |
 | `/aif-qa` | Manual QA for a feature/fix: change summary → test plan → test cases | No | `paths.qa/<branch-slug>/*.md` (default: `.ai-factory/qa/<branch-slug>/`) |
 
@@ -195,12 +196,14 @@ Ownership is command-scoped to avoid conflicting writers:
 | `/aif-fix`                                | `paths.fix_plan`, `paths.patches/*.md`                                                        | bug-fix learning loop artifacts                           |
 | `/aif-evolve`                             | `paths.evolutions/*.md`, `paths.evolutions/patch-cursor.json`, `.ai-factory/skill-context/*`  | skill-context overrides + evolution logs + cursor state   |
 | `/aif-qa`                                 | `paths.qa/<branch-slug>/change-summary.md`, `test-plan.md`, `test-cases.md`                   | derived branch slug as subdirectory (see aif-qa SKILL.md) |
+| `/aif-rules-check`                        | read-only context by default                                                                  | standalone rules gate; no default context-file writes     |
 | `/aif-commit` `/aif-review` `/aif-verify` | read-only context by default                                                                  | gate and report, no default context-file writes           |
 
 Context-gate defaults for `/aif-commit`, `/aif-review`, `/aif-verify`:
 - Check architecture, roadmap, and rules alignment as read-only context.
 - Missing optional files (`ROADMAP.md`, `RULES.md`) are `WARN`, not immediate failures.
 - In strict verification, clear architecture/rules violations and clear roadmap mismatch are blocking failures.
+- `/aif-rules-check` is the standalone rules-only companion and uses `PASS` / `WARN` / `FAIL` without changing the `WARN` / `ERROR` contract above.
 
 ## Workflow Skills
 
@@ -295,6 +298,10 @@ Optional step after `/aif-implement`. Goes through every task in the plan and ve
 
 Also runs read-only context gates against the resolved architecture, roadmap, and RULES.md artifacts. In normal mode, roadmap/milestone linkage gaps are warnings; in strict mode, clear roadmap mismatch is a failure, while missing `feat`/`fix`/`perf` milestone linkage remains a warning.
 
+### `/aif-rules-check` — standalone rules gate
+
+Checks only rules compliance for staged changes, working-tree changes, or a provided git ref. It reads the resolved rules hierarchy, uses optional active plan context only to disambiguate scope, and stays read-only. Standalone verdicts are `PASS` / `WARN` / `FAIL`: missing or ambiguous rules stay `WARN`, while `FAIL` is reserved for explicit hard-rule violations tied to concrete diff evidence.
+
 ### `/aif-review` — code review with read-only context gates
 
 Reviews staged changes or PR diff and reports correctness/security/performance findings. Includes read-only architecture/roadmap/rules gate notes in review output (`WARN` for non-blocking inconsistencies, `ERROR` only for explicitly blocking criteria).
@@ -331,7 +338,7 @@ Reads patches incrementally using an evolve cursor, analyzes project patterns, a
 
 ---
 
-For full details on all skills including utility commands (`/aif-docs`, `/aif-dockerize`, `/aif-build-automation`, `/aif-ci`, `/aif-commit`, `/aif-skill-generator`, `/aif-reference`, `/aif-security-checklist`, `/aif-qa`), see [Core Skills](skills.md).
+For full details on all skills including utility commands (`/aif-docs`, `/aif-dockerize`, `/aif-build-automation`, `/aif-ci`, `/aif-commit`, `/aif-rules-check`, `/aif-skill-generator`, `/aif-reference`, `/aif-security-checklist`, `/aif-qa`), see [Core Skills](skills.md).
 
 ## Why Spec-Driven?
 

--- a/scripts/test-aif-rules-check.sh
+++ b/scripts/test-aif-rules-check.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Smoke tests for /aif-rules-check contract and severity boundaries.
+# Usage: ./scripts/test-aif-rules-check.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL_DIR="$ROOT_DIR/skills/aif-rules-check"
+CONTRACT_REF="$SKILL_DIR/references/RULES-CHECK-CONTRACT.md"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() {
+    PASSED=$((PASSED + 1))
+    echo -e "  ${GREEN}OK${NC} $1"
+}
+
+fail() {
+    FAILED=$((FAILED + 1))
+    echo -e "  ${RED}FAIL${NC} $1"
+}
+
+assert_exact_line() {
+    local file="$1"
+    local expected="$2"
+    local success_message="$3"
+    local failure_message="$4"
+
+    if grep -Fqx "$expected" "$file"; then
+        pass "$success_message"
+    else
+        fail "$failure_message"
+    fi
+}
+
+echo -e "\n${BOLD}=== /aif-rules-check skill contract ===${NC}\n"
+
+if grep -Fq 'If `paths.rules_file` is missing from config, default to `.ai-factory/RULES.md` instead of treating config as incomplete.' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md documents fallback to .ai-factory/RULES.md"
+else
+    fail "SKILL.md must document fallback to .ai-factory/RULES.md"
+fi
+
+if grep -Fq 'Optional plan context: use the active plan file only when it helps interpret scope or area relevance; absence of a plan is never a failure.' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md documents optional plan context"
+else
+    fail "SKILL.md must document optional plan context"
+fi
+
+if grep -Fq 'If there are still no changed files, return `WARN` rather than a hard failure.' "$SKILL_DIR/SKILL.md" \
+   && grep -Fq 'If no rules sources resolve, return `WARN` rather than a hard failure.' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md keeps missing-scope and missing-rules outcomes at WARN"
+else
+    fail "SKILL.md must keep missing-scope and missing-rules outcomes at WARN"
+fi
+
+if grep -Fq 'Only return `FAIL` when an explicit hard rule is clearly violated by the inspected diff or changed files.' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md restricts FAIL to explicit hard-rule violations"
+else
+    fail "SKILL.md must restrict FAIL to explicit hard-rule violations"
+fi
+
+if grep -Fq 'This command is read-only: do not edit `RULES.md`, `rules/base.md`, `rules.<area>`, plan files, or source code.' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md documents read-only boundary"
+else
+    fail "SKILL.md must document read-only boundary"
+fi
+
+allowed_line=$(grep -E '^allowed-tools:' "$SKILL_DIR/SKILL.md" || true)
+if [[ "$allowed_line" == *"Bash(git *)"* ]]; then
+    pass "SKILL.md allowed-tools includes Bash(git *)"
+else
+    fail "SKILL.md allowed-tools must include Bash(git *)"
+fi
+
+echo -e "\n${BOLD}=== /aif-rules-check report contract ===${NC}\n"
+
+assert_exact_line \
+    "$CONTRACT_REF" \
+    '**Overall Verdict:** PASS | WARN | FAIL' \
+    "contract keeps exact overall verdict line" \
+    "contract must contain the exact line '**Overall Verdict:** PASS | WARN | FAIL'"
+
+assert_exact_line \
+    "$CONTRACT_REF" \
+    '**Files Checked:** <count>' \
+    "contract keeps exact files-checked line" \
+    "contract must contain the exact line '**Files Checked:** <count>'"
+
+assert_exact_line \
+    "$CONTRACT_REF" \
+    '### Gate Results' \
+    "contract keeps Gate Results section" \
+    "contract must contain the exact heading '### Gate Results'"
+
+assert_exact_line \
+    "$CONTRACT_REF" \
+    '### Blocking Violations' \
+    "contract keeps Blocking Violations section" \
+    "contract must contain the exact heading '### Blocking Violations'"
+
+assert_exact_line \
+    "$CONTRACT_REF" \
+    '### Suggested Fixes' \
+    "contract keeps Suggested Fixes section" \
+    "contract must contain the exact heading '### Suggested Fixes'"
+
+assert_exact_line \
+    "$CONTRACT_REF" \
+    '### Suggested Rule Updates' \
+    "contract keeps Suggested Rule Updates section" \
+    "contract must contain the exact heading '### Suggested Rule Updates'"
+
+assert_exact_line \
+    "$CONTRACT_REF" \
+    '`WARN` - no applicable rules were resolved, evidence is ambiguous, or there are no changed files to evaluate.' \
+    "contract keeps no-rules/no-diff semantics at WARN" \
+    "contract must keep no-rules/no-diff semantics at WARN"
+
+assert_exact_line \
+    "$CONTRACT_REF" \
+    '`FAIL` - an explicit hard rule is clearly violated by the inspected diff or changed files.' \
+    "contract keeps FAIL reserved for explicit hard-rule violations" \
+    "contract must keep FAIL reserved for explicit hard-rule violations"
+
+assert_exact_line \
+    "$CONTRACT_REF" \
+    '`PASS` / `WARN` / `FAIL` belongs only to `/aif-rules-check`; `/aif-commit`, `/aif-review`, and `/aif-verify` keep `WARN` / `ERROR`.' \
+    "contract preserves standalone-vs-context-gate severity boundary" \
+    "contract must preserve standalone-vs-context-gate severity boundary"
+
+TOTAL=$((PASSED + FAILED))
+echo ""
+echo -e "${BOLD}Total:${NC} $TOTAL, ${GREEN}Passed:${NC} $PASSED, ${RED}Failed:${NC} $FAILED"
+
+if [[ $FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/test-aif-rules-check.sh
+++ b/scripts/test-aif-rules-check.sh
@@ -48,6 +48,18 @@ else
     fail "SKILL.md must document fallback to .ai-factory/RULES.md"
 fi
 
+if grep -Fq 'If `git.base_branch` is missing from config, resolve the repository default branch from git metadata when possible; use `main` only as the final fallback.' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md documents git.base_branch auto-detect fallback"
+else
+    fail "SKILL.md must document git.base_branch auto-detect fallback"
+fi
+
+if grep -Fqx -- '- `git.base_branch`: `main`' "$SKILL_DIR/SKILL.md"; then
+    fail "SKILL.md must not hardcode git.base_branch to main"
+else
+    pass "SKILL.md no longer hardcodes git.base_branch to main"
+fi
+
 if grep -Fq 'Optional plan context: use the active plan file only when it helps interpret scope or area relevance; absence of a plan is never a failure.' "$SKILL_DIR/SKILL.md"; then
     pass "SKILL.md documents optional plan context"
 else

--- a/scripts/test-init.sh
+++ b/scripts/test-init.sh
@@ -116,11 +116,14 @@ echo "claude init smoke tests passed"
 FLAT_PROJECT_DIR="$TMPDIR/init-smoke-antigravity"
 mkdir -p "$FLAT_PROJECT_DIR"
 
-(cd "$FLAT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agents antigravity --skills aif > "$TMPDIR/init-antigravity.log" 2>&1)
+(cd "$FLAT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agents antigravity --skills aif,aif-rules-check > "$TMPDIR/init-antigravity.log" 2>&1)
 
 assert_exists "$FLAT_PROJECT_DIR/.agent/workflows/aif.md" "antigravity init must install aif as a flat workflow"
+assert_exists "$FLAT_PROJECT_DIR/.agent/workflows/aif-rules-check.md" "antigravity init must install aif-rules-check as a flat workflow"
 assert_exists "$FLAT_PROJECT_DIR/.agent/workflows/references/update-config.mjs" "flat workflow installs must include the config helper in references/"
 assert_exists "$FLAT_PROJECT_DIR/.agent/workflows/references/config-template.yaml" "flat workflow installs must include config template references"
+assert_exists "$FLAT_PROJECT_DIR/.agent/workflows/references/RULES-CHECK-CONTRACT.md" "flat workflow installs must include rules-check references"
+assert_not_exists "$FLAT_PROJECT_DIR/.agent/skills/aif-rules-check" "workflow-classified skills must not remain under .agent/skills/"
 
 echo "flat workflow init smoke tests passed"
 

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -673,6 +673,20 @@ fi
 # ─────────────────────────────────────────────
 # Summary
 # ─────────────────────────────────────────────
+echo -e "\n${BOLD}=== aif-rules-check skill smoke tests ===${NC}\n"
+
+set +e
+RULES_CHECK_SMOKE_OUTPUT=$(bash "$ROOT_DIR/scripts/test-aif-rules-check.sh" 2>&1)
+RULES_CHECK_SMOKE_EXIT=$?
+set -e
+
+if [[ $RULES_CHECK_SMOKE_EXIT -eq 0 ]]; then
+    pass "aif-rules-check smoke tests"
+else
+    fail "aif-rules-check smoke tests"
+    echo "$RULES_CHECK_SMOKE_OUTPUT" | sed 's/^/      /'
+fi
+
 echo -e "\n${BOLD}=== Results ===${NC}"
 echo -e "  Total:    $TOTAL"
 echo -e "  Passed:   ${GREEN}$PASSED${NC}"

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -181,8 +181,8 @@ assert_not_exists "$AG_PROJECT_DIR/.agent/skills/aif-docs/references/stale.md" "
 echo "antigravity force smoke tests passed"
 
 # -------------------------------------------------------------------
-# Kilo Code workflow smoke: action skills should install as workflows
-# and no longer remain under .kilocode/skills/.
+# Kilo Code workflow smoke: workflow-classified skills should install
+# as workflows and no longer remain under .kilocode/skills/.
 # -------------------------------------------------------------------
 
 KILO_PROJECT_DIR="$TMPDIR/update-smoke-kilocode"
@@ -195,7 +195,7 @@ cat > "$KILO_PROJECT_DIR/.ai-factory.json" << 'EOF'
     {
       "id": "kilocode",
       "skillsDir": ".kilocode/skills",
-      "installedSkills": ["aif", "aif-plan", "aif-commit", "aif-docs"],
+      "installedSkills": ["aif", "aif-plan", "aif-commit", "aif-rules-check", "aif-docs"],
       "mcp": {
         "github": false,
         "filesystem": false,
@@ -217,11 +217,13 @@ assert_contains "$KILO_OUTPUT" "\[kilocode\] Status:" "kilocode status section m
 assert_exists "$KILO_PROJECT_DIR/.kilocode/workflows/aif.md" "aif workflow must be installed for Kilo Code"
 assert_exists "$KILO_PROJECT_DIR/.kilocode/workflows/aif-plan.md" "aif-plan workflow must be installed for Kilo Code"
 assert_exists "$KILO_PROJECT_DIR/.kilocode/workflows/aif-commit.md" "aif-commit workflow must be installed for Kilo Code"
+assert_exists "$KILO_PROJECT_DIR/.kilocode/workflows/aif-rules-check.md" "aif-rules-check workflow must be installed for Kilo Code"
 assert_contains "$KILO_PROJECT_DIR/.kilocode/workflows/aif-plan.md" "/aif:[a-z-]+" "Kilo workflow content must use Kilo invocation syntax"
 assert_exists "$KILO_PROJECT_DIR/.kilocode/skills/aif-docs/SKILL.md" "non-workflow Kilo skills must remain in skills/"
 assert_not_exists "$KILO_PROJECT_DIR/.kilocode/skills/aif" "workflow skill should not remain in skills/"
 assert_not_exists "$KILO_PROJECT_DIR/.kilocode/skills/aif-plan" "workflow skill should not remain in skills/"
 assert_not_exists "$KILO_PROJECT_DIR/.kilocode/skills/aif-commit" "workflow skill should not remain in skills/"
+assert_not_exists "$KILO_PROJECT_DIR/.kilocode/skills/aif-rules-check" "workflow skill should not remain in skills/"
 
 echo "kilocode workflow smoke tests passed"
 

--- a/skills/aif-commit/SKILL.md
+++ b/skills/aif-commit/SKILL.md
@@ -54,6 +54,7 @@ If any rule is violated — fix the output before presenting it to the user.
    - Check rules hierarchy (resolved `paths.rules_file` + `rules.base` + named `rules.<area>`) for commit conventions
    - Missing optional files (`ROADMAP.md`, `RULES.md`) are `WARN`, not blockers
    - Never modify context artifacts from this command
+   - If the user wants a standalone rules-only pass, suggest `/aif-rules-check`; keep `/aif-commit` gate labels at `WARN` / `ERROR`
 
 3. **Determine Commit Type**
    - `feat`: New feature

--- a/skills/aif-review/SKILL.md
+++ b/skills/aif-review/SKILL.md
@@ -115,6 +115,8 @@ Gate result severity:
 - `WARN` for non-blocking inconsistencies or missing optional files.
 - `ERROR` only for explicit blocking criteria requested by the user/review policy.
 
+If the user wants a standalone rules-only pass, suggest `/aif-rules-check`. Keep `/aif-review` gate labels at `WARN` / `ERROR`.
+
 `/aif-review` is read-only for context artifacts by default. Do not modify context files unless user explicitly asks.
 
 ### Project Context

--- a/skills/aif-rules-check/SKILL.md
+++ b/skills/aif-rules-check/SKILL.md
@@ -39,10 +39,11 @@ If config is missing or partial, use defaults:
 - `paths.plan`: `.ai-factory/PLAN.md`
 - `paths.plans`: `.ai-factory/plans/`
 - `git.enabled`: `true`
-- `git.base_branch`: `main`
+- `git.base_branch`: detect the repo default branch from git metadata; fall back to `main` only when detection is unavailable
 - `rules.base`: `.ai-factory/rules/base.md`
 
 If `paths.rules_file` is missing from config, default to `.ai-factory/RULES.md` instead of treating config as incomplete.
+If `git.base_branch` is missing from config, resolve the repository default branch from git metadata when possible; use `main` only as the final fallback.
 
 ### Step 1.1: Load Skill Context
 

--- a/skills/aif-rules-check/SKILL.md
+++ b/skills/aif-rules-check/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: aif-rules-check
+description: Run a standalone read-only rules compliance gate against changed files or a git ref. Use when you need a dedicated project-rules check without a full review or verify pass.
+argument-hint: "[git ref | empty]"
+allowed-tools: Read Glob Grep Bash(git *) AskUserQuestion
+disable-model-invocation: false
+metadata:
+  author: AI Factory
+  version: "1.0"
+  category: quality
+---
+
+# Rules Compliance Gate
+
+Run a standalone read-only rules gate for project rules. This command checks rule compliance only; it does not replace `/aif-review` or `/aif-verify`.
+
+## Step 0: Load Contract
+
+- Read `references/RULES-CHECK-CONTRACT.md` first.
+- Treat it as the canonical source for verdict semantics and report structure.
+- If examples in this file drift from the reference, follow the reference.
+
+## Step 1: Load Config
+
+**FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
+- `paths.rules_file`
+- `paths.rules`
+- `paths.plan`
+- `paths.plans`
+- `language.ui`
+- `git.enabled`
+- `git.base_branch`
+- `rules.base`
+- named `rules.<area>` entries
+
+If config is missing or partial, use defaults:
+- `paths.rules_file`: `.ai-factory/RULES.md`
+- `paths.rules`: `.ai-factory/rules/`
+- `paths.plan`: `.ai-factory/PLAN.md`
+- `paths.plans`: `.ai-factory/plans/`
+- `git.enabled`: `true`
+- `git.base_branch`: `main`
+- `rules.base`: `.ai-factory/rules/base.md`
+
+If `paths.rules_file` is missing from config, default to `.ai-factory/RULES.md` instead of treating config as incomplete.
+
+### Step 1.1: Load Skill Context
+
+**Read `.ai-factory/skill-context/aif-rules-check/SKILL.md`** - MANDATORY if the file exists.
+
+This file contains project-specific rules accumulated by `/aif-evolve` from patches,
+codebase conventions, and tech-stack analysis. These rules are tailored to the current project.
+
+**How to apply skill-context rules:**
+- Treat them as project-level overrides for this skill's general instructions.
+- When a skill-context rule conflicts with a general rule in this file, the skill-context rule wins.
+- When there is no conflict, apply both.
+- Skill-context rules apply to all outputs of this skill, including verdict wording and report structure.
+
+**Enforcement:** Before presenting the final report, verify it against all skill-context rules and fix any drift.
+
+## Step 2: Resolve Inputs
+
+Resolve two inputs before checking any rule:
+
+1. **Changed scope** - the diff and file list you are evaluating
+2. **Resolved rule sources** - the rule artifacts that may apply to that scope
+
+### Step 2.1: Resolve Changed Scope
+
+**If the user provided a git ref:**
+
+1. Validate it first:
+   ```bash
+   git rev-parse --verify <argument>
+   ```
+2. If valid, use:
+   ```bash
+   git diff --name-only <argument>...HEAD
+   git diff <argument>...HEAD
+   ```
+3. If invalid, ask:
+
+   ```
+   AskUserQuestion: `<argument>` is not a valid git ref. What should I check instead?
+
+   Options:
+   1. Check staged / working-tree changes
+   2. Cancel
+   ```
+
+**Without arguments:**
+
+1. Prefer staged work:
+   ```bash
+   git diff --cached --name-only
+   git diff --cached
+   ```
+2. If nothing is staged, fall back to working tree:
+   ```bash
+   git diff --name-only
+   git diff
+   ```
+3. If there is still no local diff and `git.enabled = true`, fall back to branch diff:
+   ```bash
+   git diff --name-only <resolved-base-branch>...HEAD
+   git diff <resolved-base-branch>...HEAD
+   ```
+
+If there are still no changed files, return `WARN` rather than a hard failure.
+
+### Step 2.2: Resolve Rule Sources
+
+Load rule sources in this order:
+
+1. The resolved `paths.rules_file` artifact
+2. The resolved `rules.base` file
+3. Any named `rules.<area>` files from config that clearly match the changed scope
+
+Area rules are optional and scoped:
+- Use changed file paths, folder names, and optional plan context to judge relevance.
+- If relevance is ambiguous, mention the rule source as uncertain and keep the outcome at `WARN`, not `FAIL`.
+
+If no rules sources resolve, return `WARN` rather than a hard failure.
+
+### Step 2.3: Optional Plan Context
+
+Optional plan context: use the active plan file only when it helps interpret scope or area relevance; absence of a plan is never a failure.
+
+Plan resolution order:
+1. Branch-based `paths.plans/<current-branch>.md`
+2. A single named full plan in `paths.plans`
+3. The fast plan at `paths.plan`
+
+Do not fail the rules check because a plan file is missing or ambiguous.
+
+## Step 3: Evaluate Rules
+
+Read the changed files from the resolved scope and compare them against the resolved rules.
+
+Classification rules:
+- `PASS` when at least one applicable rule was checked and no clear violations were found.
+- `WARN` when no applicable rules were resolved, the evidence is ambiguous, or there are no changed files to evaluate.
+- `FAIL` when an explicit hard rule is clearly violated by the inspected diff or changed files.
+
+Only return `FAIL` when an explicit hard rule is clearly violated by the inspected diff or changed files.
+
+Evidence rules:
+- Tie every blocking violation to specific rule text and at least one concrete file/path or diff hunk.
+- If a rule sounds like a preference, is too vague, or cannot be verified confidently from the diff, do not escalate it past `WARN`.
+- Missing optional files or partially configured rules hierarchy are `WARN`, not `FAIL`.
+
+## Step 4: Read-Only Boundary
+
+This command is read-only: do not edit `RULES.md`, `rules/base.md`, `rules.<area>`, plan files, or source code.
+
+If rules are missing, stale, or need refinement:
+- Suggest `/aif-rules <rule text>` for axioms
+- Suggest `/aif-rules area:<name>` for area-specific rules
+
+## Step 5: Output
+
+Use the exact verdict semantics and section order from `references/RULES-CHECK-CONTRACT.md`.
+
+Required content:
+- overall verdict
+- files checked
+- gate results
+- blocking violations
+- suggested fixes
+- suggested rule updates
+
+When useful, suggest the next best workflow:
+- `/aif-review` for broader code review
+- `/aif-verify` for full plan-completeness verification
+- `/aif-rules` when the underlying rules need to be captured or corrected

--- a/skills/aif-rules-check/references/RULES-CHECK-CONTRACT.md
+++ b/skills/aif-rules-check/references/RULES-CHECK-CONTRACT.md
@@ -1,0 +1,34 @@
+# Rules Compliance Report
+
+**Overall Verdict:** PASS | WARN | FAIL
+**Files Checked:** <count>
+
+### Gate Results
+- PASS [rules] <summary>
+- WARN [rules] <summary>
+- FAIL [rules] <summary>
+
+### Blocking Violations
+- <file>: <explicit hard-rule violation tied to rule text>
+
+### Suggested Fixes
+- <concrete code or workflow fix>
+
+### Suggested Rule Updates
+- <candidate rule to add or clarify via /aif-rules>
+
+## Verdict Semantics
+
+`PASS` - at least one applicable rule was checked and no clear violations were found.
+`WARN` - no applicable rules were resolved, evidence is ambiguous, or there are no changed files to evaluate.
+`FAIL` - an explicit hard rule is clearly violated by the inspected diff or changed files.
+
+## Severity Boundary
+
+`PASS` / `WARN` / `FAIL` belongs only to `/aif-rules-check`; `/aif-commit`, `/aif-review`, and `/aif-verify` keep `WARN` / `ERROR`.
+
+## Read-Only Contract
+
+- `/aif-rules-check` does not edit rule artifacts or source files.
+- Missing optional rule files stay `WARN`.
+- Rule updates still route through `/aif-rules`.

--- a/skills/aif-verify/SKILL.md
+++ b/skills/aif-verify/SKILL.md
@@ -302,6 +302,8 @@ Logging/reporting format:
 - Non-blocking findings: `WARN [gate-name] ...`
 - Blocking findings: `ERROR [gate-name] ...`
 
+If the user wants a standalone rules-only pass, suggest `/aif-rules-check`. Keep `/aif-verify` gate labels at `WARN` / `ERROR`.
+
 ### 3.6 Context Drift (Optional Remediation)
 
 `/aif-verify` is **read-only** for context artifacts. Do not edit or regenerate `.ai-factory/*` files here.

--- a/skills/aif-verify/references/CONTEXT-GATES-AND-OWNERSHIP.md
+++ b/skills/aif-verify/references/CONTEXT-GATES-AND-OWNERSHIP.md
@@ -56,6 +56,15 @@ Gate outputs must use:
 - **Warn:** `.ai-factory/ROADMAP.md` missing, ambiguous milestone mapping, or no milestone linkage for `feat`/`fix`/`perf` work.
 - **Fail (strict verify only):** Clear mismatch with roadmap direction after all available roadmap context is considered.
 
+## Standalone Rules Gate
+
+`/aif-rules-check` is the standalone, read-only rules-only companion to these context gates.
+
+- It evaluates the resolved rules hierarchy plus changed files/diff and reports `PASS` / `WARN` / `FAIL`.
+- Missing or non-applicable rules remain `WARN`.
+- Explicit hard-rule violations may become `FAIL`.
+- This does not change the `WARN` / `ERROR` reporting contract used by `/aif-commit`, `/aif-review`, and `/aif-verify`.
+
 ## Threshold Decisions (Resolved)
 
 ### Verify normal mode

--- a/src/cli/wizard/skill-hints.ts
+++ b/src/cli/wizard/skill-hints.ts
@@ -20,6 +20,7 @@ const SKILL_HINTS: Record<string, string> = {
     'aif-review': 'Review staged changes/PR',
     'aif-roadmap': 'Roadmap and milestones',
     'aif-rules': 'Project rules and conventions',
+    'aif-rules-check': 'Standalone project rules gate',
     'aif-security-checklist': 'Security audit checklist',
     'aif-skill-generator': 'Generate new agent skills',
     'aif-verify': 'Verify implementation completeness',

--- a/src/core/transformer.ts
+++ b/src/core/transformer.ts
@@ -32,6 +32,7 @@ export const WORKFLOW_SKILLS = new Set([
   'aif-implement',
   'aif-improve',
   'aif-plan',
+  'aif-rules-check',
   'aif-verify',
 ]);
 

--- a/src/core/transformers/antigravity.ts
+++ b/src/core/transformers/antigravity.ts
@@ -42,6 +42,7 @@ export class AntigravityTransformer implements AgentTransformer {
 - Use \`/aif-fix\` for bug fixes — analyzes, fixes, suggests tests
 - Use \`/aif-commit\` for commits — follows conventional commits
 - Use \`/aif-implement\` to execute plans step by step
+- Use \`/aif-rules-check\` for a standalone project rules gate
 - Use \`/aif-review\` before merging — checks code quality
 
 ## Safety
@@ -64,6 +65,7 @@ Action-oriented skills that execute specific tasks:
 - \`aif-fix.md\` — Fix bugs with structured approach
 - \`aif-implement.md\` — Execute plans step by step
 - \`aif-commit.md\` — Create conventional commits
+- \`aif-rules-check.md\` — Run a standalone rules compliance gate
 - \`aif-review.md\` — Code review checklist
 - \`aif-ci.md\` — CI/CD pipeline setup
 


### PR DESCRIPTION
## Summary

Adds a standalone `/aif-rules-check` skill for rules-only validation without requiring a full `/aif-review` or `/aif-verify` pass.

Closes #83.

## What Changed

- added bundled `skills/aif-rules-check/` with a dedicated read-only rules gate
- added canonical report contract in `references/RULES-CHECK-CONTRACT.md`
- classified `aif-rules-check` as a workflow skill for transformer-based runtimes
- updated Antigravity and KiloCode smoke coverage for workflow installation behavior
- kept `/aif-commit`, `/aif-review`, and `/aif-verify` on the existing `WARN` / `ERROR` context-gate wording
- updated docs and discovery surfaces:
  - `docs/skills.md`
  - `docs/workflow.md`
  - `docs/configuration.md`
  - `docs/config-reference.md`
  - `AGENTS.md`
  - `src/cli/wizard/skill-hints.ts`
- added dedicated regression coverage in `scripts/test-aif-rules-check.sh`

## Verification

Passed:
- `npm run build`
- `npm run lint`
- `bash skills/aif-skill-generator/scripts/validate.sh skills/aif-rules-check`
- `bash scripts/test-aif-rules-check.sh`
- targeted PowerShell smoke for KiloCode and Antigravity init/update workflow placement

Known notes:
- full `npm test` still fails in this Windows + bash environment because the bash harness cannot resolve `node` / `npm`
- `/aif-rules-check` still documents `git.base_branch: main` as a fallback, while repo docs prefer an auto-detected base-branch fallback
