### PR TITLE
feat(quality): add machine-readable gate summaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,8 +114,9 @@ Context gate policy for quality commands:
 - Roadmap mismatch is warning-first in normal mode, blocking in strict mode when mismatch is clear.
 - Missing roadmap milestone linkage for `feat`/`fix`/`perf` is warning-first by default, even in strict verify when a
   roadmap exists.
-- `/aif-rules-check` is the standalone rules-only companion and uses `PASS` / `WARN` / `FAIL`; `/aif-commit`,
-  `/aif-review`, and `/aif-verify` keep `WARN` / `ERROR`.
+- `/aif-rules-check` is the standalone rules-only companion and uses human `PASS` / `WARN` / `FAIL` labels.
+- `/aif-verify`, `/aif-review`, `/aif-security-checklist`, and `/aif-rules-check` append a final machine-readable
+  `aif-gate-result` JSON block with lowercase `pass` / `warn` / `fail` status values.
 
 ### Config-Aware Skills
 
@@ -211,6 +212,7 @@ Reports standalone verdict:
     - PASS → applicable rules checked and no clear violations found
     - WARN → missing/ambiguous rules or no changed files
     - FAIL → explicit hard-rule violation tied to diff evidence
+    - final `aif-gate-result` JSON block → parseable lowercase pass/warn/fail summary
     ↓
 Suggests `/aif-rules` when rules need to be added or clarified
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ See the full [Development Workflow](docs/workflow.md) with diagram and decision 
 | [Reflex Loop](docs/loop.md) | Iterative generate → evaluate → critique → refine workflow |
 | [Subagents](docs/subagents.md) | Claude Code only: repo-local planning, implementation, and loop subagents with narrow role contracts |
 | [Core Skills](docs/skills.md) | All slash commands — explore, grounded, plan, fix, implement, evolve, docs, and more |
+| [Quality Gates](docs/quality-gates.md) | Machine-readable `aif-gate-result` summaries for verify, review, security, and rules gates |
 | [Skill Evolution](docs/evolve.md) | How /aif-fix patches feed into /aif-evolve to generate smarter skill rules |
 | [Plan Files](docs/plan-files.md) | Plan files, self-improvement patches, skill acquisition |
 | [Security](docs/security.md) | Two-level security scanning for external skills |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -340,6 +340,7 @@ For full phase contracts and stop conditions, see [Reflex Loop](loop.md).
 - Keep context artifact ownership command-scoped (roadmap by `/aif-roadmap`, rules by `/aif-rules`, architecture by `/aif-architecture`, research by `/aif-explore`).
 - Treat `/aif-rules-check`, `/aif-commit`, `/aif-review`, and `/aif-verify` as read-only consumers of context artifacts by default.
 - Use `WARN` for non-blocking gate findings (missing optional files, ambiguous mapping) and `ERROR` for blocking violations.
+- Parseable quality gates append a final `aif-gate-result` JSON block with lowercase `pass` / `warn` / `fail` status values; see [Quality Gates](quality-gates.md).
 
 ### Logging
 All implementations include verbose, configurable logging:

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,0 +1,125 @@
+[Back to README](../README.md) · [Development Workflow](workflow.md) · [Core Skills](skills.md)
+
+# Quality Gates
+
+AI Factory quality gates keep their normal human-readable Markdown reports, then append one final machine-readable block. Handoff, AIFHub, and future orchestrators should parse only the last `aif-gate-result` fenced block in the final gate output instead of scraping prose.
+
+Supported gates:
+- `/aif-verify` -> `gate: "verify"`
+- `/aif-review` -> `gate: "review"`
+- `/aif-security-checklist` -> `gate: "security"`
+- `/aif-rules-check` -> `gate: "rules"`
+
+The block must be valid JSON and must appear after the human summary.
+
+## Schema
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "verify",
+  "status": "fail",
+  "blocking": true,
+  "blockers": [
+    {
+      "id": "verify-task-1",
+      "severity": "error",
+      "file": "src/example.ts",
+      "summary": "Required behavior is missing."
+    }
+  ],
+  "affected_files": ["src/example.ts"],
+  "suggested_next": {
+    "command": "/aif-fix",
+    "reason": "Blocking implementation gaps remain."
+  }
+}
+```
+
+Rules:
+- `schema_version` is currently `1`.
+- `gate` is one of `verify`, `review`, `security`, or `rules`.
+- `status` is one of `pass`, `warn`, or `fail`.
+- `blocking` is a boolean.
+- `blockers` contains only findings that should block the current gate.
+- `blockers[].severity` uses `error` or `warning`; security `critical`/`high` maps to `error`, while `medium`/`low` normally remains a non-blocking human warning.
+- `affected_files` is a predictable top-level array of files the gate actually evaluated or cited. It is not limited to blocker files. Use `[]` when no files apply.
+- `suggested_next.command` is selected from the global allowlist: `/aif-fix`, `/aif-rules`, `/aif-architecture`, `/aif-roadmap`, `/aif-commit`, or `null`. Individual gates may document narrower subsets.
+
+## Status Examples
+
+Pass:
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "review",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": ["skills/aif-review/SKILL.md"],
+  "suggested_next": {
+    "command": "/aif-commit",
+    "reason": "Review found no blocking issues."
+  }
+}
+```
+
+Warn:
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "rules",
+  "status": "warn",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": {
+    "command": "/aif-rules",
+    "reason": "Rules are missing or ambiguous for the changed scope."
+  }
+}
+```
+
+Fail:
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "security",
+  "status": "fail",
+  "blocking": true,
+  "blockers": [
+    {
+      "id": "security-secret-1",
+      "severity": "error",
+      "file": "src/config.ts",
+      "summary": "A hardcoded secret is present."
+    }
+  ],
+  "affected_files": ["src/config.ts"],
+  "suggested_next": {
+    "command": "/aif-fix",
+    "reason": "Remove the exposed secret and rotate it."
+  }
+}
+```
+
+## Compatibility
+
+Manual workflows continue to read the human Markdown summaries. Existing `WARN`, `ERROR`, `PASS`, and `FAIL` labels can remain in those summaries when they are useful for people.
+
+The machine contract is only the final fenced JSON block in actual gate output. Orchestrators should ignore earlier Markdown headings, bullets, and examples.
+
+## Ownership
+
+Quality gates remain read-only for context artifacts by default. If a gate finds stale architecture, roadmap, or rules context, it should suggest the owner command instead of editing the artifact directly.
+
+Exceptions stay with existing command contracts. For example, `/aif-security-checklist ignore <item>` may write the configured security ignored-item artifact, but normal security audit findings are report output.
+
+## See Also
+
+- [Development Workflow](workflow.md) - where gates fit into the workflow
+- [Core Skills](skills.md) - command reference for each quality gate
+- [Configuration](configuration.md) - artifact ownership and context gate defaults

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -153,6 +153,7 @@ Verifies completed implementation against the plan:
 - **Git-aware diffing** — uses `git.base_branch` for branch-diff verification; no-git repositories fall back to recent commits / working tree instead of assuming `main`
 - **Issue remediation** — if issues found, first suggests `/aif-fix <issue summary>` (recommended), with optional direct fix in-session
 - **Follow-up suggestions** — if all green, suggests `/aif-security-checklist`, `/aif-review`, then `/aif-commit`
+- **Machine-readable result** — appends a final `aif-gate-result` JSON block with `status: pass|warn|fail`, `blocking`, `blockers`, `affected_files`, and `suggested_next`
 
 **Strict mode** (`--strict`) is recommended before merging: requires all tasks complete, build passing, tests passing, lint clean, zero TODOs in changed files, and passing architecture/rules/roadmap gates. For `feat`/`fix`/`perf`, missing roadmap milestone linkage is reported as a warning, not a failure.
 
@@ -414,6 +415,7 @@ Reviews staged changes or PR diffs:
 - Checks correctness, security, performance, and maintainability
 - Adds read-only context-gate findings (architecture/roadmap/rules) to review output
 - Uses `WARN` for non-blocking context drift and `ERROR` only for explicitly blocking review criteria
+- Appends a final `aif-gate-result` JSON block for Handoff/AIFHub and other orchestrators
 - If you only need the rules gate, use `/aif-rules-check`
 
 ### `/aif-rules-check [git ref]`
@@ -425,8 +427,8 @@ Runs a standalone read-only rules compliance gate:
 - Reads `.ai-factory/config.yaml` for `paths.rules_file`, `paths.rules`, `paths.plan`, `paths.plans`, `language.ui`, `git.enabled`, `git.base_branch`, `rules.base`, and any named `rules.<area>`
 - Resolves rules with graceful fallback: if `paths.rules_file` is omitted, it defaults to `.ai-factory/RULES.md`
 - Checks staged changes, working-tree diff, or a provided git ref against the resolved rules hierarchy
-- Uses standalone verdicts: `PASS` when checked rules are satisfied, `WARN` when rules are missing/ambiguous or no changed files are available, `FAIL` only for explicit hard-rule violations tied to rule text
-- Output sections: overall verdict, files checked, gate results, blocking violations, suggested fixes, suggested rule updates
+- Uses human standalone verdicts: `PASS` when checked rules are satisfied, `WARN` when rules are missing/ambiguous or no changed files are available, `FAIL` only for explicit hard-rule violations tied to rule text
+- Output sections: overall verdict, files checked, gate results, blocking violations, suggested fixes, suggested rule updates, and a final `aif-gate-result` JSON block
 - Remains read-only; if rules need to change, route that through `/aif-rules`
 
 - Config policy: config-aware; reads rule paths, optional active plan context, and git diff defaults from `config.yaml`
@@ -493,6 +495,8 @@ Security audit based on OWASP Top 10 and best practices:
 
 Each category includes a checklist, vulnerable/safe code examples (TypeScript, PHP), and an automated audit script.
 
+Audit outputs append a final `aif-gate-result` JSON block for full and category audits. The `ignore <item>` writer flow updates the configured security ignored-item artifact and only reports a gate result when it also performs an audit.
+
 **Ignoring items** — if a finding is intentionally accepted, mark it as ignored:
 ```
 /aif-security-checklist ignore no-csrf
@@ -534,5 +538,6 @@ The `--all` flag runs all three stages in sequence without inter-stage prompts. 
 ## See Also
 
 - [Development Workflow](workflow.md) — how workflow skills connect end-to-end
+- [Quality Gates](quality-gates.md) - machine-readable gate summary contract
 - [Reflex Loop](loop.md) — strict loop protocol for iterative quality gating
 - [Plan Files](plan-files.md) — where workflow artifacts are stored

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -203,7 +203,8 @@ Context-gate defaults for `/aif-commit`, `/aif-review`, `/aif-verify`:
 - Check architecture, roadmap, and rules alignment as read-only context.
 - Missing optional files (`ROADMAP.md`, `RULES.md`) are `WARN`, not immediate failures.
 - In strict verification, clear architecture/rules violations and clear roadmap mismatch are blocking failures.
-- `/aif-rules-check` is the standalone rules-only companion and uses `PASS` / `WARN` / `FAIL` without changing the `WARN` / `ERROR` contract above.
+- `/aif-rules-check` is the standalone rules-only companion and uses human `PASS` / `WARN` / `FAIL` labels.
+- `/aif-verify`, `/aif-review`, `/aif-security-checklist`, and `/aif-rules-check` append a final machine-readable `aif-gate-result` JSON block with lowercase `pass` / `warn` / `fail` status values. See [Quality Gates](quality-gates.md).
 
 ## Workflow Skills
 
@@ -297,15 +298,15 @@ When executing through the Claude top-level `implement-coordinator`, the quality
 
 Optional step after `/aif-implement`. Goes through every task in the plan and verifies the code actually implements it. Checks build, tests, lint, looks for leftover TODOs, undocumented env vars, and plan-vs-code drift. If gaps are found, it first suggests `/aif-fix <issue summary>` (recommended). If verification is clean, it suggests `/aif-security-checklist` and `/aif-review`. Use `--strict` before merging to the configured base branch.
 
-Also runs read-only context gates against the resolved architecture, roadmap, and RULES.md artifacts. In normal mode, roadmap/milestone linkage gaps are warnings; in strict mode, clear roadmap mismatch is a failure, while missing `feat`/`fix`/`perf` milestone linkage remains a warning.
+Also runs read-only context gates against the resolved architecture, roadmap, and RULES.md artifacts. In normal mode, roadmap/milestone linkage gaps are warnings; in strict mode, clear roadmap mismatch is a failure, while missing `feat`/`fix`/`perf` milestone linkage remains a warning. The final output appends an `aif-gate-result` JSON block for orchestrators.
 
 ### `/aif-rules-check` — standalone rules gate
 
-Checks only rules compliance for staged changes, working-tree changes, or a provided git ref. It reads the resolved rules hierarchy, uses optional active plan context only to disambiguate scope, and stays read-only. Standalone verdicts are `PASS` / `WARN` / `FAIL`: missing or ambiguous rules stay `WARN`, while `FAIL` is reserved for explicit hard-rule violations tied to concrete diff evidence.
+Checks only rules compliance for staged changes, working-tree changes, or a provided git ref. It reads the resolved rules hierarchy, uses optional active plan context only to disambiguate scope, and stays read-only. Human verdicts are `PASS` / `WARN` / `FAIL`: missing or ambiguous rules stay `WARN`, while `FAIL` is reserved for explicit hard-rule violations tied to concrete diff evidence. The final output appends an `aif-gate-result` JSON block with lowercase `pass` / `warn` / `fail`.
 
 ### `/aif-review` — code review with read-only context gates
 
-Reviews staged changes or PR diff and reports correctness/security/performance findings. Includes read-only architecture/roadmap/rules gate notes in review output (`WARN` for non-blocking inconsistencies, `ERROR` only for explicitly blocking criteria).
+Reviews staged changes or PR diff and reports correctness/security/performance findings. Includes read-only architecture/roadmap/rules gate notes in review output (`WARN` for non-blocking inconsistencies, `ERROR` only for explicitly blocking criteria), then appends an `aif-gate-result` JSON block.
 
 ### `/aif-commit` — conventional commit with read-only context gates
 

--- a/scripts/test-aif-rules-check.sh
+++ b/scripts/test-aif-rules-check.sh
@@ -144,9 +144,9 @@ assert_exact_line \
 
 assert_exact_line \
     "$CONTRACT_REF" \
-    '`PASS` / `WARN` / `FAIL` belongs only to `/aif-rules-check`; `/aif-commit`, `/aif-review`, and `/aif-verify` keep `WARN` / `ERROR`.' \
-    "contract preserves standalone-vs-context-gate severity boundary" \
-    "contract must preserve standalone-vs-context-gate severity boundary"
+    'The human rules report keeps `PASS` / `WARN` / `FAIL`. The final machine-readable summary uses lowercase `pass` / `warn` / `fail` in the `aif-gate-result` JSON block, matching the shared quality gate result contract.' \
+    "contract documents rules-check machine-readable summary boundary" \
+    "contract must document the rules-check machine-readable summary boundary"
 
 TOTAL=$((PASSED + FAILED))
 echo ""

--- a/scripts/test-gate-result-contract.sh
+++ b/scripts/test-gate-result-contract.sh
@@ -1,0 +1,295 @@
+#!/bin/bash
+# Smoke tests for machine-readable quality gate result contracts.
+# Usage: ./scripts/test-gate-result-contract.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONTRACT_REF="$ROOT_DIR/skills/aif-verify/references/GATE-RESULT-CONTRACT.md"
+DOCS_REF="$ROOT_DIR/docs/quality-gates.md"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() {
+    PASSED=$((PASSED + 1))
+    echo -e "  ${GREEN}OK${NC} $1"
+}
+
+fail() {
+    FAILED=$((FAILED + 1))
+    echo -e "  ${RED}FAIL${NC} $1"
+}
+
+assert_file_exists() {
+    local file="$1"
+    local message="$2"
+
+    if [[ -f "$file" ]]; then
+        pass "$message"
+    else
+        fail "$message"
+    fi
+}
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    local message="$3"
+
+    if [[ -f "$file" ]] && grep -Fq "$expected" "$file"; then
+        pass "$message"
+    else
+        fail "$message"
+    fi
+}
+
+extract_last_gate_result() {
+    local input_file="$1"
+    local output_file="$2"
+
+    awk '
+        /^```aif-gate-result$/ {
+            capture = 1
+            buffer = ""
+            next
+        }
+        /^```$/ && capture {
+            last = buffer
+            capture = 0
+            next
+        }
+        capture {
+            buffer = buffer $0 ORS
+        }
+        END {
+            if (last == "") {
+                exit 1
+            }
+            printf "%s", last
+        }
+    ' "$input_file" > "$output_file"
+}
+
+validate_gate_result_json() {
+    local json_file="$1"
+    local message="$2"
+
+    if command -v jq >/dev/null 2>&1; then
+        if jq -e '
+            . as $result |
+            $result.schema_version == 1 and
+            (["verify", "review", "security", "rules"] | index($result.gate)) and
+            (["pass", "warn", "fail"] | index($result.status)) and
+            ($result.blocking | type == "boolean") and
+            ($result.blockers | type == "array") and
+            ($result.affected_files | type == "array") and
+            ($result.suggested_next | type == "object") and
+            (
+                $result.suggested_next.command == null or
+                (["/aif-fix", "/aif-rules", "/aif-architecture", "/aif-roadmap", "/aif-commit"] | index($result.suggested_next.command))
+            )
+        ' "$json_file" >/dev/null; then
+            pass "$message"
+        else
+            fail "$message"
+        fi
+    elif command -v node >/dev/null 2>&1; then
+        if GATE_RESULT_JSON_FILE="$json_file" node <<'JS'
+const fs = require('fs');
+
+const result = JSON.parse(fs.readFileSync(process.env.GATE_RESULT_JSON_FILE, 'utf8'));
+const allowedGates = new Set(['verify', 'review', 'security', 'rules']);
+const allowedStatus = new Set(['pass', 'warn', 'fail']);
+const allowedNext = new Set(['/aif-fix', '/aif-rules', '/aif-architecture', '/aif-roadmap', '/aif-commit', null]);
+
+const ok = (
+  result.schema_version === 1 &&
+  allowedGates.has(result.gate) &&
+  allowedStatus.has(result.status) &&
+  typeof result.blocking === 'boolean' &&
+  Array.isArray(result.blockers) &&
+  Array.isArray(result.affected_files) &&
+  result.suggested_next &&
+  typeof result.suggested_next === 'object' &&
+  allowedNext.has(result.suggested_next.command)
+);
+
+process.exit(ok ? 0 : 1);
+JS
+        then
+            pass "$message"
+        else
+            fail "$message"
+        fi
+    elif command -v python3 >/dev/null 2>&1; then
+        if python3 - "$json_file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    result = json.load(fh)
+
+allowed_gates = {"verify", "review", "security", "rules"}
+allowed_status = {"pass", "warn", "fail"}
+allowed_next = {"/aif-fix", "/aif-rules", "/aif-architecture", "/aif-roadmap", "/aif-commit", None}
+
+ok = (
+    result.get("schema_version") == 1
+    and result.get("gate") in allowed_gates
+    and result.get("status") in allowed_status
+    and isinstance(result.get("blocking"), bool)
+    and isinstance(result.get("blockers"), list)
+    and isinstance(result.get("affected_files"), list)
+    and isinstance(result.get("suggested_next"), dict)
+    and result["suggested_next"].get("command") in allowed_next
+)
+
+sys.exit(0 if ok else 1)
+PY
+        then
+            pass "$message"
+        else
+            fail "$message"
+        fi
+    else
+        fail "$message (requires jq, node, or python3)"
+    fi
+}
+
+echo -e "\n${BOLD}=== Gate result shared contract ===${NC}\n"
+
+assert_file_exists "$CONTRACT_REF" "shared gate result contract exists"
+assert_contains "$CONTRACT_REF" '```aif-gate-result' "contract documents exact fence language"
+assert_contains "$CONTRACT_REF" 'Orchestrators must parse the last `aif-gate-result` fenced block' "contract documents trailing fence parsing"
+assert_contains "$CONTRACT_REF" '"schema_version": 1' "contract documents schema_version"
+assert_contains "$CONTRACT_REF" '"status": "pass|warn|fail"' "contract documents allowed status values"
+assert_contains "$CONTRACT_REF" '"blocking": true|false' "contract documents boolean blocking"
+assert_contains "$CONTRACT_REF" 'critical`/`high` -> `error`' "contract documents security severity bridge"
+assert_contains "$CONTRACT_REF" 'files the gate actually evaluated or cited' "contract documents affected_files semantics"
+assert_contains "$CONTRACT_REF" '"suggested_next": {' "contract documents suggested_next object"
+assert_contains "$CONTRACT_REF" '/aif-fix' "contract documents allowed next commands"
+assert_contains "$CONTRACT_REF" 'Each gate may document a narrower subset' "contract documents per-gate suggested_next subsets"
+assert_contains "$CONTRACT_REF" '/aif-commit' "contract documents commit as clean next step"
+
+echo -e "\n${BOLD}=== Gate skill output contracts ===${NC}\n"
+
+declare -A GATE_SKILLS=(
+  [verify]="$ROOT_DIR/skills/aif-verify/SKILL.md"
+  [review]="$ROOT_DIR/skills/aif-review/SKILL.md"
+  [security]="$ROOT_DIR/skills/aif-security-checklist/SKILL.md"
+  [rules]="$ROOT_DIR/skills/aif-rules-check/SKILL.md"
+)
+
+for gate in verify review security rules; do
+    file="${GATE_SKILLS[$gate]}"
+    assert_contains "$file" '```aif-gate-result' "$gate skill includes aif-gate-result fence"
+    assert_contains "$file" '"gate": "' "$gate skill includes gate field in JSON example"
+    assert_contains "$file" '"status": "pass|warn|fail"' "$gate skill documents pass/warn/fail status"
+    assert_contains "$file" '"blocking": true|false' "$gate skill documents boolean blocking"
+    assert_contains "$file" '"blockers": [' "$gate skill documents blockers array"
+    assert_contains "$file" '"affected_files": [' "$gate skill documents affected_files array"
+    assert_contains "$file" '"suggested_next": {' "$gate skill documents suggested_next object"
+done
+
+assert_contains "$ROOT_DIR/skills/aif-rules-check/SKILL.md" 'PASS` -> `pass`, `WARN` -> `warn`, and `FAIL` -> `fail`' "rules skill documents explicit verdict mapping"
+assert_contains "$ROOT_DIR/skills/aif-rules-check/SKILL.md" 'Do not use `/aif-review` in the JSON `suggested_next.command`' "rules skill separates disallowed review command"
+assert_contains "$ROOT_DIR/skills/aif-security-checklist/SKILL.md" 'Do not append this gate block for the `ignore <item>` writer flow' "security skill documents ignore writer-flow exception"
+
+echo -e "\n${BOLD}=== Gate result docs ===${NC}\n"
+
+assert_file_exists "$DOCS_REF" "quality gate docs page exists"
+assert_contains "$DOCS_REF" '```aif-gate-result' "docs include parseable fence examples"
+assert_contains "$DOCS_REF" 'parse only the last `aif-gate-result` fenced block' "docs document trailing fence parsing"
+assert_contains "$DOCS_REF" '"schema_version": 1' "docs include schema_version"
+assert_contains "$DOCS_REF" '"gate": "verify"' "docs include verify example"
+assert_contains "$DOCS_REF" '"gate": "review"' "docs include review example"
+assert_contains "$DOCS_REF" '"gate": "security"' "docs include security example"
+assert_contains "$DOCS_REF" '"gate": "rules"' "docs include rules example"
+assert_contains "$DOCS_REF" '"status": "fail"' "docs include fail example"
+assert_contains "$DOCS_REF" '"status": "warn"' "docs include warn example"
+assert_contains "$DOCS_REF" '"status": "pass"' "docs include pass example"
+assert_contains "$DOCS_REF" '"blocking": true' "docs include blocking true example"
+assert_contains "$DOCS_REF" '"blocking": false' "docs include blocking false example"
+assert_contains "$DOCS_REF" '"blockers": [' "docs include blockers array"
+assert_contains "$DOCS_REF" '"affected_files": [' "docs include affected_files array"
+assert_contains "$DOCS_REF" '"suggested_next": {' "docs include suggested_next object"
+
+echo -e "\n${BOLD}=== Gate result fixture validation ===${NC}\n"
+
+FIXTURE_FILE="$(mktemp)"
+FIXTURE_JSON="$(mktemp)"
+trap 'rm -f "$FIXTURE_FILE" "$FIXTURE_JSON"' EXIT
+
+cat > "$FIXTURE_FILE" <<'EOF'
+## Human Review
+
+Earlier examples may appear in documentation or quoted context.
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "review",
+  "status": "fail",
+  "blocking": true,
+  "blockers": [
+    {
+      "id": "review-example-1",
+      "severity": "error",
+      "summary": "Example only."
+    }
+  ],
+  "affected_files": ["docs/example.md"],
+  "suggested_next": {
+    "command": "/aif-fix",
+    "reason": "Example only."
+  }
+}
+```
+
+The final machine-readable result comes last.
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "verify",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": ["skills/aif-verify/SKILL.md"],
+  "suggested_next": {
+    "command": "/aif-commit",
+    "reason": "Verification passed."
+  }
+}
+```
+EOF
+
+if extract_last_gate_result "$FIXTURE_FILE" "$FIXTURE_JSON"; then
+    pass "runtime fixture extracts trailing gate-result fence"
+else
+    fail "runtime fixture extracts trailing gate-result fence"
+fi
+
+validate_gate_result_json "$FIXTURE_JSON" "runtime fixture validates gate-result JSON schema"
+
+if grep -Fq '"gate": "verify"' "$FIXTURE_JSON" && grep -Fq '"status": "pass"' "$FIXTURE_JSON"; then
+    pass "runtime fixture ignores earlier example fences"
+else
+    fail "runtime fixture ignores earlier example fences"
+fi
+
+TOTAL=$((PASSED + FAILED))
+echo ""
+echo -e "${BOLD}Total:${NC} $TOTAL, ${GREEN}Passed:${NC} $PASSED, ${RED}Failed:${NC} $FAILED"
+
+if [[ $FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -863,6 +863,20 @@ else
     echo "$RULES_CHECK_SMOKE_OUTPUT" | sed 's/^/      /'
 fi
 
+echo -e "\n${BOLD}=== Gate result contract smoke tests ===${NC}\n"
+
+set +e
+GATE_RESULT_SMOKE_OUTPUT=$(bash "$ROOT_DIR/scripts/test-gate-result-contract.sh" 2>&1)
+GATE_RESULT_SMOKE_EXIT=$?
+set -e
+
+if [[ $GATE_RESULT_SMOKE_EXIT -eq 0 ]]; then
+    pass "gate result contract smoke tests"
+else
+    fail "gate result contract smoke tests"
+    echo "$GATE_RESULT_SMOKE_OUTPUT" | sed 's/^/      /'
+fi
+
 echo -e "\n${BOLD}=== Results ===${NC}"
 echo -e "  Total:    $TOTAL"
 echo -e "  Passed:   ${GREEN}$PASSED${NC}"

--- a/skills/aif-review/SKILL.md
+++ b/skills/aif-review/SKILL.md
@@ -111,11 +111,23 @@ Before finalizing review findings, run read-only context gates:
 - Check the resolved RULES.md artifact (if present) for explicit convention violations.
 - Check the resolved roadmap artifact (if present) for milestone alignment and mention missing linkage for likely `feat`/`fix`/`perf` work.
 
-Gate result severity:
+Human gate result severity:
 - `WARN` for non-blocking inconsistencies or missing optional files.
 - `ERROR` only for explicit blocking criteria requested by the user/review policy.
 
-If the user wants a standalone rules-only pass, suggest `/aif-rules-check`. Keep `/aif-review` gate labels at `WARN` / `ERROR`.
+If the user wants a standalone rules-only pass, suggest `/aif-rules-check`. Keep human `/aif-review` gate labels at `WARN` / `ERROR`, then append the standard machine-readable gate result with `pass|warn|fail` status.
+
+Machine-readable gate result:
+- Append one final fenced `aif-gate-result` JSON block after the human-readable review.
+- Use `"gate": "review"`.
+- Use `"status": "pass|warn|fail"` where:
+  - `fail` = review findings should block merge, including critical correctness, security, data-loss, performance, or explicit blocking context-gate issues.
+  - `warn` = only non-blocking findings, suggestions, missing optional context, or review uncertainty remain.
+  - `pass` = no material review findings remain.
+- Use `"blocking": true|false`.
+- Include merge-blocking review findings only in `"blockers": [`.
+- Include reviewed or implicated paths in `"affected_files": [`.
+- Set `"suggested_next": {` to `/aif-fix`, `/aif-rules`, `/aif-architecture`, `/aif-roadmap`, `/aif-commit`, or `null`.
 
 `/aif-review` is read-only for context artifacts by default. Do not modify context files unless user explicitly asks.
 
@@ -203,6 +215,25 @@ If any rule is violated — fix the output before presenting it to the user.
 ### Positive Notes
 [Good patterns observed]
 ```
+
+Append the final machine-readable result after the markdown summary:
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "review",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": {
+    "command": "/aif-commit",
+    "reason": "Review found no blocking issues."
+  }
+}
+```
+
+Schema reminder: `"status": "pass|warn|fail"`, `"blocking": true|false`, `"blockers": [`, `"affected_files": [`, `"suggested_next": {`.
 
 ## Review Style
 

--- a/skills/aif-rules-check/SKILL.md
+++ b/skills/aif-rules-check/SKILL.md
@@ -170,8 +170,36 @@ Required content:
 - blocking violations
 - suggested fixes
 - suggested rule updates
+- final machine-readable `aif-gate-result` fenced JSON block
 
 When useful, suggest the next best workflow:
 - `/aif-review` for broader code review
 - `/aif-verify` for full plan-completeness verification
 - `/aif-rules` when the underlying rules need to be captured or corrected
+
+Machine-readable gate result:
+- Append one final fenced `aif-gate-result` JSON block after the human-readable rules report.
+- Use `"gate": "rules"`.
+- Map the human rules verdict exactly: `PASS` -> `pass`, `WARN` -> `warn`, and `FAIL` -> `fail`.
+- Use `"blocking": true|false`; set it to `true` only for explicit hard-rule violations that produce a human `FAIL`.
+- Include only hard-rule violations in `"blockers": [`.
+- Include changed or inspected paths in `"affected_files": [`.
+- Set `"suggested_next": {` to `/aif-rules` when rules should be added or clarified, `/aif-fix` when code must change, or `null` when no allowed next command fits.
+- Do not use `/aif-review` in the JSON `suggested_next.command`; it may appear only in human-readable workflow suggestions.
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "rules",
+  "status": "warn",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": {
+    "command": "/aif-rules",
+    "reason": "Rules are missing or ambiguous for the changed scope."
+  }
+}
+```
+
+Schema reminder: `"status": "pass|warn|fail"`, `"blocking": true|false`, `"blockers": [`, `"affected_files": [`, `"suggested_next": {`.

--- a/skills/aif-rules-check/references/RULES-CHECK-CONTRACT.md
+++ b/skills/aif-rules-check/references/RULES-CHECK-CONTRACT.md
@@ -17,15 +17,36 @@
 ### Suggested Rule Updates
 - <candidate rule to add or clarify via /aif-rules>
 
+### Machine-Readable Gate Result
+
+Append one final fenced JSON block after the human-readable report:
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "rules",
+  "status": "warn",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": {
+    "command": "/aif-rules",
+    "reason": "Rules are missing or ambiguous for the changed scope."
+  }
+}
+```
+
+Schema reminder: `"status": "pass|warn|fail"`, `"blocking": true|false`, `"blockers": [`, `"affected_files": [`, `"suggested_next": {`.
+
 ## Verdict Semantics
 
 `PASS` - at least one applicable rule was checked and no clear violations were found.
 `WARN` - no applicable rules were resolved, evidence is ambiguous, or there are no changed files to evaluate.
 `FAIL` - an explicit hard rule is clearly violated by the inspected diff or changed files.
 
-## Severity Boundary
+## Machine-Readable Summary Boundary
 
-`PASS` / `WARN` / `FAIL` belongs only to `/aif-rules-check`; `/aif-commit`, `/aif-review`, and `/aif-verify` keep `WARN` / `ERROR`.
+The human rules report keeps `PASS` / `WARN` / `FAIL`. The final machine-readable summary uses lowercase `pass` / `warn` / `fail` in the `aif-gate-result` JSON block, matching the shared quality gate result contract.
 
 ## Read-Only Contract
 

--- a/skills/aif-security-checklist/SKILL.md
+++ b/skills/aif-security-checklist/SKILL.md
@@ -142,6 +142,43 @@ This checks:
 
 ---
 
+## Machine-Readable Gate Result
+
+For `/aif-security-checklist` audits (full audit or category audit), keep the human-readable security report first and append one final fenced `aif-gate-result` JSON block.
+
+Do not append this gate block for the `ignore <item>` writer flow unless that invocation also performs and reports an audit result.
+
+Status mapping:
+- `fail`: an unignored critical/high security issue or other explicitly production-blocking finding remains.
+- `warn`: only medium/low findings, ignored items needing review, incomplete audit evidence, or audit command limitations remain.
+- `pass`: the audit completed and no unignored findings remain.
+
+Machine-readable fields:
+- Use `"gate": "security"`.
+- Use `"status": "pass|warn|fail"`.
+- Use `"blocking": true|false`.
+- Include only production-blocking findings in `"blockers": [`.
+- Include implicated paths in `"affected_files": [`.
+- Set `"suggested_next": {` to `/aif-fix` for code/config security fixes or `null` when no workflow command fits.
+- Never include secrets, tokens, raw passwords, or private credentials in the JSON block.
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "security",
+  "status": "warn",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": ["src/api/session.ts"],
+  "suggested_next": {
+    "command": "/aif-fix",
+    "reason": "Address non-blocking security hardening findings."
+  }
+}
+```
+
+---
+
 ## 🔴 Critical: Pre-Deployment Checklist
 
 ### Must Fix Before Production

--- a/skills/aif-verify/SKILL.md
+++ b/skills/aif-verify/SKILL.md
@@ -44,6 +44,7 @@ If config.yaml doesn't exist, use defaults:
 ### 0.1 Load Ownership and Gate Contract
 
 - Read `references/CONTEXT-GATES-AND-OWNERSHIP.md` first.
+- Read `references/GATE-RESULT-CONTRACT.md` for the machine-readable quality gate summary.
 - Treat it as the canonical source for:
   - command-to-artifact ownership,
   - read-only behavior for `aif-commit`/`aif-review`/`aif-verify`,
@@ -298,11 +299,23 @@ Strict mode behavior:
 - Clear roadmap mismatch fails verification.
 - Missing milestone linkage for `feat`/`fix`/`perf` remains a warning (even when `.ai-factory/ROADMAP.md` exists).
 
-Logging/reporting format:
+Human logging/reporting format:
 - Non-blocking findings: `WARN [gate-name] ...`
 - Blocking findings: `ERROR [gate-name] ...`
 
-If the user wants a standalone rules-only pass, suggest `/aif-rules-check`. Keep `/aif-verify` gate labels at `WARN` / `ERROR`.
+If the user wants a standalone rules-only pass, suggest `/aif-rules-check`. Keep human context-gate labels at `WARN` / `ERROR`, then derive the final machine-readable gate result from the full verification report.
+
+Machine-readable gate result:
+- Append one final fenced `aif-gate-result` JSON block after the human-readable verification report.
+- Use `"gate": "verify"`.
+- Use `"status": "pass|warn|fail"` where:
+  - `fail` = incomplete required tasks, failed blocking quality checks, strict-mode context gate failures, or other blockers requiring remediation.
+  - `warn` = only non-blocking warnings remain, optional checks were skipped, docs/test gaps were accepted as warnings, or context drift is ambiguous.
+  - `pass` = no blocking or warning findings remain.
+- Use `"blocking": true|false`; set it to `true` only when the result should stop commit or merge flow.
+- Include only blocking findings in `"blockers": [`; keep non-blocking notes in the human summary.
+- Include changed or implicated paths in `"affected_files": [`.
+- Set `"suggested_next": {` to `/aif-fix`, `/aif-rules`, `/aif-architecture`, `/aif-roadmap`, `/aif-commit`, or `null` according to `references/GATE-RESULT-CONTRACT.md`.
 
 ### 3.6 Context Drift (Optional Remediation)
 
@@ -369,6 +382,27 @@ Options:
 - **All Green** — everything verified, no issues
 - **Minor Issues** — small gaps that can be fixed quickly
 - **Significant Gaps** — tasks missing or partially done, needs re-implementation
+
+### 4.2.1 Append Machine-Readable Gate Result
+
+After the human-readable report and overall status, append exactly one final `aif-gate-result` fenced JSON block.
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "verify",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": {
+    "command": "/aif-commit",
+    "reason": "Verification passed without blockers."
+  }
+}
+```
+
+Schema reminder: `"status": "pass|warn|fail"`, `"blocking": true|false`, `"blockers": [`, `"affected_files": [`, `"suggested_next": {`.
 
 ### 4.3 Action on Issues
 

--- a/skills/aif-verify/references/CONTEXT-GATES-AND-OWNERSHIP.md
+++ b/skills/aif-verify/references/CONTEXT-GATES-AND-OWNERSHIP.md
@@ -41,6 +41,8 @@ Gate outputs must use:
 - `WARN` for non-blocking mismatches or missing optional files
 - `ERROR` for blocking violations
 
+For machine-readable orchestration, supported quality gates append a final `aif-gate-result` JSON block using lowercase `pass` / `warn` / `fail` status values. The human `WARN` / `ERROR` labels above remain readable report labels, not the machine contract.
+
 ### Architecture Gate
 - **Pass:** Changes follow documented module/layer boundaries.
 - **Warn:** Architecture document appears stale or mapping is ambiguous.
@@ -63,7 +65,7 @@ Gate outputs must use:
 - It evaluates the resolved rules hierarchy plus changed files/diff and reports `PASS` / `WARN` / `FAIL`.
 - Missing or non-applicable rules remain `WARN`.
 - Explicit hard-rule violations may become `FAIL`.
-- This does not change the `WARN` / `ERROR` reporting contract used by `/aif-commit`, `/aif-review`, and `/aif-verify`.
+- This does not change the human `WARN` / `ERROR` reporting labels used by `/aif-commit`, `/aif-review`, and `/aif-verify`; `/aif-review` and `/aif-verify` still append the shared machine-readable gate result when they act as quality gates.
 
 ## Threshold Decisions (Resolved)
 

--- a/skills/aif-verify/references/GATE-RESULT-CONTRACT.md
+++ b/skills/aif-verify/references/GATE-RESULT-CONTRACT.md
@@ -1,0 +1,88 @@
+# Machine-Readable Quality Gate Result Contract
+
+Quality gate skills keep their human-readable markdown report first, then append one final fenced JSON block for orchestrators.
+
+Orchestrators must parse the last `aif-gate-result` fenced block in the final gate output. Earlier fences in documentation, examples, or quoted prior output are illustrative and are not the gate result.
+
+Supported gates:
+- `verify` for `/aif-verify`
+- `review` for `/aif-review`
+- `security` for `/aif-security-checklist`
+- `rules` for `/aif-rules-check`
+
+The fenced block language must be exactly `aif-gate-result`.
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "verify",
+  "status": "fail",
+  "blocking": true,
+  "blockers": [
+    {
+      "id": "verify-task-1",
+      "severity": "error",
+      "file": "src/example.ts",
+      "summary": "Required behavior is missing."
+    }
+  ],
+  "affected_files": ["src/example.ts"],
+  "suggested_next": {
+    "command": "/aif-fix",
+    "reason": "Blocking implementation gaps remain."
+  }
+}
+```
+
+## Schema
+
+```text
+"schema_version": 1
+"gate": "verify|review|security|rules"
+"status": "pass|warn|fail"
+"blocking": true|false
+"blockers": [
+  {
+    "id": "stable-finding-id",
+    "severity": "error|warning",
+    "file": "optional/path",
+    "summary": "short human-readable summary"
+  }
+]
+"affected_files": ["path/to/file"]
+"suggested_next": {
+  "command": "/aif-fix|/aif-rules|/aif-architecture|/aif-roadmap|/aif-commit|null",
+  "reason": "short rationale or null"
+}
+```
+
+Rules:
+- The fenced block contains JSON only. Do not include comments, trailing commas, Markdown bullets, or prose inside it.
+- `status` must be one of `pass`, `warn`, or `fail`.
+- `blocking` must be a boolean.
+- `blockers` contains only findings that should block the current quality gate. Non-blocking notes stay in the human summary.
+- `blockers[].severity` uses the shared gate scale: `error` for blocking findings and `warning` only when policy treats a warning-class finding as blocking. Security domain severities map to this scale (`critical`/`high` -> `error`; `medium`/`low` -> non-blocking human warning unless policy escalates them).
+- `affected_files` is a predictable top-level array of files the gate actually evaluated or cited in the result. It is not limited to blocker files, and it should not include unrelated repository files. Use an empty array when no specific files apply.
+- `suggested_next.command` must come from the global allowlist: `/aif-fix`, `/aif-rules`, `/aif-architecture`, `/aif-roadmap`, `/aif-commit`, or `null`. Each gate may document a narrower subset for its own outputs.
+- The JSON block appears after the human-readable summary so manual workflows remain readable.
+
+## Status Semantics
+
+- `pass`: the gate completed without blocking or warning findings.
+- `warn`: the gate completed with non-blocking findings, missing optional context, ambiguous evidence, accepted skips, or advisory security/rules notes.
+- `fail`: the gate found at least one blocker that should stop commit, merge, deploy, or implementation handoff.
+
+## Suggested Next Command
+
+Allowed commands by gate:
+- `verify`: `/aif-fix`, `/aif-rules`, `/aif-architecture`, `/aif-roadmap`, `/aif-commit`, or `null`.
+- `review`: `/aif-fix`, `/aif-rules`, `/aif-architecture`, `/aif-roadmap`, `/aif-commit`, or `null`.
+- `security`: `/aif-fix` or `null`.
+- `rules`: `/aif-rules`, `/aif-fix`, or `null`.
+
+- `/aif-fix`: code, tests, config, or documentation must be corrected.
+- `/aif-rules`: rules are missing, ambiguous, or need a writer-owned update.
+- `/aif-architecture`: architecture context is stale or violated.
+- `/aif-roadmap`: roadmap context is stale, missing, or contradicted.
+- `/aif-commit`: the gate is clean and committing is the natural next step.
+- `null`: no AI Factory command is appropriate.


### PR DESCRIPTION
Implemented machine-readable quality gate summaries for #85.

Changes:
- Added a shared `aif-gate-result` JSON contract with `schema_version`, `gate`, `status`, `blocking`, `blockers`, `affected_files`, and `suggested_next`.
- Updated `/aif-verify`, `/aif-review`, `/aif-security-checklist`, and `/aif-rules-check` to append the final fenced JSON block after their human-readable reports.
- Added user-facing docs in `docs/quality-gates.md`.
- Added smoke coverage for the contract and wired it into `scripts/test-skills.sh`.
- Updated rules-check wording so human `PASS/WARN/FAIL` remains readable while machine output uses lowercase `pass|warn|fail`.

Verification:
- `npx tsc --noEmit` passes.
- `bash scripts/test-gate-result-contract.sh` passes: 51/51.
- `bash scripts/test-aif-rules-check.sh` passes: 17/17.
- `git diff --check origin/HEAD..HEAD` passes.
- `npm test` is currently environment-limited in Bash because `node` is not found from `/mnt/c/...`; the new gate-result smoke test itself passes inside the full suite.

closed #85 