### PR TITLE
Make /aif MCP guidance runtime-aware for OpenCode and GitHub Copilot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,14 +398,17 @@ ai-factory upgrade
 User-facing documentation is split between a lean README and detailed `docs/` pages:
 
 ```
-README.md                    # Landing page (~105 lines) — first impression, install, example workflow
+README.md                    # Landing page — first impression, install, example workflow
 docs/
 ├── getting-started.md       # What is AI Factory, supported agents table, first project walkthrough, CLI
 ├── workflow.md              # Workflow diagram, "When to Use What" table, workflow skills overview
 ├── loop.md                  # Reflex loop protocol: phases, rules, state, stop conditions
+├── subagents.md             # Claude-only bundled subagents and runtime-local agent-file boundaries
 ├── skills.md                # Full reference: Workflow Skills + Utility Skills
+├── evolve.md                # Patch-driven skill evolution and skill-context learning loop
 ├── plan-files.md            # Plan files, self-improvement patches, skill acquisition strategy
 ├── security.md              # Two-level security scanning system
+├── extensions.md            # Extension commands, injections, MCP, runtimes, and agent files
 ├── configuration.md         # .ai-factory.json, MCP config, project structure, best practices
 └── config-reference.md      # Full config.yaml schema, defaults, and skill read/write matrix
 ```
@@ -415,8 +418,8 @@ docs/
 1. **README is a landing page, not a manual.** It should contain: logo, tagline, "Why?", install, quick start, example workflow, documentation links table, external links, license. Nothing else.
 2. **Details go to `docs/`.** Each file is self-contained — one topic, one page. A user should be able to read a single doc file and get the full picture on that topic.
 3. **No duplication.** If information lives in `docs/`, README links to it — does not repeat it. The only exception: installation command appears in both README and `docs/getting-started.md` (users expect it in README).
-4. **Navigation.** Every docs/ file starts with `[← Back to README](../README.md)` and ends with a "See Also" section linking to 2-3 related pages. `getting-started.md` has "Next Steps" instead.
-5. **Workflow skills vs utility skills.** `docs/workflow.md` describes the workflow skills (plan, loop, improve, implement, fix, evolve) with concise overviews. `docs/loop.md` is the source of truth for Reflex Loop contracts and state transitions. `docs/skills.md` has the full reference for ALL skills, split into "Workflow Skills" and "Utility Skills" sections.
+4. **Navigation.** Every docs/ file starts with prev/back/next navigation that follows the README Documentation table order and ends with a "See Also" section linking to 2-3 related pages. `getting-started.md` may use a simpler first-page header and ends with "Next Steps" instead.
+5. **Workflow skills vs utility skills.** `docs/workflow.md` describes the workflow skills (plan, loop, improve, implement, fix, evolve) with concise overviews. `docs/loop.md` is the source of truth for Reflex Loop contracts and state transitions. `docs/subagents.md` documents bundled Claude-only subagents. `docs/skills.md` has the full reference for ALL skills, split into "Workflow Skills" and "Utility Skills" sections.
 6. **Cross-links use relative paths.** From README: `docs/workflow.md`. Between docs: `workflow.md` (same directory).
 
 ### When to Update What
@@ -426,6 +429,9 @@ docs/
 | New skill added | `docs/skills.md` (add to appropriate section), `docs/workflow.md` (if it's a workflow skill), README Documentation table description (if skill count text changes) |
 | New agent added | `docs/getting-started.md` (agents table), README (agent name in "Multi-agent support" bullet) |
 | Workflow logic changed | `docs/workflow.md` (diagram + skill descriptions), `docs/skills.md` (detailed reference) |
+| Subagent or runtime-local agent-file behavior changed | `docs/subagents.md`, `docs/configuration.md`, README Documentation table description if navigation text changes |
+| Skill evolution / patch learning changed | `docs/evolve.md`, `docs/plan-files.md` when patch lifecycle or skill-context flow changes |
+| Extension lifecycle or runtime-extension behavior changed | `docs/extensions.md`, `docs/configuration.md` |
 | New config option | `docs/configuration.md`, `docs/config-reference.md` |
 | Security scanning changed | `docs/security.md` |
 | Plan file format changed | `docs/plan-files.md` |

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ ai-factory init
 ---
 
 ## Installation
+
 ### Using npm
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ ai-factory init
 ---
 
 ## Installation
-
 ### Using npm
 
 ```bash
@@ -72,46 +71,9 @@ Then open your AI agent and start working:
 /aif
 ```
 
-## Usage
+Need CLI flags, update/upgrade details, or extension commands? See [Getting Started](docs/getting-started.md). Need slash-command reference? See [Core Skills](docs/skills.md).
 
-If the package is installed:
-```bash
-ai-factory init
-```
-
-Or running without installation via `npx`:
-```bash
-npx ai-factory init
-```
-
-### Non-interactive mode
-
-Pass `--agents` to skip the interactive wizard:
-
-```bash
-# Agents + MCP servers
-ai-factory init --agents claude,cursor --mcp github,playwright
-
-# With specific skills
-ai-factory init --agents claude --skills commit,plan
-
-# Without base skills
-ai-factory init --agents codex --no-skills --mcp github
-```
-
-Available MCP servers: `github`, `postgres`, `filesystem`, `chrome-devtools`, `playwright`
-
-### Upgrading from v1 to v2
-
-```bash
-ai-factory upgrade
-```
-
-`ai-factory upgrade` removes old bare-named skills (`commit`, `feature`, etc.) and installs new `aif-*` prefixed versions. Custom skills are preserved.
-
-> **Note:** `ai-factory update` automatically checks npm for a newer CLI version and offers to install it before updating skills, then reports `changed/unchanged/skipped/removed` for installed base skills. Use `ai-factory update --force` for a clean reinstall of currently installed base skills.
-
-### Example Workflow
+## Example Workflow
 
 ```bash
 # Explore options and requirements before planning (optional)
@@ -144,20 +106,6 @@ ai-factory upgrade
 
 See the full [Development Workflow](docs/workflow.md) with diagram and decision table.
 
-### Auto-Generated Documentation
-
-AI Factory can generate and maintain your project docs with a single command:
-
-```bash
-/aif-docs          # Creates README + docs/ structure from your codebase
-/aif-docs --web    # Also generates a static HTML documentation site
-```
-
-- **Generates docs from scratch** — analyzes your codebase and creates a lean README + detailed `docs/` pages by topic
-- **Cleans up scattered files** — finds loose CONTRIBUTING.md, ARCHITECTURE.md, SETUP.md in your root and consolidates them into a structured `docs/` directory
-- **Keeps docs in sync** — integrates with `/aif-implement` docs policy (`Docs: yes` = mandatory docs checkpoint routed to `/aif-docs`, `Docs: no` = visible `WARN [docs]`)
-- **Builds a docs website** — `--web` generates a static HTML site with navigation and dark mode, ready to host
-
 ---
 
 ## Documentation
@@ -176,22 +124,9 @@ AI Factory can generate and maintain your project docs with a single command:
 | [Configuration](docs/configuration.md) | `.ai-factory.json`, MCP servers, project structure, best practices |
 | [Config Reference](docs/config-reference.md) | Full `config.yaml` key reference and skill read/write matrix |
 
----
-
-![happy](https://github.com/ilhm344/ai-factory/blob/2.x/art/aif2.jpg)
-
-## AIF Handoff
-
-Looking for an **Autonomous Kanban board where AI agents plan, implement, and review your tasks**? Check out [aif-handoff](https://github.com/lee-to/aif-handoff) — a visual task management system built on top of AI Factory.
-
-![ui-light](https://github.com/lee-to/aif-handoff/blob/main/art/ui-light.png)
-![ui-dark](https://github.com/lee-to/aif-handoff/blob/main/art/ui-dark.png)
-![ui-light-list](https://github.com/lee-to/aif-handoff/blob/main/art/ui-light-list.png)
-![ui-dark-list](https://github.com/lee-to/aif-handoff/blob/main/art/ui-dark-list.png)
-
 ## Links
-
 - [Official Website](https://aif.cutcode.dev) - AI Factory website
+- [aif-handoff](https://github.com/lee-to/aif-handoff) - Autonomous Kanban board built on AI Factory
 - If AI Factory feels too simple for your goals, try [HLV](https://github.com/lee-to/hlv)
 - [skills.sh](https://skills.sh) - Skill marketplace
 - [Agent Skills Spec](https://agentskills.io) - Skill specification

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -212,24 +212,57 @@ AI Factory can configure these MCP servers:
 | Chrome Devtools | Browser inspection, debugging, performance | - |
 | Playwright | Browser automation, web testing | - |
 
-Configuration saved to agent's settings file (e.g. `.mcp.json` for Claude Code, `.cursor/mcp.json` for Cursor, `.vscode/mcp.json` for GitHub Copilot, `.roo/mcp.json` for Roo Code, `.kilocode/mcp.json` for Kilo Code, `opencode.json` for OpenCode). GitHub Copilot uses `servers` as the root object in `mcp.json`; other standard agents use `mcpServers` (OpenCode uses `mcp`).
+Configuration saved to agent's settings file (e.g. `.mcp.json` for Claude Code, `.cursor/mcp.json` for Cursor, `.vscode/mcp.json` for GitHub Copilot, `.roo/mcp.json` for Roo Code, `.kilocode/mcp.json` for Kilo Code, `opencode.json` for OpenCode).
+
+### Runtime Format Matrix
+
+| Runtime | Root key | Entry shape |
+|---------|----------|-------------|
+| Standard MCP runtimes (Claude Code, Cursor, Roo Code, Kilo Code, Qwen Code) | `mcpServers` | `{ "command": "...", "args": [...], "env": {...} }` |
+| OpenCode | `mcp` | `{ "type": "local", "command": ["...", "..."], "environment": {...} }` |
+| GitHub Copilot | `servers` | `{ "type": "stdio", "command": "...", "args": [...], "env": {...} }` |
 
 ### Environment Variables
 
-MCP configs use `${VAR}` placeholders for credentials (GitHub Copilot receives `${env:VAR}` in `.vscode/mcp.json`). Set them before launching the agent:
+MCP configs use `${VAR}` placeholders for credentials. OpenCode stores credentials under `environment`, while GitHub Copilot receives `${env:VAR}` in `.vscode/mcp.json`. Set them before launching the agent:
 
 ```bash
 export GITHUB_TOKEN="ghp_your_token"
 export DATABASE_URL="postgresql://user:pass@localhost:5432/db"
 ```
 
-Or replace the placeholders with actual values directly in the config file:
+Examples by runtime:
 
 ```json
 {
   "mcpServers": {
     "github": {
       "env": { "GITHUB_TOKEN": "ghp_your_token" }
+    }
+  }
+}
+```
+
+```json
+{
+  "mcp": {
+    "github": {
+      "type": "local",
+      "command": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "environment": { "GITHUB_TOKEN": "${GITHUB_TOKEN}" }
+    }
+  }
+}
+```
+
+```json
+{
+  "servers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "${env:GITHUB_TOKEN}" }
     }
   }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,13 +214,15 @@ AI Factory can configure these MCP servers:
 
 Configuration saved to agent's settings file (e.g. `.mcp.json` for Claude Code, `.cursor/mcp.json` for Cursor, `.vscode/mcp.json` for GitHub Copilot, `.roo/mcp.json` for Roo Code, `.kilocode/mcp.json` for Kilo Code, `opencode.json` for OpenCode).
 
-### Runtime Format Matrix
+### Runtime Format Contract
 
-| Runtime | Root key | Entry shape |
-|---------|----------|-------------|
-| Standard MCP runtimes (Claude Code, Cursor, Roo Code, Kilo Code, Qwen Code) | `mcpServers` | `{ "command": "...", "args": [...], "env": {...} }` |
-| OpenCode | `mcp` | `{ "type": "local", "command": ["...", "..."], "environment": {...} }` |
-| GitHub Copilot | `servers` | `{ "type": "stdio", "command": "...", "args": [...], "env": {...} }` |
+Source of truth for runtime MCP shapes and wrapper examples:
+[`skills/aif/SKILL.md#MCP Configuration`](../skills/aif/SKILL.md#mcp-configuration)
+
+Quick key mapping:
+- Standard MCP runtimes use `mcpServers.<server>`
+- OpenCode uses `mcp.<server>`
+- GitHub Copilot uses `servers.<server>`
 
 ### Environment Variables
 
@@ -231,42 +233,7 @@ export GITHUB_TOKEN="ghp_your_token"
 export DATABASE_URL="postgresql://user:pass@localhost:5432/db"
 ```
 
-Examples by runtime:
-
-```json
-{
-  "mcpServers": {
-    "github": {
-      "env": { "GITHUB_TOKEN": "ghp_your_token" }
-    }
-  }
-}
-```
-
-```json
-{
-  "mcp": {
-    "github": {
-      "type": "local",
-      "command": ["npx", "-y", "@modelcontextprotocol/server-github"],
-      "environment": { "GITHUB_TOKEN": "${GITHUB_TOKEN}" }
-    }
-  }
-}
-```
-
-```json
-{
-  "servers": {
-    "github": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
-      "env": { "GITHUB_TOKEN": "${env:GITHUB_TOKEN}" }
-    }
-  }
-}
-```
+Runtime-specific wrapper examples are intentionally centralized in the `/aif` skill section above to avoid docs drift.
 
 ## Project Structure
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,13 +98,31 @@ ai-factory extension update my-extension --force
 ai-factory extension remove my-extension
 ```
 
-For v1 -> v2 migration, run `ai-factory upgrade` to rename old skills to the new `aif-*` prefix.
+### `ai-factory init` Flags
+
+- `--agents` - Comma-separated target agents (for example `claude,codex`)
+- `--skills` - Comma-separated skill set to install instead of full defaults
+- `--no-skills` - Skip base skill installation (useful when only MCP setup is needed)
+- `--mcp` - Comma-separated MCP servers to configure (`github`, `postgres`, `filesystem`, `chrome-devtools`, `playwright`)
+
+### Upgrade from v1 to v2
+
+Run `ai-factory upgrade` to migrate old bare-named skills (`commit`, `feature`, etc.) to `aif-*` names. Custom skills are preserved.
 
 `ai-factory update` now:
 - Checks for extension updates from their sources (npm, GitHub, etc.) before updating base skills
 - Prints per-agent status buckets for base skills (`changed`, `unchanged`, `skipped`, `removed`)
 - For runtimes with managed agent files, also refreshes bundled package-managed agent files (Claude today) and prints a separate `Agent files` status block
 - Skills newly available in the package but not previously installed are shown as `skipped` (not auto-installed)
+
+### Documentation Commands
+
+```bash
+/aif-docs
+/aif-docs --web
+```
+
+`/aif-docs` refreshes README + `docs/` from the current project context. `--web` additionally emits a static documentation site (`docs-html/`).
 
 ## Next Steps
 

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "bash scripts/test-skills.sh",
-    "test:init": "bash scripts/test-init.sh",
-    "test:update": "bash scripts/test-update.sh",
+    "test": "node scripts/run-bash-test.mjs scripts/test-skills.sh",
+    "test:init": "node scripts/run-bash-test.mjs scripts/test-init.sh",
+    "test:update": "node scripts/run-bash-test.mjs scripts/test-update.sh",
     "lint:unused": "tsc --noEmit --noUnusedLocals --noUnusedParameters",
     "lint:dead": "knip --reporter compact",
     "lint": "npm run lint:unused && npm run lint:dead",

--- a/scripts/run-bash-test.mjs
+++ b/scripts/run-bash-test.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+const [scriptArg, ...scriptArgs] = process.argv.slice(2);
+const debug = process.env.AIF_TEST_RUNNER_DEBUG === '1';
+
+if (!scriptArg) {
+  console.error('Usage: node scripts/run-bash-test.mjs <script> [args...]');
+  process.exit(2);
+}
+
+const scriptPath = path.resolve(repoRoot, scriptArg);
+if (!fs.existsSync(scriptPath)) {
+  console.error(`Test script not found: ${scriptArg}`);
+  process.exit(2);
+}
+
+function pathExists(candidate) {
+  return candidate ? fs.existsSync(candidate) : false;
+}
+
+function isWslLauncher(candidate) {
+  if (process.platform !== 'win32') {
+    return false;
+  }
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+  return path.resolve(candidate).toLowerCase() === path.join(systemRoot, 'System32', 'bash.exe').toLowerCase();
+}
+
+function findOnPath(binary) {
+  return (process.env.PATH || '')
+    .split(path.delimiter)
+    .filter(Boolean)
+    .map(entry => path.join(entry, binary))
+    .filter(pathExists);
+}
+
+function findBash() {
+  if (process.env.AIF_BASH) {
+    return process.env.AIF_BASH;
+  }
+
+  if (process.platform !== 'win32') {
+    return 'bash';
+  }
+
+  const gitBashCandidates = [
+    'C:\\Program Files\\Git\\bin\\bash.exe',
+    'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
+    process.env.LOCALAPPDATA && path.join(process.env.LOCALAPPDATA, 'Programs', 'Git', 'bin', 'bash.exe'),
+    process.env.LOCALAPPDATA && path.join(process.env.LOCALAPPDATA, 'Programs', 'Git', 'usr', 'bin', 'bash.exe'),
+  ].filter(Boolean);
+
+  const pathCandidates = findOnPath('bash.exe');
+  const candidates = [
+    ...gitBashCandidates,
+    ...pathCandidates.filter(candidate => candidate.toLowerCase().includes(`${path.sep}git${path.sep}`)),
+    ...pathCandidates.filter(candidate => !isWslLauncher(candidate)),
+    ...pathCandidates,
+  ];
+
+  return candidates.find(pathExists) || 'bash';
+}
+
+function toBashPath(targetPath, bashPath) {
+  if (process.platform !== 'win32') {
+    return targetPath;
+  }
+
+  if (isWslLauncher(bashPath)) {
+    const drivePath = targetPath.match(/^([A-Za-z]):\\(.*)$/);
+    if (drivePath) {
+      return `/mnt/${drivePath[1].toLowerCase()}/${drivePath[2].replace(/\\/g, '/')}`;
+    }
+  }
+
+  return targetPath.replace(/\\/g, '/');
+}
+
+const bash = findBash();
+const bashScriptPath = toBashPath(scriptPath, bash);
+
+if (debug) {
+  console.error(`[FIX:test-runner] Using bash: ${bash}`);
+  console.error(`[FIX:test-runner] Running script: ${bashScriptPath}`);
+}
+
+const child = spawn(bash, [bashScriptPath, ...scriptArgs], {
+  cwd: repoRoot,
+  env: process.env,
+  stdio: 'inherit',
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    console.error(`[FIX:test-runner] ${scriptArg} terminated by ${signal}`);
+    process.exit(1);
+  }
+  process.exit(code ?? 1);
+});
+
+child.on('error', error => {
+  console.error(`[FIX:test-runner] Failed to start bash: ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -502,6 +502,11 @@ AIF_MCP_SECTION=$(awk '
   capture && /^---$/ { exit }
   capture { print }
 ' "$ROOT_DIR/skills/aif/SKILL.md")
+DOCS_MCP_SECTION=$(awk '
+  /^## MCP Configuration$/ { capture=1; next }
+  capture && /^## / { exit }
+  capture { print }
+' "$ROOT_DIR/docs/configuration.md")
 
 if [[ -z "$AIF_MCP_SECTION" ]]; then
     fail "/aif MCP Configuration section missing"
@@ -527,10 +532,34 @@ else
     fail "/aif MCP section missing GitHub Copilot runtime contract"
 fi
 
-if printf '%s\n' "$AIF_MCP_SECTION" | grep -Eiq 'all (supported )?(agents|runtimes).*(mcpServers)|mcpServers.*all (supported )?(agents|runtimes)'; then
+if printf '%s\n' "$AIF_MCP_SECTION" | grep -Eiq '(all|every|any).*(supported )?(agents|runtimes).*(mcpServers)|mcpServers.*(all|every|any).*(supported )?(agents|runtimes)|(works|work).*(across|for).*(agents|runtimes).*(mcpServers)'; then
     fail "/aif MCP section still implies universal mcpServers usage"
 else
     pass "/aif MCP section does not imply universal mcpServers usage"
+fi
+
+if [[ -z "$DOCS_MCP_SECTION" ]]; then
+    fail "docs MCP Configuration section missing"
+else
+    pass "docs MCP Configuration section present"
+fi
+
+if printf '%s\n' "$DOCS_MCP_SECTION" | grep -Fq '../skills/aif/SKILL.md#mcp-configuration' && printf '%s\n' "$DOCS_MCP_SECTION" | grep -Fqi 'source of truth'; then
+    pass "docs MCP section links to canonical /aif MCP source-of-truth"
+else
+    fail "docs MCP section must link to canonical /aif MCP source-of-truth"
+fi
+
+if printf '%s\n' "$DOCS_MCP_SECTION" | grep -Fq 'mcpServers.<server>' && printf '%s\n' "$DOCS_MCP_SECTION" | grep -Fq 'mcp.<server>' && printf '%s\n' "$DOCS_MCP_SECTION" | grep -Fq 'servers.<server>'; then
+    pass "docs MCP section includes runtime key mapping reminders"
+else
+    fail "docs MCP section missing runtime key mapping reminders"
+fi
+
+if printf '%s\n' "$DOCS_MCP_SECTION" | grep -Fq '| Runtime | Root key | Entry shape |'; then
+    fail "docs MCP section reintroduced duplicated runtime matrix table"
+else
+    pass "docs MCP section avoids duplicated runtime matrix table"
 fi
 
 # skills_cli_agent_flag patterns

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -514,25 +514,25 @@ else
     pass "/aif MCP Configuration section present"
 fi
 
-if printf '%s\n' "$AIF_MCP_SECTION" | grep -Fq "depends on the runtime"; then
+if grep -Fq "depends on the runtime" <<< "$AIF_MCP_SECTION"; then
     pass "/aif MCP section states that MCP shape depends on runtime"
 else
     fail "/aif MCP section does not state runtime-dependent MCP shape"
 fi
 
-if printf '%s\n' "$AIF_MCP_SECTION" | grep -Fq "OpenCode" && printf '%s\n' "$AIF_MCP_SECTION" | grep -Fq 'mcp.<server>' && printf '%s\n' "$AIF_MCP_SECTION" | grep -Fq '"type": "local"'; then
+if grep -Fq "OpenCode" <<< "$AIF_MCP_SECTION" && grep -Fq 'mcp.<server>' <<< "$AIF_MCP_SECTION" && grep -Fq '"type": "local"' <<< "$AIF_MCP_SECTION"; then
     pass "/aif MCP section includes OpenCode runtime contract"
 else
     fail "/aif MCP section missing OpenCode runtime contract"
 fi
 
-if printf '%s\n' "$AIF_MCP_SECTION" | grep -Fq "GitHub Copilot" && printf '%s\n' "$AIF_MCP_SECTION" | grep -Fq 'servers.<server>' && printf '%s\n' "$AIF_MCP_SECTION" | grep -Fq '"type": "stdio"'; then
+if grep -Fq "GitHub Copilot" <<< "$AIF_MCP_SECTION" && grep -Fq 'servers.<server>' <<< "$AIF_MCP_SECTION" && grep -Fq '"type": "stdio"' <<< "$AIF_MCP_SECTION"; then
     pass "/aif MCP section includes GitHub Copilot runtime contract"
 else
     fail "/aif MCP section missing GitHub Copilot runtime contract"
 fi
 
-if printf '%s\n' "$AIF_MCP_SECTION" | grep -Eiq '(all|every|any).*(supported )?(agents|runtimes).*(mcpServers)|mcpServers.*(all|every|any).*(supported )?(agents|runtimes)|(works|work).*(across|for).*(agents|runtimes).*(mcpServers)'; then
+if grep -Eiq '(all|every|any).*(supported )?(agents|runtimes).*(mcpServers)|mcpServers.*(all|every|any).*(supported )?(agents|runtimes)|(works|work).*(across|for).*(agents|runtimes).*(mcpServers)' <<< "$AIF_MCP_SECTION"; then
     fail "/aif MCP section still implies universal mcpServers usage"
 else
     pass "/aif MCP section does not imply universal mcpServers usage"
@@ -544,19 +544,19 @@ else
     pass "docs MCP Configuration section present"
 fi
 
-if printf '%s\n' "$DOCS_MCP_SECTION" | grep -Fq '../skills/aif/SKILL.md#mcp-configuration' && printf '%s\n' "$DOCS_MCP_SECTION" | grep -Fqi 'source of truth'; then
+if grep -Fq '../skills/aif/SKILL.md#mcp-configuration' <<< "$DOCS_MCP_SECTION" && grep -Fq 'Source of truth' <<< "$DOCS_MCP_SECTION"; then
     pass "docs MCP section links to canonical /aif MCP source-of-truth"
 else
     fail "docs MCP section must link to canonical /aif MCP source-of-truth"
 fi
 
-if printf '%s\n' "$DOCS_MCP_SECTION" | grep -Fq 'mcpServers.<server>' && printf '%s\n' "$DOCS_MCP_SECTION" | grep -Fq 'mcp.<server>' && printf '%s\n' "$DOCS_MCP_SECTION" | grep -Fq 'servers.<server>'; then
+if grep -Fq 'mcpServers.<server>' <<< "$DOCS_MCP_SECTION" && grep -Fq 'mcp.<server>' <<< "$DOCS_MCP_SECTION" && grep -Fq 'servers.<server>' <<< "$DOCS_MCP_SECTION"; then
     pass "docs MCP section includes runtime key mapping reminders"
 else
     fail "docs MCP section missing runtime key mapping reminders"
 fi
 
-if printf '%s\n' "$DOCS_MCP_SECTION" | grep -Fq '| Runtime | Root key | Entry shape |'; then
+if grep -Fq '| Runtime | Root key | Entry shape |' <<< "$DOCS_MCP_SECTION"; then
     fail "docs MCP section reintroduced duplicated runtime matrix table"
 else
     pass "docs MCP section avoids duplicated runtime matrix table"

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -488,12 +488,49 @@ else
 fi
 
 # settings_file patterns
-HARDCODED_SETTINGS=$(grep -rE '(\.mcp\.json|settings\.local\.json|\.cursor/mcp\.json|\.vscode/mcp\.json|\.qwen/settings\.json)' "$ROOT_DIR/skills/" "$ROOT_DIR/subagents/" --include='*.md' 2>/dev/null | grep -v '{{' | wc -l | tr -d ' ' || true)
+HARDCODED_SETTINGS=$(grep -rE '(opencode\.json|\.mcp\.json|settings\.local\.json|\.cursor/mcp\.json|\.vscode/mcp\.json|\.roo/mcp\.json|\.kilocode/mcp\.json|\.qwen/settings\.json)' "$ROOT_DIR/skills/" "$ROOT_DIR/subagents/" --include='*.md' 2>/dev/null | grep -v '{{' | wc -l | tr -d ' ' || true)
 if [[ "$HARDCODED_SETTINGS" -eq 0 ]]; then
     pass "no hardcoded settings_file in skills/ and subagents/"
 else
     fail "found $HARDCODED_SETTINGS hardcoded settings_file values (use {{settings_file}})"
-    grep -rEn '(\.mcp\.json|settings\.local\.json|\.cursor/mcp\.json|\.vscode/mcp\.json|\.qwen/settings\.json)' "$ROOT_DIR/skills/" "$ROOT_DIR/subagents/" --include='*.md' 2>/dev/null | grep -v '{{' | sed 's/^/      /'
+    grep -rEn '(opencode\.json|\.mcp\.json|settings\.local\.json|\.cursor/mcp\.json|\.vscode/mcp\.json|\.roo/mcp\.json|\.kilocode/mcp\.json|\.qwen/settings\.json)' "$ROOT_DIR/skills/" "$ROOT_DIR/subagents/" --include='*.md' 2>/dev/null | grep -v '{{' | sed 's/^/      /'
+fi
+
+# /aif MCP runtime-contract wording
+AIF_MCP_SECTION=$(awk '
+  /^## MCP Configuration$/ { capture=1; next }
+  capture && /^---$/ { exit }
+  capture { print }
+' "$ROOT_DIR/skills/aif/SKILL.md")
+
+if [[ -z "$AIF_MCP_SECTION" ]]; then
+    fail "/aif MCP Configuration section missing"
+else
+    pass "/aif MCP Configuration section present"
+fi
+
+if printf '%s\n' "$AIF_MCP_SECTION" | grep -Fq "depends on the runtime"; then
+    pass "/aif MCP section states that MCP shape depends on runtime"
+else
+    fail "/aif MCP section does not state runtime-dependent MCP shape"
+fi
+
+if printf '%s\n' "$AIF_MCP_SECTION" | grep -Fq "OpenCode" && printf '%s\n' "$AIF_MCP_SECTION" | grep -Fq 'mcp.<server>' && printf '%s\n' "$AIF_MCP_SECTION" | grep -Fq '"type": "local"'; then
+    pass "/aif MCP section includes OpenCode runtime contract"
+else
+    fail "/aif MCP section missing OpenCode runtime contract"
+fi
+
+if printf '%s\n' "$AIF_MCP_SECTION" | grep -Fq "GitHub Copilot" && printf '%s\n' "$AIF_MCP_SECTION" | grep -Fq 'servers.<server>' && printf '%s\n' "$AIF_MCP_SECTION" | grep -Fq '"type": "stdio"'; then
+    pass "/aif MCP section includes GitHub Copilot runtime contract"
+else
+    fail "/aif MCP section missing GitHub Copilot runtime contract"
+fi
+
+if printf '%s\n' "$AIF_MCP_SECTION" | grep -Eiq 'all (supported )?(agents|runtimes).*(mcpServers)|mcpServers.*all (supported )?(agents|runtimes)'; then
+    fail "/aif MCP section still implies universal mcpServers usage"
+else
+    pass "/aif MCP section does not imply universal mcpServers usage"
 fi
 
 # skills_cli_agent_flag patterns

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -500,7 +500,21 @@ Install skills, configure MCP, generate `AGENTS.md` in resolved `language.artifa
 
 ## MCP Configuration
 
-### GitHub
+AI Factory writes MCP config to `{{settings_file}}`, but the outer settings shape depends on the runtime.
+
+### Runtime Format Matrix
+
+| Runtime | Write under | Entry shape |
+|---------|-------------|-------------|
+| Standard MCP runtimes (Claude Code, Cursor, Roo Code, Kilo Code, Qwen Code) | `mcpServers.<server>` | `{ "command": "...", "args": [...], "env": {...} }` |
+| OpenCode | `mcp.<server>` | `{ "type": "local", "command": ["...", "..."], "environment": {...} }` |
+| GitHub Copilot | `servers.<server>` | `{ "type": "stdio", "command": "...", "args": [...], "env": {...} }` |
+
+Use the canonical server templates below as the source values, then wrap them using the runtime-specific format above.
+
+### Canonical Server Templates
+
+#### GitHub
 **When:** Project has `.git` or uses GitHub
 
 ```json
@@ -513,7 +527,7 @@ Install skills, configure MCP, generate `AGENTS.md` in resolved `language.artifa
 }
 ```
 
-### Postgres
+#### Postgres
 **When:** Uses PostgreSQL, Prisma, Drizzle, Supabase
 
 ```json
@@ -526,7 +540,7 @@ Install skills, configure MCP, generate `AGENTS.md` in resolved `language.artifa
 }
 ```
 
-### Filesystem
+#### Filesystem
 **When:** Needs advanced file operations
 
 ```json
@@ -538,7 +552,7 @@ Install skills, configure MCP, generate `AGENTS.md` in resolved `language.artifa
 }
 ```
 
-### Playwright
+#### Playwright
 **When:** Needs browser automation, web testing, interaction via accessibility tree
 
 ```json
@@ -549,6 +563,50 @@ Install skills, configure MCP, generate `AGENTS.md` in resolved `language.artifa
   }
 }
 ```
+
+### Runtime-Specific Wrapper Examples
+
+Standard MCP runtimes (`mcpServers`):
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    }
+  }
+}
+```
+
+OpenCode (`mcp` + `type: "local"` + command array):
+
+```json
+{
+  "mcp": {
+    "filesystem": {
+      "type": "local",
+      "command": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "."]
+    }
+  }
+}
+```
+
+GitHub Copilot (`servers` + `type: "stdio"`):
+
+```json
+{
+  "servers": {
+    "filesystem": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    }
+  }
+}
+```
+
+For GitHub Copilot, convert credential placeholders from `${VAR}` to `${env:VAR}` in the final config file. For OpenCode, use `environment` instead of `env` when the server requires credentials.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #91 by aligning `/aif` MCP instructions with the runtime-specific MCP formats already supported by the CLI.

## What changed

- updated `skills/aif/SKILL.md` so MCP guidance is runtime-aware instead of implying universal `mcpServers`
- added explicit wrapper examples for:
  - standard MCP runtimes: `mcpServers`
  - OpenCode: `mcp` + `type: "local"` + command array
  - GitHub Copilot: `servers` + `type: "stdio"`
- synced `docs/configuration.md` with the same runtime matrix and env placeholder rules
- added deterministic `/aif` MCP wording checks to `scripts/test-skills.sh`
- refreshed `README.md` and `AGENTS.md` so the docs structure stays in sync with the current docs set and README remains a landing page

## Verification

- `cmd /c npm test`
  - the new MCP wording checks pass
  - the full suite still hits the pre-existing Windows + bash `node: command not found` issue outside this change
- `git diff --check`

## Notes

- no `src/core/mcp.ts` behavior changes were needed; the runtime serializer was already correct
- this change focuses on instruction/docs/test-contract drift, not MCP runtime logic
