### PR TITLE
feat(aif-plan): honor HANDOFF_BRANCH_PREPARED contract

### DIFF
--- a/skills/aif-plan/SKILL.md
+++ b/skills/aif-plan/SKILL.md
@@ -330,7 +330,7 @@ Docs policy semantics:
 
 - Skip this entire step. Branch validation already happened in Step 0.
 - The plan file path uses `HANDOFF_BRANCH_NAME` (slashes replaced by `-`) as the stem.
-- Do NOT run `git checkout`, `git pull`, `git checkout -b`, or `git worktree add`.
+- Do **NOT** run `git checkout`, `git pull`, `git checkout -b`, or `git worktree add`.
 
 **If `git.enabled = false` or `git.create_branches = false`:**
 

--- a/skills/aif-plan/SKILL.md
+++ b/skills/aif-plan/SKILL.md
@@ -18,7 +18,14 @@ Create an implementation plan for a feature or task. Two modes:
 
 ### Step 0 (pre): Detect Handoff Mode
 
-Determine Handoff mode, task ID, and branch contract. If the caller passed `HANDOFF_MODE`, `HANDOFF_TASK_ID`, `HANDOFF_BRANCH_PREPARED`, and `HANDOFF_BRANCH_NAME` as explicit text in the prompt, use those values. Otherwise, use the Bash tool to read the environment variables:
+Determine Handoff mode, task ID, and branch contract. Resolve each value independently so legacy callers that pass only `HANDOFF_MODE` and `HANDOFF_TASK_ID` still enter Handoff mode correctly:
+
+- `HANDOFF_MODE`: explicit prompt value if present; otherwise environment value; otherwise empty string.
+- `HANDOFF_TASK_ID`: explicit prompt value if present; otherwise environment value; otherwise empty string.
+- `HANDOFF_BRANCH_PREPARED`: explicit prompt value if present; otherwise environment value; otherwise `0`.
+- `HANDOFF_BRANCH_NAME`: explicit prompt value if present; otherwise environment value; otherwise empty string.
+
+Use the Bash tool only for values that were not passed explicitly in the prompt:
 
 ```
 Bash: printenv HANDOFF_MODE || true
@@ -44,7 +51,8 @@ Handoff owns branch creation at the agent-code level. The skill must NOT create 
 **If `HANDOFF_BRANCH_PREPARED` is `1`:**
 
 - Do **NOT** execute `git checkout`, `git pull`, or `git checkout -b`.
-- Do **NOT** create a worktree (ignore `--parallel` for branch creation purposes).
+- Treat `--parallel` as disabled for all downstream behavior.
+- Do **NOT** create a worktree.
 - Read `HANDOFF_BRANCH_NAME` from the prompt / env.
 - Validate strict equality:
   ```
@@ -331,6 +339,7 @@ Docs policy semantics:
 - Skip this entire step. Branch validation already happened in Step 0.
 - The plan file path uses `HANDOFF_BRANCH_NAME` (slashes replaced by `-`) as the stem.
 - Do **NOT** run `git checkout`, `git pull`, `git checkout -b`, or `git worktree add`.
+- Treat `--parallel` as disabled: do not create a worktree and do not auto-invoke `/aif-implement`.
 
 **If `git.enabled = false` or `git.create_branches = false`:**
 
@@ -542,7 +551,7 @@ Use the canonical template in `references/TASK-FORMAT.md` (Plan File Template).
 
 ### Step 6: Next Steps
 
-**Full mode + parallel (`--parallel`):** Automatically invoke `/aif-implement` — the whole point of parallel is autonomous end-to-end execution in an isolated worktree.
+**Full mode + parallel (`--parallel`):** Automatically invoke `/aif-implement` — the whole point of parallel is autonomous end-to-end execution in an isolated worktree. If `HANDOFF_BRANCH_PREPARED = 1`, treat `--parallel` as disabled and do not auto-invoke `/aif-implement`.
 
 ```
 /aif-implement

--- a/skills/aif-plan/SKILL.md
+++ b/skills/aif-plan/SKILL.md
@@ -18,11 +18,13 @@ Create an implementation plan for a feature or task. Two modes:
 
 ### Step 0 (pre): Detect Handoff Mode
 
-Determine Handoff mode and task ID. If the caller passed `HANDOFF_MODE` and `HANDOFF_TASK_ID` as explicit text in the prompt, use those values. Otherwise, use the Bash tool to read the environment variables:
+Determine Handoff mode, task ID, and branch contract. If the caller passed `HANDOFF_MODE`, `HANDOFF_TASK_ID`, `HANDOFF_BRANCH_PREPARED`, and `HANDOFF_BRANCH_NAME` as explicit text in the prompt, use those values. Otherwise, use the Bash tool to read the environment variables:
 
 ```
 Bash: printenv HANDOFF_MODE || true
 Bash: printenv HANDOFF_TASK_ID || true
+Bash: printenv HANDOFF_BRANCH_PREPARED || true
+Bash: printenv HANDOFF_BRANCH_NAME || true
 ```
 
 **Then check `HANDOFF_MODE`:**
@@ -34,6 +36,30 @@ The Handoff coordinator already manages status transitions and DB writes directl
 - **No interactive questions:** Do not use `AskUserQuestion` — use sensible defaults (verbose logging, yes to tests, yes to docs, skip roadmap linkage).
 - **Mode default:** If mode is not specified, default to `fast`.
 - **Plan annotation (MANDATORY):** If `HANDOFF_TASK_ID` is non-empty, you MUST insert `<!-- handoff:task:<HANDOFF_TASK_ID> -->` as the very first line of the plan file, before the title. This annotation links the plan to its Handoff task for bidirectional sync. **Omitting this annotation when HANDOFF_TASK_ID is set is a bug — verify before completing.**
+
+##### Branch ownership under Handoff (CRITICAL)
+
+Handoff owns branch creation at the agent-code level. The skill must NOT create or switch branches when Handoff has prepared one. Apply these rules:
+
+**If `HANDOFF_BRANCH_PREPARED` is `1`:**
+
+- Do **NOT** execute `git checkout`, `git pull`, or `git checkout -b`.
+- Do **NOT** create a worktree (ignore `--parallel` for branch creation purposes).
+- Read `HANDOFF_BRANCH_NAME` from the prompt / env.
+- Validate strict equality:
+  ```
+  Bash: git rev-parse --abbrev-ref HEAD
+  ```
+  The output must equal `HANDOFF_BRANCH_NAME` exactly. Do **not** accept partial matches, prefix matches, or "branch contains `/`" heuristics.
+- If the current branch does **not** match `HANDOFF_BRANCH_NAME`, STOP. Report a blocker in the plan summary:
+  > `Branch drift: expected <HANDOFF_BRANCH_NAME>, actual <current>.`
+  Do **NOT** "fix" drift by switching or creating a branch — Handoff classifies that as `BranchIsolationError` / `blocked_external`.
+- Use `HANDOFF_BRANCH_NAME` (with `/` replaced by `-`) as the full-mode plan filename stem: `<configured plans dir>/<HANDOFF_BRANCH_NAME-with-slashes-replaced>.md`. Skip the slug derivation in Step 1.2.
+
+**If `HANDOFF_MODE` is `1` but `HANDOFF_BRANCH_PREPARED` is unset or `0`:**
+
+- Fallback path for older Handoff clients that have not adopted the prepared-branch contract.
+- Execute Step 1.4 branch creation normally per `git.create_branches` config.
 
 #### When `HANDOFF_MODE` is NOT `1` (manual Claude Code session)
 
@@ -219,6 +245,8 @@ Task(subagent_type: Explore, model: sonnet, prompt:
 
 ### Step 1.2: Generate Full-Mode Plan Identifier
 
+**If `HANDOFF_BRANCH_PREPARED = 1`:** skip slug generation entirely. Use `HANDOFF_BRANCH_NAME` as the branch identifier and `<HANDOFF_BRANCH_NAME-with-slashes-replaced>.md` as the plan filename stem. Continue to Step 1.3.
+
 Generate a reusable slug from the description first. This slug is used for:
 
 - the git branch name when branch creation is enabled
@@ -297,6 +325,12 @@ Docs policy semantics:
 - Store the selected milestone name and a 1-sentence rationale for inclusion in the plan file
 
 ### Step 1.4: Optional Branch / Worktree Setup
+
+**If `HANDOFF_BRANCH_PREPARED = 1` (Handoff owns the branch):**
+
+- Skip this entire step. Branch validation already happened in Step 0.
+- The plan file path uses `HANDOFF_BRANCH_NAME` (slashes replaced by `-`) as the stem.
+- Do NOT run `git checkout`, `git pull`, `git checkout -b`, or `git worktree add`.
 
 **If `git.enabled = false` or `git.create_branches = false`:**
 

--- a/subagents/plan-polisher.md
+++ b/subagents/plan-polisher.md
@@ -27,11 +27,13 @@ Repo-specific rules:
 
 ## Handoff Integration
 
-Determine Handoff mode and task ID. The caller (plan-coordinator) passes these as explicit text in the prompt:
+Determine Handoff mode, task ID, and branch contract. The caller (plan-coordinator) passes these as explicit text in the prompt:
 
 ```
 HANDOFF_MODE: <value>
 HANDOFF_TASK_ID: <value>
+HANDOFF_BRANCH_PREPARED: <value>
+HANDOFF_BRANCH_NAME: <value>
 ```
 
 If the caller did NOT pass them, fall back to reading environment using the Bash tool:
@@ -39,11 +41,22 @@ If the caller did NOT pass them, fall back to reading environment using the Bash
 ```
 Bash: printenv HANDOFF_MODE || true
 Bash: printenv HANDOFF_TASK_ID || true
+Bash: printenv HANDOFF_BRANCH_PREPARED || true
+Bash: printenv HANDOFF_BRANCH_NAME || true
 ```
 
 **When `HANDOFF_MODE` is `1`** (autonomous Handoff agent):
 - **No interactive prompts:** Use defaults — do not attempt to ask the user questions.
 - **Plan annotation (MANDATORY):** If `HANDOFF_TASK_ID` is non-empty, you MUST insert `<!-- handoff:task:<HANDOFF_TASK_ID> -->` as the very first line of the plan file, before the title. This annotation links the plan to its Handoff task for bidirectional sync. **Omitting this annotation when HANDOFF_TASK_ID is set is a bug.**
+
+**Branch ownership under Handoff (CRITICAL):**
+
+- If `HANDOFF_BRANCH_PREPARED = 1`:
+  - Do **NOT** execute `git checkout`, `git pull`, `git checkout -b`, or create worktrees. Handoff already prepared the branch.
+  - Run `Bash: git rev-parse --abbrev-ref HEAD` and verify strict equality with `HANDOFF_BRANCH_NAME`. Do **not** accept partial matches or "branch contains `/`" heuristics — false positives on unrelated branches like `release/v1` would silently corrupt state.
+  - On mismatch, STOP. Record a blocker in the plan summary: `Branch drift: expected <HANDOFF_BRANCH_NAME>, actual <current>.` Do not switch or create a branch — Handoff classifies that as `BranchIsolationError` / `blocked_external`.
+  - Plan filename stem is `HANDOFF_BRANCH_NAME` with `/` replaced by `-`. Skip the slug-derivation logic below.
+- If `HANDOFF_MODE = 1` but `HANDOFF_BRANCH_PREPARED` is unset or `0`: fallback path for older Handoff clients — apply the standalone "Branch creation (full mode only)" rules below.
 
 **When `HANDOFF_MODE` is NOT `1`** (manual session):
 - If polishing an existing plan that already has a `<!-- handoff:task:<id> -->` annotation, preserve it on the first line when rewriting the file.
@@ -86,6 +99,7 @@ If the config file is missing, use the same defaults as `/aif-plan`:
 - git.branch_prefix: `feature/`
 
 Branch creation (full mode only):
+- **If `HANDOFF_BRANCH_PREPARED = 1` → skip this entire block.** Handoff owns the branch; validation already happened in the Handoff Integration section above. Do NOT create, switch, pull, or worktree. Use `HANDOFF_BRANCH_NAME` (slashes replaced by `-`) as the plan filename stem.
 - In full mode, before determining the plan file path, you MUST ensure a feature branch exists.
 - If `git.enabled = false` or `git.create_branches = false` → do NOT create or switch branches. Derive a slug from the request and use that slug for the full-mode plan filename under the resolved plans directory.
 - Treat the current branch as an AI Factory feature branch only if it starts with the configured `git.branch_prefix`. If `git.branch_prefix` is missing, use the default `feature/` prefix. Do not infer feature-branch status merely from the presence of `/` in the branch name.
@@ -104,6 +118,7 @@ Branch creation (full mode only):
 
 Plan file location (CRITICAL — do not deviate):
 - If the caller provided an explicit `@<path>` → use that exact path. This overrides mode-based rules.
+- **Handoff-prepared branch** (`HANDOFF_BRANCH_PREPARED = 1`) → `<resolved plans dir>/<HANDOFF_BRANCH_NAME-with-slashes-replaced>.md`. Take the branch name from `HANDOFF_BRANCH_NAME`, not from `git rev-parse` (the strict-equality check above already proved they match).
 - **Fast mode** → always the resolved `paths.plan` (default: `.ai-factory/PLAN.md`). No other filename.
 - **Full mode with branch creation** → `<resolved plans dir>/<branch-name>.md` where `<branch-name>` is the current git branch name (with `/` replaced by `-`). The branch must exist at this point (created above or already checked out).
 - **Full mode without branch creation** (`git.enabled = false` or `git.create_branches = false`) → `<resolved plans dir>/<slug>.md`.
@@ -132,7 +147,7 @@ Scope rule:
 
 Workflow:
 1. Parse the user request like `/aif-plan`.
-2. If full mode → ensure feature branch exists using the "Branch creation" rules above.
+2. If `HANDOFF_BRANCH_PREPARED = 1` → validate strict equality of current branch vs `HANDOFF_BRANCH_NAME`; on mismatch STOP and report blocker. Skip step 3-branch-side actions. If full mode without Handoff prep → ensure feature branch exists using the "Branch creation" rules above.
 3. Determine the target file path using the "Plan file location" rules above.
 4. Explore the codebase using the "Local exploration protocol" (Read, Glob, Grep, Bash) to gather context for the plan.
 5. Generate the plan content following the `/aif-plan` skill template and rules.

--- a/subagents/plan-polisher.md
+++ b/subagents/plan-polisher.md
@@ -27,7 +27,7 @@ Repo-specific rules:
 
 ## Handoff Integration
 
-Determine Handoff mode, task ID, and branch contract. The caller (plan-coordinator) passes these as explicit text in the prompt:
+Determine Handoff mode, task ID, and branch contract. Resolve each value independently. The caller (plan-coordinator) may pass any of these as explicit text in the prompt:
 
 ```
 HANDOFF_MODE: <value>
@@ -36,7 +36,12 @@ HANDOFF_BRANCH_PREPARED: <value>
 HANDOFF_BRANCH_NAME: <value>
 ```
 
-If the caller did NOT pass them, fall back to reading environment using the Bash tool:
+For each value not passed explicitly, fall back to reading environment using the Bash tool. Defaults after explicit/env lookup:
+
+- `HANDOFF_MODE`: empty string.
+- `HANDOFF_TASK_ID`: empty string.
+- `HANDOFF_BRANCH_PREPARED`: `0`.
+- `HANDOFF_BRANCH_NAME`: empty string.
 
 ```
 Bash: printenv HANDOFF_MODE || true
@@ -52,6 +57,7 @@ Bash: printenv HANDOFF_BRANCH_NAME || true
 **Branch ownership under Handoff (CRITICAL):**
 
 - If `HANDOFF_BRANCH_PREPARED = 1`:
+  - Treat `--parallel` as disabled for all downstream behavior.
   - Do **NOT** execute `git checkout`, `git pull`, `git checkout -b`, or create worktrees. Handoff already prepared the branch.
   - Run `Bash: git rev-parse --abbrev-ref HEAD` and verify strict equality with `HANDOFF_BRANCH_NAME`. Do **not** accept partial matches or "branch contains `/`" heuristics — false positives on unrelated branches like `release/v1` would silently corrupt state.
   - On mismatch, STOP. Record a blocker in the plan summary: `Branch drift: expected <HANDOFF_BRANCH_NAME>, actual <current>.` Do not switch or create a branch — Handoff classifies that as `BranchIsolationError` / `blocked_external`.


### PR DESCRIPTION
## Summary
- `aif-plan` and `plan-polisher` now respect Handoff's prepared-branch contract: when `HANDOFF_BRANCH_PREPARED=1`, the skill no longer runs `git checkout -b`, validates strict equality against `HANDOFF_BRANCH_NAME`, and uses that name as the plan filename stem.
- On branch drift, the skill STOPS and reports a blocker instead of "fixing" by switching/creating — matching the `BranchIsolationError` / `blocked_external` classification added in aif-handoff#85.
- Fallback path preserved for older Handoff clients (HANDOFF_MODE=1 without `HANDOFF_BRANCH_PREPARED`) and standalone `/aif-plan` runs (Step 1.4 still owns branch creation per `git.create_branches`).

Closes #96. Pairs with [aif-handoff#85](https://github.com/lee-to/aif-handoff/pull/85).

## Test plan
- [ ] Standalone `/aif-plan full <desc>` on `main` with `git.create_branches: true` still creates `feature/<slug>` and writes `<plans>/feature-<slug>.md`
- [ ] Standalone `/aif-plan full <desc>` with `git.create_branches: false` skips branch ops and writes `<plans>/<slug>.md`
- [ ] Handoff run injects `HANDOFF_MODE=1 HANDOFF_BRANCH_PREPARED=1 HANDOFF_BRANCH_NAME=feature/foo-abc123` → skill writes `<plans>/feature-foo-abc123.md` on the prepared branch, no `git checkout -b`, no double-branch
- [ ] Drift case (Handoff prepares `feature/foo-abc123`, current branch is `main`) → skill reports `Branch drift: expected ..., actual ...` blocker and does not switch
- [ ] Legacy Handoff client (`HANDOFF_MODE=1`, no `HANDOFF_BRANCH_PREPARED`) → fallback to Step 1.4 branch creation per config
- [ ] `plan-polisher` subagent receives same env/prompt vars and applies identical gating

🤖 Generated with [Claude Code](https://claude.com/claude-code)