### PR TITLE
feat(aif-implement): add --without-plan inline mode + ai-tester scenarios

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -125,13 +125,23 @@ Executes the plan:
 /aif-implement @my-custom-plan.md # Execute using an explicit plan file
 /aif-implement 5      # Start from task #5
 /aif-implement status # Check progress
+/aif-implement --without-plan add GET /healthz returning {"status":"ok"} # Inline one-shot task, no plan file
 ```
 - **Reads skill-context first** (`.ai-factory/skill-context/aif-implement/SKILL.md`) and only uses limited recent patch fallback when needed
 - Finds plan file (`@plan-file` if provided; otherwise branch-based `paths.plans/<branch>.md`, then a single named full plan in `paths.plans`, then `paths.plan`, then `paths.fix_plan` → redirects to `/aif-fix`)
 - `--list` mode is read-only: shows available plan files and exits
+- `--without-plan <description>` mode (inline):
+  - Executes exactly one small task from the description — no plan file created, read, or updated
+  - Mutually exclusive with `@plan-file`, `status`, and task id
+  - Skips `TaskList` / checkbox updates, does **not** create `FIX_PLAN.md` or `paths.patches` entries (use `/aif-fix` for bugs, not this flag)
+  - Loads the same project context as regular mode (config, `DESCRIPTION.md`, `ARCHITECTURE.md`, rules, skill-context)
+  - Tests are written only if the description explicitly asks for them
+  - Redirects to `/aif-plan fast <description>` when the description looks too broad for a one-shot task
+  - Optional `--docs=yes|no|warn` (default: `warn`) — `yes` runs the docs checkpoint via `/aif-docs`, `no` silences the warn line, `warn` emits `WARN [docs]` only
+  - Supports Handoff via `HANDOFF_TASK_ID` env var with a synthetic `- [ ] <description>` plan pushed through `handoff_push_plan`; when `HANDOFF_TASK_ID` is unset, MCP sync is skipped entirely
 - Executes tasks one by one
 - Prompts for commits at checkpoints
-- Docs policy after completion:
+- Docs policy after completion (plan-backed modes):
   - `Docs: yes` → mandatory documentation checkpoint (update docs / create feature page / skip)
   - `Docs: no` or unset → `WARN [docs]` only (no mandatory checkpoint)
   - Docs updates are always routed through `/aif-docs`

--- a/skills/aif-implement/SKILL.md
+++ b/skills/aif-implement/SKILL.md
@@ -187,7 +187,7 @@ If `HANDOFF_TASK_ID` is missing → skip all MCP sync for this run.
 **Docs policy (inline mode, driven by `--docs`):**
 
 - `--docs=yes` → after completion, show the docs checkpoint (same AskUserQuestion as `Docs: yes` in regular mode) and route changes through `/aif-docs`.
-- `--docs=no` → skip the checkpoint, emit `WARN [docs] --docs=no in inline mode; skipping documentation checkpoint`.
+- `--docs=no` → suppress the documentation checkpoint, emit `WARN [docs] --docs=no in inline mode; documentation checkpoint skipped`.
 - `--docs=warn` (default) → emit `WARN [docs] Inline mode default is warn-only; documentation checkpoint skipped. Pass --docs=yes to enable.`
 
 **Context maintenance in inline mode:**

--- a/skills/aif-implement/SKILL.md
+++ b/skills/aif-implement/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aif-implement
 description: Execute implementation tasks from the current plan. Works through tasks sequentially, marks completion, and preserves progress for continuation across sessions. Use when user says "implement", "start coding", "execute plan", or "continue implementation".
-argument-hint: '[--list] [@plan-file] [task-id or "status"]'
+argument-hint: '[--list] [--without-plan <description>] [@plan-file] [task-id or "status"]'
 allowed-tools: Read Write Edit Glob Grep Bash TaskList TaskGet TaskUpdate AskUserQuestion Questions mcp__handoff__handoff_sync_status mcp__handoff__handoff_push_plan mcp__handoff__handoff_get_task mcp__handoff__handoff_list_tasks mcp__handoff__handoff_update_task
 disable-model-invocation: false
 ---
@@ -54,9 +54,11 @@ Handoff sync is handled inline — see **Step 0.2** (after reading the plan file
    - `rules.base` plus any named `rules.<area>` entries
 2. Parse arguments:
    - --list → list available plans only (no implementation; STOP)
+   - --without-plan <description> → inline implementation mode; skip plan discovery and jump to Step 0.inline
    - @<path> → explicit plan file override (highest priority)
    - <number> → start from specific task
    - status → status-only mode
+   - Optional inline-mode flag: --docs=yes|no|warn (only valid with --without-plan; default: warn)
 3. If `git.enabled = true`, check for uncommitted changes (`git status`)
 4. If `git.enabled = true`, check current branch
 ```
@@ -87,6 +89,142 @@ If `$ARGUMENTS` contains `--list`, run read-only plan discovery and stop.
 For detailed output format and examples, see:
 
 - `skills/aif-implement/references/IMPLEMENTATION-GUIDE.md` → "List Available Plans (`--list`)"
+
+### Step 0.inline: Inline Implementation Mode (`--without-plan`)
+
+If `$ARGUMENTS` contains `--without-plan`, execute a single scoped task from the description WITHOUT creating or reading any plan file. This is the lightweight path for small `feat`/`chore` tasks that do not justify a full plan but are not bug fixes either (use `/aif-fix` for bugs).
+
+**Argument parsing:**
+
+```
+1. description = everything after `--without-plan`, excluding any recognized flag tokens (`--docs=...`).
+2. docs_policy = value of `--docs=yes|no|warn` if present, else `warn` (default).
+3. Validation:
+   - description is empty →
+     ERROR: "Usage: /aif-implement --without-plan <description> [--docs=yes|no|warn]"
+     → STOP
+   - arguments also contain `@<path>`, `status`, or a bare task id number →
+     ERROR: "`--without-plan` is mutually exclusive with @plan-file, status, and task id."
+     → STOP
+   - `--docs=<value>` where <value> not in {yes, no, warn} →
+     ERROR: "Invalid --docs value. Expected yes|no|warn."
+     → STOP
+```
+
+**Scope guard (prevent silent mega-tasks):**
+
+Before executing, assess the description. If it looks too broad for a one-shot inline task — multiple unrelated imperatives joined by "and"/"и", references to multiple subsystems, or roughly more than ~300 characters of scope — do NOT attempt to guess a plan. Instead print:
+
+```
+Description looks too broad for inline implementation. Recommended:
+  /aif-plan fast <description>
+```
+
+→ STOP.
+
+Small, focused descriptions (e.g. "add GET /healthz returning 200 with {status:\"ok\"}") proceed.
+
+**Surprise-warn on existing plan artifacts (non-blocking):**
+
+Inline mode ignores plan files by design. If any of these exist on disk, emit a `WARN [inline]` line so the user notices the intentional skip (do NOT read them, do NOT redirect):
+
+- `<configured plans dir>/<branch>.md` (git mode only)
+- resolved fast plan path (`paths.plan`)
+- resolved fix plan path (`paths.fix_plan`)
+
+Example: `WARN [inline] paths.plan exists but is ignored in --without-plan mode.`
+
+**Load project context (same as regular implement):**
+
+Use the resolved config from Step 0:
+
+- `paths.description` (DESCRIPTION.md) if present
+- `paths.architecture` (ARCHITECTURE.md) if present
+- `paths.rules_file` (RULES.md) + `rules.base` + named `rules.<area>` entries
+- `.ai-factory/skill-context/aif-implement/SKILL.md` — MANDATORY if the file exists (same precedence and enforcement as regular mode in Step 0.1)
+- `language.ui`, `language.artifacts`
+
+Skip: plan file discovery, fix-plan discovery, resume/recovery reconciliation, TaskList loading, checkbox state comparison.
+
+**Execute the task (one-shot):**
+
+1. Announce: `Inline implementation: <description>`
+2. Read only files relevant to the described scope
+3. Apply changes following existing code patterns and skill-context rules
+4. Apply verbose logging per `references/LOGGING-GUIDE.md`
+5. Write tests ONLY if the description explicitly says so (e.g. "with tests", "add tests for X")
+6. Verify the change compiles/runs and the described behavior works
+
+**Prohibited in inline mode:**
+
+- Do NOT create or read `paths.plan` / `paths.plans/*` / `paths.fix_plan`.
+- Do NOT invoke `/aif-plan` or `/aif-fix`.
+- Do NOT create entries under `paths.patches` (no `[FIX]` self-improvement patch — this is not a bugfix flow).
+- Do NOT call `TaskList` / `TaskGet` / `TaskUpdate` (no plan = no persisted tasks).
+- Do NOT search for or modify plan checkboxes on disk.
+- Do NOT trigger the roadmap milestone completion check, docs checkpoint-from-plan-setting, plan-file cleanup prompt, or worktree merge prompt (those belong to the plan-backed workflow).
+
+**Handoff inline support (manual mode only):**
+
+If the `HANDOFF_TASK_ID` env var is set AND `HANDOFF_MODE` is NOT `1`:
+
+1. Build synthetic plan content:
+
+   ```markdown
+   # Inline implementation
+   - [ ] <description>
+   ```
+
+2. Call `handoff_sync_status` with `{ taskId: <HANDOFF_TASK_ID>, newStatus: "implementing", sourceTimestamp: "<current UTC ISO 8601>", direction: "aif_to_handoff", paused: true }`.
+3. Call `handoff_push_plan` with `{ taskId: <HANDOFF_TASK_ID>, planContent: <synthetic content above> }`.
+4. After successful execution, flip the checkbox to `- [x]` in the synthetic content and call `handoff_push_plan` again with the updated text.
+5. Finalize sync:
+   - If `HANDOFF_SKIP_REVIEW` is `1` → `handoff_sync_status` → `"done"` with `paused: false`.
+   - Otherwise → `handoff_sync_status` → `"review"` with `paused: true`.
+
+If `HANDOFF_TASK_ID` is missing → skip all MCP sync for this run.
+
+**Docs policy (inline mode, driven by `--docs`):**
+
+- `--docs=yes` → after completion, show the docs checkpoint (same AskUserQuestion as `Docs: yes` in regular mode) and route changes through `/aif-docs`.
+- `--docs=no` → skip the checkpoint, emit `WARN [docs] --docs=no in inline mode; skipping documentation checkpoint`.
+- `--docs=warn` (default) → emit `WARN [docs] Inline mode default is warn-only; documentation checkpoint skipped. Pass --docs=yes to enable.`
+
+**Context maintenance in inline mode:**
+
+- Resolved description artifact updates: allowed, same rules as regular mode (only factual deltas for new deps/integrations).
+- Resolved architecture artifact + `AGENTS.md`: allowed only if new modules/folders were actually created.
+- Resolved roadmap artifact: NOT updated in inline mode (no milestone linkage available without a plan).
+- Resolved rules file: NOT edited in inline mode (same as regular).
+
+**Completion output (inline mode):**
+
+```
+## Inline Implementation Complete
+
+Task: <description>
+
+Files modified:
+- <file> (created|modified)
+Documentation: <outcome per --docs>
+
+What's next?
+
+1. 🔍 /aif-verify — Verify the change (recommended)
+2. 💾 /aif-commit — Commit directly
+```
+
+Then offer:
+
+```
+AskUserQuestion: Inline task complete. What's next?
+
+Options:
+1. Verify first — Run /aif-verify (recommended)
+2. Skip to commit — Go straight to /aif-commit
+```
+
+→ **STOP** after the chosen follow-up completes. No summary document, no report file.
 
 ### Step 0.0: Resume / Recovery (after a break or after /clear)
 
@@ -740,6 +878,15 @@ Lists the resolved fast plan path, resolved fix plan path, and current-branch `<
 ```
 
 Uses the provided plan file instead of auto-detecting by branch/default files.
+
+### Inline Implementation (No Plan)
+
+```
+/aif-implement --without-plan add GET /healthz endpoint returning {"status":"ok"}
+/aif-implement --without-plan rename LogLevel.VERBOSE to LogLevel.TRACE --docs=yes
+```
+
+One-shot execution of a small task without any plan file. Mutually exclusive with `@plan-file`, `status`, and task id. Does not create `FIX_PLAN.md` or patches. Default docs policy is `warn`; pass `--docs=yes` to run the docs checkpoint, `--docs=no` to silence the warning. See **Step 0.inline** for the full flow.
 
 ### Start from Specific Task
 

--- a/skills/aif-implement/SKILL.md
+++ b/skills/aif-implement/SKILL.md
@@ -144,7 +144,7 @@ Use the resolved config from Step 0:
 - `.ai-factory/skill-context/aif-implement/SKILL.md` — MANDATORY if the file exists (same precedence and enforcement as regular mode in Step 0.1)
 - `language.ui`, `language.artifacts`
 
-Skip: plan file discovery, fix-plan discovery, resume/recovery reconciliation, TaskList loading, checkbox state comparison.
+**Plan artifact policy:** inline mode does NOT load or use plan/fix-plan files. Plan files are never read, parsed, or executed. A minimal existence probe is permitted (see the surprise-warn section above) solely to emit the `WARN [inline]` line — nothing is read from disk. Also skip: resume/recovery reconciliation, TaskList loading, checkbox state comparison.
 
 **Execute the task (one-shot):**
 
@@ -152,7 +152,7 @@ Skip: plan file discovery, fix-plan discovery, resume/recovery reconciliation, T
 2. Read only files relevant to the described scope
 3. Apply changes following existing code patterns and skill-context rules
 4. Apply verbose logging per `references/LOGGING-GUIDE.md`
-5. Write tests ONLY if the description explicitly says so (e.g. "with tests", "add tests for X")
+5. Do not add tests by default. Add them only if the description explicitly requests tests (e.g. "with tests", "add tests for X") OR if existing project conventions / touched code paths clearly require them (e.g. a test file mirrors every source file in the area being changed, or a RULES.md / skill-context rule mandates test coverage for this kind of change). When in doubt, prefer NO tests and let the user follow up via `/aif-plan` if wider test coverage is needed.
 6. Verify the change compiles/runs and the described behavior works
 
 **Prohibited in inline mode:**

--- a/skills/aif-implement/SKILL.md
+++ b/skills/aif-implement/SKILL.md
@@ -166,7 +166,16 @@ Use the resolved config from Step 0:
 
 **Handoff inline support (manual mode only):**
 
-If the `HANDOFF_TASK_ID` env var is set AND `HANDOFF_MODE` is NOT `1`:
+> Naming clarification: `--without-plan` means "without a **local** plan artifact on disk" (no `paths.plan` / `paths.plans/*` / `paths.fix_plan`). When a Handoff task is linked, the task is still represented as a synthetic plan **inside Handoff** via `handoff_push_plan` — that's a remote representation, not a local file. The local-no-plan contract is preserved; only the remote sync surface is unchanged.
+
+**When `HANDOFF_MODE` is `1` (autonomous Handoff agent invoked inline mode):**
+
+- Do NOT call any `mcp__handoff__*` tool (the coordinator manages status/sync directly — same rule as Step 0 (pre)).
+- Do NOT create local plan artifacts (the regular Prohibited list above still applies).
+- Do NOT switch branches, create worktrees, merge worktrees, or otherwise alter the branch/worktree the coordinator set up — inline mode operates on the working tree it was invoked in.
+- Proceed with the one-shot execution; the coordinator marks the task complete after the skill returns.
+
+**When `HANDOFF_MODE` is NOT `1` and `HANDOFF_TASK_ID` is set (manual Claude Code session linked to a Handoff task):**
 
 1. Build synthetic plan content:
 

--- a/skills/aif-implement/tests/fast-plan-creates-file.yaml
+++ b/skills/aif-implement/tests/fast-plan-creates-file.yaml
@@ -1,0 +1,109 @@
+scenario: fast-plan-creates-file
+description: |
+  Default mode (no args) must discover `.ai-factory/PLAN.md` written by
+  `/aif-plan fast`, read it, execute the single task it contains, and flip
+  the checkbox `- [ ]` → `- [x]` per Step 3.6.
+
+  Verifies:
+  (1) the skill Reads the fast plan at `.ai-factory/PLAN.md`;
+  (2) the described file is actually written with the expected content;
+  (3) the skill Edits the plan to mark the task complete.
+skill: aif-implement
+argument: ""
+max_turns: 50
+
+runner:
+  model: claude-sonnet-4-6
+  permission_mode: bypassPermissions
+  allowed_tools_override:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash(git *)
+    - Bash(mkdir *)
+    - Bash(ls *)
+    - Bash(pwd)
+    - Bash(basename *)
+    - Bash(cd *)
+    - Bash(printenv *)
+    - AskUserQuestion
+    - Questions
+    - TaskList
+    - TaskCreate
+    - TaskUpdate
+
+fixtures:
+  git_init: true
+  git_branch: main
+  files_committed:
+    - path: README.md
+      content: |
+        # Demo repo
+
+        Minimal fixture repo for the aif-implement plan-discovery scenario.
+    - path: package.json
+      content: |
+        {
+          "name": "demo",
+          "version": "0.1.0"
+        }
+    - path: .ai-factory/PLAN.md
+      content: |
+        # Feature: hello-world-file
+
+        ## Context
+        - Mode: fast
+        - Tests: no
+        - Logging: no
+        - Docs: no
+
+        ## Tasks
+
+        - [ ] Task 1: Create `test.txt` at the repo root containing exactly the text `Hello world` (no trailing newline)
+
+user_responses:
+  # Completion — docs checkpoint is warn-only because Docs: no, but the skill
+  # still asks whether to delete the fast plan file, then verify/commit.
+  - match_question: "(?i)(delete|remove).*(plan|PLAN\\.md)"
+    choose: "No, keep it"
+  - match_question: "(?i)(verify|commit|what'?s next|next\\??)"
+    choose: "Skip to commit"
+  - match_question: "(?i)(uncommitted|stash|commit.*first)"
+    choose: "No, stash and continue"
+  - match_question: "(?i)(proceed|confirm|ready|start|approve)"
+    choose: "Yes"
+
+assertions:
+  # Positive — plan file was discovered and read.
+  - id: reads-plan-md
+    type: tool_called
+    tool: Read
+    args_match:
+      file_path: "\\.ai-factory/PLAN\\.md$"
+    weight: 2
+
+  # Positive — the task's output file was produced. The skill may legitimately
+  # use either Write or Bash (printf/echo) for a one-line file; ai-tester has
+  # no OR between assertions, so the completion report is the reliable anchor.
+  # Step 5 of aif-implement lists modified files by name in its final message.
+  # (Content integrity isn't asserted here — the completion text lists the
+  # file name, not its bytes; that would require a stronger `Write`-only path.)
+  - id: reports-test-txt-created
+    type: output_contains
+    pattern: "(?i)test\\.txt"
+    weight: 3
+
+  # Positive — the plan's checkbox was flipped to `- [x]` per Step 3.6.
+  - id: updates-plan-checkbox
+    type: tool_called
+    tool: Edit
+    args_match:
+      file_path: "\\.ai-factory/PLAN\\.md$"
+      new_string: "- \\[x\\]"
+    weight: 2
+
+  # Sandbox hygiene — all file-path tool calls stay inside the worktree.
+  - id: stay-in-sandbox
+    type: no_path_escape

--- a/skills/aif-implement/tests/fast-plan-creates-file.yaml
+++ b/skills/aif-implement/tests/fast-plan-creates-file.yaml
@@ -61,7 +61,7 @@ fixtures:
 
         ## Tasks
 
-        - [ ] Task 1: Create `test.txt` at the repo root containing exactly the text `Hello world` (no trailing newline)
+        - [ ] Task 1: Use the `Write` tool to create `test.txt` at the repo root containing exactly the text `Hello world` (no trailing newline). Do not use Bash to echo/printf the file — the test asserts the Write tool call.
 
 user_responses:
   # Completion — docs checkpoint is warn-only because Docs: no, but the skill
@@ -84,16 +84,23 @@ assertions:
       file_path: "\\.ai-factory/PLAN\\.md$"
     weight: 2
 
-  # Positive — the task's output file was produced. The skill may legitimately
-  # use either Write or Bash (printf/echo) for a one-line file; ai-tester has
-  # no OR between assertions, so the completion report is the reliable anchor.
-  # Step 5 of aif-implement lists modified files by name in its final message.
-  # (Content integrity isn't asserted here — the completion text lists the
-  # file name, not its bytes; that would require a stronger `Write`-only path.)
+  # Positive — the task's output file was produced with the EXACT requested
+  # content. The plan task explicitly mandates the Write tool (not Bash) so
+  # the assertion can pin both file path and content bytes.
+  - id: writes-test-txt-with-hello-world
+    type: tool_called
+    tool: Write
+    args_match:
+      file_path: "(^|/)test\\.txt$"
+      content: "Hello world"
+    weight: 3
+
+  # Defense in depth — the completion report mentions the produced file by
+  # name (Step 5 of aif-implement lists modified files in its final message).
   - id: reports-test-txt-created
     type: output_contains
     pattern: "(?i)test\\.txt"
-    weight: 3
+    weight: 1
 
   # Positive — the plan's checkbox was flipped to `- [x]` per Step 3.6.
   - id: updates-plan-checkbox

--- a/skills/aif-implement/tests/without-plan-broad-scope-redirects.yaml
+++ b/skills/aif-implement/tests/without-plan-broad-scope-redirects.yaml
@@ -1,0 +1,96 @@
+scenario: without-plan-broad-scope-redirects
+description: |
+  Inline mode has a scope guard (Step 0.inline → "Scope guard") that redirects
+  broad / multi-subsystem / multi-imperative descriptions to `/aif-plan fast
+  <description>` instead of attempting a one-shot implementation.
+
+  The description here deliberately chains multiple unrelated imperatives
+  across subsystems (auth, billing, analytics dashboards, admin UI, seed data,
+  migrations) and is well above the ~300-char soft budget mentioned in the
+  skill, so the guard should fire.
+
+  Verifies:
+  (1) the skill's output mentions `/aif-plan fast` as the redirect target;
+  (2) no file is created / modified (no Write, no Edit) — the skill stops
+      before executing anything;
+  (3) no plan / fix-plan / patches artifacts are written;
+  (4) the skill does NOT silently fall into full execution.
+skill: aif-implement
+argument: >-
+  --without-plan add JWT-based authentication with refresh tokens and session
+  revocation across the api and web app, introduce a Stripe-backed billing
+  subsystem with subscription plans and usage metering, build a real-time
+  analytics dashboard with websocket streams and historical aggregation,
+  ship a new admin UI for user and feature-flag management, seed the database
+  with realistic demo data, and write the migrations for all the new tables
+  plus a rollout guide
+max_turns: 20
+
+runner:
+  model: claude-sonnet-4-6
+  permission_mode: bypassPermissions
+  allowed_tools_override:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash(git *)
+    - Bash(ls *)
+    - Bash(pwd)
+    - Bash(basename *)
+    - Bash(cd *)
+    - Bash(printenv *)
+    - AskUserQuestion
+    - Questions
+
+fixtures:
+  git_init: true
+  git_branch: main
+  files_committed:
+    - path: README.md
+      content: |
+        # Demo repo
+
+        Minimal fixture repo for the aif-implement inline-mode scope-guard scenario.
+    - path: package.json
+      content: |
+        {
+          "name": "demo",
+          "version": "0.1.0"
+        }
+
+user_responses: []
+
+assertions:
+  # Skill must surface the `/aif-plan fast` redirect (exact text from Step 0.inline).
+  - id: redirects-to-aif-plan-fast
+    type: output_contains
+    pattern: "/aif-plan\\s+fast"
+    weight: 3
+
+  # Skill must signal this is a scope problem (not a silent stop).
+  - id: explains-scope-redirect
+    type: output_contains
+    pattern: "(?i)broad|too\\s+large|scope"
+    weight: 1
+
+  # The skill must not start implementing anything — no Write.
+  - id: no-write-any-file
+    type: no_tool_called
+    tool: Write
+
+  # No Edit either.
+  - id: no-edit-any-file
+    type: no_tool_called
+    tool: Edit
+
+  # No plan / fix-plan / patches artifacts.
+  - id: no-plan-artifacts-written
+    type: no_tool_called
+    tool: Write
+    args_match:
+      file_path: "\\.ai-factory/(PLAN|FIX_PLAN)\\.md$|\\.ai-factory/plans/|\\.ai-factory/patches/"
+
+  - id: stay-in-sandbox
+    type: no_path_escape

--- a/skills/aif-implement/tests/without-plan-conflict-errors.yaml
+++ b/skills/aif-implement/tests/without-plan-conflict-errors.yaml
@@ -1,0 +1,96 @@
+scenario: without-plan-conflict-errors
+description: |
+  Inline mode is mutually exclusive with `@plan-file`, `status`, and numeric
+  task id per Step 0.inline. This scenario passes BOTH `--without-plan ...`
+  AND `@.ai-factory/PLAN.md` and asserts the skill refuses to run.
+
+  Verifies:
+  (1) the skill's output contains the "mutually exclusive" conflict error;
+  (2) the described `test.txt` file is NOT created;
+  (3) the seeded plan file is NOT Read (no plan discovery / loading), since
+      inline mode is supposed to ignore plan artifacts entirely — and the
+      conflict must be caught at argument-parse time, before plan loading;
+  (4) no checkbox flip / Edit on the plan file.
+skill: aif-implement
+argument: '--without-plan create a file named test.txt at the repo root containing exactly the text "Hello world" @.ai-factory/PLAN.md'
+max_turns: 20
+
+runner:
+  model: claude-sonnet-4-6
+  permission_mode: bypassPermissions
+  allowed_tools_override:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash(git *)
+    - Bash(ls *)
+    - Bash(pwd)
+    - Bash(basename *)
+    - Bash(cd *)
+    - Bash(printenv *)
+    - AskUserQuestion
+    - Questions
+
+fixtures:
+  git_init: true
+  git_branch: main
+  files_committed:
+    - path: README.md
+      content: |
+        # Demo repo
+
+        Minimal fixture repo for the aif-implement inline-mode conflict scenario.
+    - path: package.json
+      content: |
+        {
+          "name": "demo",
+          "version": "0.1.0"
+        }
+    - path: .ai-factory/PLAN.md
+      content: |
+        # Feature: should-never-be-loaded
+
+        ## Context
+        - Mode: fast
+        - Tests: no
+        - Logging: no
+        - Docs: no
+
+        ## Tasks
+
+        - [ ] Task 1: this plan should be ignored because --without-plan + @plan-file is a hard conflict
+
+user_responses: []
+
+assertions:
+  # Documented error: "`--without-plan` is mutually exclusive with @plan-file, status, and task id."
+  - id: prints-mutually-exclusive-error
+    type: output_contains
+    pattern: "(?i)mutually\\s+exclusive"
+    weight: 3
+
+  # The described file must NOT be created.
+  - id: no-write-test-txt
+    type: no_tool_called
+    tool: Write
+    args_match:
+      file_path: "(^|/)test\\.txt$"
+
+  # The plan file must NOT be read (conflict is caught before plan loading).
+  - id: no-read-plan-md
+    type: no_tool_called
+    tool: Read
+    args_match:
+      file_path: "\\.ai-factory/PLAN\\.md$"
+
+  # The plan file must NOT be edited (no checkbox flip, no rewrite).
+  - id: no-edit-plan-md
+    type: no_tool_called
+    tool: Edit
+    args_match:
+      file_path: "\\.ai-factory/PLAN\\.md$"
+
+  - id: stay-in-sandbox
+    type: no_path_escape

--- a/skills/aif-implement/tests/without-plan-creates-file.yaml
+++ b/skills/aif-implement/tests/without-plan-creates-file.yaml
@@ -6,9 +6,13 @@ description: |
   Verifies:
   (1) the described file is actually written with the expected content;
   (2) the skill does NOT Read `.ai-factory/PLAN.md`, `.ai-factory/FIX_PLAN.md`,
-      or anything under `.ai-factory/plans/`;
-  (3) the skill does NOT Glob the plans directory;
-  (4) the skill does NOT Write any plan/fix-plan/patch artifacts.
+      or anything under `.ai-factory/plans/` (the real "no load" guarantee);
+  (3) the skill does NOT Write or Edit any plan/fix-plan/patch artifacts.
+
+  NOTE on Glob: a minimal Glob/exists probe of plan paths IS allowed in inline
+  mode, solely so Step 0.inline can emit `WARN [inline]` when an existing plan
+  file is being intentionally ignored. The contract is "no Read/Write/Edit of
+  plan artifacts," not "no probe at all" — see Step 0.inline in SKILL.md.
 skill: aif-implement
 argument: '--without-plan create a file named test.txt at the repo root containing exactly the text "Hello world"'
 max_turns: 40

--- a/skills/aif-implement/tests/without-plan-creates-file.yaml
+++ b/skills/aif-implement/tests/without-plan-creates-file.yaml
@@ -1,0 +1,115 @@
+scenario: without-plan-creates-file
+description: |
+  Inline mode (`/aif-implement --without-plan <description>`) must execute the
+  task described in the argument WITHOUT discovering or reading any plan file.
+
+  Verifies:
+  (1) the described file is actually written with the expected content;
+  (2) the skill does NOT Read `.ai-factory/PLAN.md`, `.ai-factory/FIX_PLAN.md`,
+      or anything under `.ai-factory/plans/`;
+  (3) the skill does NOT Glob the plans directory;
+  (4) the skill does NOT Write any plan/fix-plan/patch artifacts.
+skill: aif-implement
+argument: '--without-plan create a file named test.txt at the repo root containing exactly the text "Hello world"'
+max_turns: 40
+
+runner:
+  model: claude-sonnet-4-6
+  permission_mode: bypassPermissions
+  # Keep the test focused. No web, no handoff MCP, no subagent exploration.
+  # TaskList/TaskCreate/TaskUpdate are intentionally wired so the test can
+  # verify the skill *chose* not to call them in inline mode (per Step 0.inline).
+  allowed_tools_override:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash(git *)
+    - Bash(mkdir *)
+    - Bash(ls *)
+    - Bash(pwd)
+    - Bash(basename *)
+    - Bash(cd *)
+    - Bash(printenv *)
+    - AskUserQuestion
+    - Questions
+    - TaskList
+    - TaskCreate
+    - TaskUpdate
+
+fixtures:
+  git_init: true
+  git_branch: main
+  files_committed:
+    - path: README.md
+      content: |
+        # Demo repo
+
+        Minimal fixture repo for the aif-implement inline-mode scenario.
+    - path: package.json
+      content: |
+        {
+          "name": "demo",
+          "version": "0.1.0"
+        }
+
+user_responses:
+  # Inline mode ends with "Verify first / Skip to commit". Short-circuit by
+  # choosing "Skip to commit" so the run ends quickly; /aif-commit isn't
+  # installed in the sandbox, so the skill gracefully prints the command and
+  # stops.
+  - match_question: "(?i)(verify|commit|what'?s next|next\\??)"
+    choose: "Skip to commit"
+  - match_question: "(?i)(proceed|confirm|ready|start|approve)"
+    choose: "Yes"
+
+assertions:
+  # Positive — the file actually got written with the requested content.
+  - id: writes-test-txt-with-hello-world
+    type: tool_called
+    tool: Write
+    args_match:
+      file_path: "(^|/)test\\.txt$"
+      content: "Hello world"
+    weight: 3
+
+  # Negative — inline mode must NOT read any plan file.
+  - id: no-read-fast-plan
+    type: no_tool_called
+    tool: Read
+    args_match:
+      file_path: "\\.ai-factory/PLAN\\.md$"
+
+  - id: no-read-fix-plan
+    type: no_tool_called
+    tool: Read
+    args_match:
+      file_path: "\\.ai-factory/FIX_PLAN\\.md$"
+
+  - id: no-read-branch-plan
+    type: no_tool_called
+    tool: Read
+    args_match:
+      file_path: "\\.ai-factory/plans/"
+
+  # Negative — inline mode must NOT create or update plan/fix-plan artifacts.
+  # (Note: Glob probes for `.ai-factory/PLAN.md` / `plans/*.md` ARE allowed —
+  # Step 0.inline uses them only to emit `WARN [inline]` when a plan exists,
+  # never to load the file. The real guarantee is "no Read / Write / Edit of
+  # plan artifacts," already asserted above and below.)
+  - id: no-write-plan-artifacts
+    type: no_tool_called
+    tool: Write
+    args_match:
+      file_path: "\\.ai-factory/(PLAN|FIX_PLAN)\\.md$|\\.ai-factory/plans/|\\.ai-factory/patches/"
+
+  - id: no-edit-plan-artifacts
+    type: no_tool_called
+    tool: Edit
+    args_match:
+      file_path: "\\.ai-factory/(PLAN|FIX_PLAN)\\.md$|\\.ai-factory/plans/"
+
+  # Sandbox hygiene — all file-path tool calls stay inside the worktree.
+  - id: stay-in-sandbox
+    type: no_path_escape

--- a/skills/aif-implement/tests/without-plan-empty-errors.yaml
+++ b/skills/aif-implement/tests/without-plan-empty-errors.yaml
@@ -1,0 +1,76 @@
+scenario: without-plan-empty-errors
+description: |
+  Inline mode must reject an empty `--without-plan` argument with the exact
+  usage-error text defined in Step 0.inline, and must NOT proceed to execute
+  anything (no Write, no Edit, no Bash shell mutations, no plan artifacts).
+
+  Verifies:
+  (1) the skill's output contains the Usage: error phrasing;
+  (2) no file is created or modified;
+  (3) no plan/fix-plan artifact is created.
+skill: aif-implement
+argument: "--without-plan"
+max_turns: 20
+
+runner:
+  model: claude-sonnet-4-6
+  permission_mode: bypassPermissions
+  allowed_tools_override:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash(git *)
+    - Bash(ls *)
+    - Bash(pwd)
+    - Bash(basename *)
+    - Bash(cd *)
+    - Bash(printenv *)
+    - AskUserQuestion
+    - Questions
+
+fixtures:
+  git_init: true
+  git_branch: main
+  files_committed:
+    - path: README.md
+      content: |
+        # Demo repo
+
+        Minimal fixture repo for the aif-implement inline-mode empty-arg scenario.
+    - path: package.json
+      content: |
+        {
+          "name": "demo",
+          "version": "0.1.0"
+        }
+
+user_responses: []
+
+assertions:
+  # The skill must print the documented usage error.
+  - id: prints-usage-error
+    type: output_contains
+    pattern: "(?i)usage:\\s*/aif-implement\\s+--without-plan"
+    weight: 3
+
+  # No Write of any file should occur.
+  - id: no-write-any-file
+    type: no_tool_called
+    tool: Write
+
+  # No Edit of any file should occur.
+  - id: no-edit-any-file
+    type: no_tool_called
+    tool: Edit
+
+  # Explicitly: no plan/fix-plan/patches artifacts.
+  - id: no-plan-artifacts-written
+    type: no_tool_called
+    tool: Write
+    args_match:
+      file_path: "\\.ai-factory/(PLAN|FIX_PLAN)\\.md$|\\.ai-factory/plans/|\\.ai-factory/patches/"
+
+  - id: stay-in-sandbox
+    type: no_path_escape

--- a/skills/aif-implement/tests/without-plan-invalid-docs-errors.yaml
+++ b/skills/aif-implement/tests/without-plan-invalid-docs-errors.yaml
@@ -1,0 +1,73 @@
+scenario: without-plan-invalid-docs-errors
+description: |
+  Inline mode must reject an invalid `--docs=<value>` argument with the exact
+  error text defined in Step 0.inline, and must NOT proceed to execute the
+  task described after it.
+
+  Verifies:
+  (1) the skill's output contains the "Invalid --docs value" error;
+  (2) the described `test.txt` file is NOT created;
+  (3) no plan/fix-plan artifact is created.
+skill: aif-implement
+argument: '--without-plan --docs=maybe create a file named test.txt at the repo root containing exactly the text "Hello world"'
+max_turns: 20
+
+runner:
+  model: claude-sonnet-4-6
+  permission_mode: bypassPermissions
+  allowed_tools_override:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash(git *)
+    - Bash(ls *)
+    - Bash(pwd)
+    - Bash(basename *)
+    - Bash(cd *)
+    - Bash(printenv *)
+    - AskUserQuestion
+    - Questions
+
+fixtures:
+  git_init: true
+  git_branch: main
+  files_committed:
+    - path: README.md
+      content: |
+        # Demo repo
+
+        Minimal fixture repo for the aif-implement inline-mode invalid-docs scenario.
+    - path: package.json
+      content: |
+        {
+          "name": "demo",
+          "version": "0.1.0"
+        }
+
+user_responses: []
+
+assertions:
+  # Documented error text: "Invalid --docs value. Expected yes|no|warn."
+  - id: prints-invalid-docs-error
+    type: output_contains
+    pattern: "(?i)invalid\\s+--docs\\s+value"
+    weight: 3
+
+  # The described file must NOT be created (early stop before execution).
+  - id: no-write-test-txt
+    type: no_tool_called
+    tool: Write
+    args_match:
+      file_path: "(^|/)test\\.txt$"
+
+  # No plan/fix-plan artifacts.
+  - id: no-plan-artifacts-written
+    type: no_tool_called
+    tool: Write
+    args_match:
+      file_path: "\\.ai-factory/(PLAN|FIX_PLAN)\\.md$|\\.ai-factory/plans/|\\.ai-factory/patches/"
+
+  - id: stay-in-sandbox
+    type: no_path_escape


### PR DESCRIPTION
## Summary

Introduces `/aif-implement --without-plan <description>` — one-shot inline implementation path for small `feat`/`chore` tasks that don't justify a full plan but aren't bugs either.

Addresses #92 (feature request by @YouMixx; design refined in @ichinya's review comment).

## What's new

**Inline mode in `skills/aif-implement/SKILL.md`:**
- New `Step 0.inline` section drives the full flow.
- Mutually exclusive with `@plan-file`, `status`, and task id.
- Skips plan/fix-plan **loading** entirely — no `FIX_PLAN.md`, no `patches/*` entries, no `TaskList` calls, no checkbox updates. (A minimal Glob/exists probe of plan paths IS allowed solely to emit `WARN [inline]` when an existing plan is being intentionally ignored — nothing is read from disk.)
- Loads the same project context as regular mode (config, `DESCRIPTION.md`, `ARCHITECTURE.md`, rules, skill-context).
- `WARN [inline]` surprise-warn when a plan file exists on disk but is being ignored (warn-only; never reads/loads the file).
- Scope guard redirects broad/multi-task descriptions to `/aif-plan fast <description>`.
- Optional `--docs=yes|no|warn` override (default `warn`, since there's no `Docs: yes/no` in an inline task).
- Naming clarification: `--without-plan` means "without a **local** plan artifact on disk." When a Handoff task is linked, the task is still represented as a synthetic plan **inside Handoff** via `handoff_push_plan` — that's a remote representation, not a local file. The local-no-plan contract is preserved.
- Handoff compatibility:
  - `HANDOFF_MODE=1` (autonomous coordinator): inline mode does NOT call any `mcp__handoff__*` tool, does NOT create local plan artifacts, and does NOT switch branches / create / merge worktrees set up by the coordinator.
  - `HANDOFF_MODE` unset + `HANDOFF_TASK_ID` set (manual session): pushes a synthetic `# Inline implementation` plan through `handoff_push_plan` and updates `handoff_sync_status` (implementing → review/done).
  - `HANDOFF_TASK_ID` unset → skip MCP sync entirely.

**Docs (`docs/skills.md`):**
- New usage example and limitation bullets under `/aif-implement`.

**Tests (`skills/aif-implement/tests/`):** — six ai-tester scenarios.

| Scenario | Asserts |
|----------|---------|
| `without-plan-creates-file` | Inline mode creates `test.txt` with `Hello world` and never `Read`/`Write`/`Edit`s any plan artifact (`PLAN.md`, `FIX_PLAN.md`, `plans/`, `patches/`). Glob/exists probes are explicitly permitted. |
| `without-plan-empty-errors` | Empty `--without-plan` → `Usage: …` error + no Write/Edit + no plan artifacts. |
| `without-plan-invalid-docs-errors` | `--docs=maybe` → `Invalid --docs value` error + target file NOT created. |
| `without-plan-conflict-errors` | `--without-plan … @PLAN.md` → `mutually exclusive` error + plan file never `Read`/`Edit`. |
| `without-plan-broad-scope-redirects` | Multi-subsystem chained description → output contains `/aif-plan fast` redirect + no `Write`/`Edit`. |
| `fast-plan-creates-file` | Default mode discovers `.ai-factory/PLAN.md`, executes the task **using the `Write` tool with exact content `Hello world`**, and flips the plan checkbox `- [ ]` → `- [x]`. |

All six pass against real Claude SDK (`claude-sonnet-4-6`, bypassPermissions sandbox).

### Coverage gap (Handoff inline path)

The Handoff inline branch (synthetic plan push via `mcp__handoff__handoff_push_plan` + `handoff_sync_status`) is **NOT validated by an automated scenario** — only by manual smoke. `@cutcode/ai-tester` (0.2.0) does not provision or mock MCP servers in its isolated worktrees, so a sandboxed scenario for this path would either fail or only re-assert the graceful-degradation case. Tracked as #98 (add the scenario once ai-tester supports MCP mocking). The orchestration guarantees of inline mode (no `TaskList`/`TaskUpdate`, no roadmap milestone flow, no plan-cleanup prompt, no worktree merge prompt) remain prompt-only contracts in this PR; they are documented in `Step 0.inline` but enforced by reviewer judgment, not by tests.

## Acceptance criteria (from #92)

- [x] `/aif-implement --without-plan "add small healthcheck endpoint"` does not ask for or create a plan file.
- [x] Existing modes (`--list`, `@plan`, `status`, numeric task id, bare `/aif-implement`) work as before.
- [x] Inline mode does not create `.ai-factory/FIX_PLAN.md` or entries under `.ai-factory/patches/*`.
- [x] Inline mode does not update any plan checkbox (there is no plan file).
- [x] Empty `--without-plan` returns a clear usage error.
- [x] A large/unclear task is redirected to `/aif-plan fast <description>`.

## Test plan

- [x] `npx @cutcode/ai-tester run aif-implement --scenario without-plan-creates-file`
- [x] `npx @cutcode/ai-tester run aif-implement --scenario without-plan-empty-errors`
- [x] `npx @cutcode/ai-tester run aif-implement --scenario without-plan-invalid-docs-errors`
- [x] `npx @cutcode/ai-tester run aif-implement --scenario without-plan-conflict-errors`
- [x] `npx @cutcode/ai-tester run aif-implement --scenario without-plan-broad-scope-redirects`
- [x] `npx @cutcode/ai-tester run aif-implement --scenario fast-plan-creates-file`
- [ ] Manual smoke: `/aif-implement --without-plan create docs/EXAMPLE.md with title "Example"` in a real repo
- [ ] Manual smoke: ensure `/aif-implement @plan.md`, `/aif-implement --list`, `/aif-implement status` still work on an existing plan
- [ ] Manual smoke: Handoff inline path under `HANDOFF_TASK_ID` set + `HANDOFF_MODE` unset (sandboxed scenario tracked in #98)

## Notes

- Commit-checkpoint prompts, roadmap milestone marking, plan-file cleanup, and worktree merge flow are intentionally **not** wired into inline mode — those belong to the plan-backed workflow.
- Scope-guard heuristic (`and`/`и`, multi-subsystem, ~300 char budget) is intentionally simple and will likely need tuning after real-world usage; follow-up PRs welcome.
- Installer already skips `skills/*/tests/` per 30b28ca, so the new `tests/` directory won't ship to end-user installs.

Closes #92
Follow-up: #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)