### PR TITLE
feat(schema): publish extension manifest JSON schema

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -166,7 +166,7 @@ my-extension/
 
 ```json
 {
-  "$schema": "./node_modules/ai-factory/schemas/extension.schema.json",
+  "$schema": "https://raw.githubusercontent.com/lee-to/ai-factory/2.x/schemas/extension.schema.json",
   "name": "aif-ext-example",
   "version": "1.0.0",
   "description": "Example extension",
@@ -228,7 +228,23 @@ my-extension/
 
 Only `name` and `version` are required. All other fields are optional.
 
-AI Factory publishes the extension manifest schema at `schemas/extension.schema.json` in the npm package. Extension authors may add an optional `$schema` property for editor/tooling validation; use a relative path that works from your manifest location, or the schema URI when your tooling resolves it.
+AI Factory publishes the extension manifest schema at `schemas/extension.schema.json` in the npm package. Extension authors may add an optional `$schema` property for editor/tooling validation.
+
+Use the public schema URL when the extension should work regardless of whether the `ai-factory` CLI is installed locally or globally:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/lee-to/ai-factory/2.x/schemas/extension.schema.json"
+}
+```
+
+If your extension project installs `ai-factory` as a local dependency and you want offline or package-version-aligned validation, use the package-local schema path instead, adjusting the relative path from your `extension.json` location:
+
+```json
+{
+  "$schema": "./node_modules/ai-factory/schemas/extension.schema.json"
+}
+```
 
 The schema validates the public manifest shape: commands, runtime definitions, runtime-aware `agentFiles`, injections, skills, replacements, and MCP server templates. Install-time semantics still run in AI Factory itself, including runtime existence, safe relative paths, extension matching, duplicate ownership, and whether a runtime supports managed agent files.
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -166,6 +166,7 @@ my-extension/
 
 ```json
 {
+  "$schema": "./node_modules/ai-factory/schemas/extension.schema.json",
   "name": "aif-ext-example",
   "version": "1.0.0",
   "description": "Example extension",
@@ -227,10 +228,15 @@ my-extension/
 
 Only `name` and `version` are required. All other fields are optional.
 
+AI Factory publishes the extension manifest schema at `schemas/extension.schema.json` in the npm package. Extension authors may add an optional `$schema` property for editor/tooling validation; use a relative path that works from your manifest location, or the schema URI when your tooling resolves it.
+
+The schema validates the public manifest shape: commands, runtime definitions, runtime-aware `agentFiles`, injections, skills, replacements, and MCP server templates. Install-time semantics still run in AI Factory itself, including runtime existence, safe relative paths, extension matching, duplicate ownership, and whether a runtime supports managed agent files.
+
 ### Manifest Fields
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `$schema` | `string` | Optional schema reference for editor and tooling validation. |
 | `name` | `string` | **Required.** Unique extension name. Allowed characters: letters, digits, `_`, `-`, `.`, `@`, `/`. No `..` or absolute paths. |
 | `version` | `string` | **Required.** Version string (SemVer is recommended). |
 | `description` | `string` | Human-readable description. |

--- a/examples/extensions/aif-ext-hello/extension.json
+++ b/examples/extensions/aif-ext-hello/extension.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../../schemas/extension.schema.json",
   "name": "aif-ext-hello",
   "version": "1.0.0",
   "description": "Example extension: command, injection, custom skills, skill replacement, MCP server, custom runtime, and runtime-aware agent files",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/inquirer": "^9.0.7",
         "@types/node": "^20.11.0",
         "@types/semver": "^7.7.1",
+        "ajv": "^8.20.0",
         "knip": "^5.85.0",
         "typescript": "^5.3.3"
       },
@@ -918,9 +919,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test": "node scripts/run-bash-test.mjs scripts/test-skills.sh",
     "test:init": "node scripts/run-bash-test.mjs scripts/test-init.sh",
     "test:update": "node scripts/run-bash-test.mjs scripts/test-update.sh",
+    "test:extension-schema": "node scripts/test-extension-schema.mjs",
+    "test:extensions": "node scripts/run-bash-test.mjs scripts/test-extensions.sh",
     "lint:unused": "tsc --noEmit --noUnusedLocals --noUnusedParameters",
     "lint:dead": "knip --reporter compact",
     "lint": "npm run lint:unused && npm run lint:dead",
@@ -51,6 +53,7 @@
     "skills",
     "!skills/**/tests",
     "!skills/**/tests/**",
+    "schemas",
     "subagents",
     "mcp"
   ],
@@ -83,6 +86,7 @@
     "@types/inquirer": "^9.0.7",
     "@types/node": "^20.11.0",
     "@types/semver": "^7.7.1",
+    "ajv": "^8.20.0",
     "knip": "^5.85.0",
     "typescript": "^5.3.3"
   }

--- a/schemas/extension.schema.json
+++ b/schemas/extension.schema.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ai-factory.dev/schemas/extension.schema.json",
+  "title": "AI Factory Extension Manifest",
+  "description": "Manifest file for an AI Factory extension.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name", "version"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional JSON Schema reference for editor and tooling support."
+    },
+    "name": {
+      "type": "string",
+      "description": "Unique extension name."
+    },
+    "version": {
+      "type": "string",
+      "description": "Extension version."
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable extension description."
+    },
+    "commands": {
+      "type": "array",
+      "description": "Custom CLI commands provided by this extension.",
+      "items": {
+        "$ref": "#/$defs/ExtensionCommand"
+      }
+    },
+    "agents": {
+      "type": "array",
+      "description": "Runtime definitions provided by this extension.",
+      "items": {
+        "$ref": "#/$defs/ExtensionAgentDef"
+      }
+    },
+    "agentFiles": {
+      "type": "array",
+      "description": "Runtime-aware agent files copied into matching runtime agent directories.",
+      "items": {
+        "$ref": "#/$defs/ExtensionAgentFile"
+      }
+    },
+    "injections": {
+      "type": "array",
+      "description": "Content injections applied to installed skills.",
+      "items": {
+        "$ref": "#/$defs/ExtensionInjection"
+      }
+    },
+    "skills": {
+      "type": "array",
+      "description": "Paths to skill directories within the extension.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "replaces": {
+      "type": "object",
+      "description": "Map of extension skill paths to built-in skill names they replace.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "mcpServers": {
+      "type": "array",
+      "description": "MCP servers provided by this extension.",
+      "items": {
+        "$ref": "#/$defs/ExtensionMcpServer"
+      }
+    }
+  },
+  "$defs": {
+    "ExtensionCommand": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "description", "module"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Command name used as the CLI subcommand."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable command description."
+        },
+        "module": {
+          "type": "string",
+          "description": "Relative path to the JavaScript module implementing this command."
+        }
+      }
+    },
+    "ExtensionAgentDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "displayName",
+        "configDir",
+        "skillsDir",
+        "settingsFile",
+        "supportsMcp",
+        "skillsCliAgent"
+      ],
+      "dependentRequired": {
+        "agentsDir": ["agentFileExtension"],
+        "agentFileExtension": ["agentsDir"]
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique runtime identifier."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-readable runtime name."
+        },
+        "configDir": {
+          "type": "string",
+          "description": "Runtime configuration directory."
+        },
+        "skillsDir": {
+          "type": "string",
+          "description": "Directory where skills are installed for this runtime."
+        },
+        "agentsDir": {
+          "type": "string",
+          "description": "Runtime-local directory for custom agent files."
+        },
+        "agentFileExtension": {
+          "type": "string",
+          "description": "Required file extension for runtime agent files.",
+          "enum": [".md", ".toml"]
+        },
+        "settingsFile": {
+          "type": ["string", "null"],
+          "description": "Runtime settings file path, or null when not applicable."
+        },
+        "supportsMcp": {
+          "type": "boolean",
+          "description": "Whether this runtime supports MCP server configuration."
+        },
+        "skillsCliAgent": {
+          "type": ["string", "null"],
+          "description": "Agent id for skills CLI integration, or null when not applicable."
+        }
+      }
+    },
+    "ExtensionAgentFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runtime", "source", "target"],
+      "properties": {
+        "runtime": {
+          "type": "string",
+          "description": "Runtime id that should receive this agent file."
+        },
+        "source": {
+          "type": "string",
+          "description": "Relative path to the agent file inside the extension."
+        },
+        "target": {
+          "type": "string",
+          "description": "Runtime-local target path under the runtime agents directory."
+        }
+      }
+    },
+    "ExtensionInjection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "position", "file"],
+      "properties": {
+        "target": {
+          "type": "string",
+          "description": "Target skill name for the injection."
+        },
+        "position": {
+          "type": "string",
+          "description": "Where to place injected content.",
+          "enum": ["append", "prepend"]
+        },
+        "file": {
+          "type": "string",
+          "description": "Relative path to the injection content file."
+        }
+      }
+    },
+    "ExtensionMcpServer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "template"],
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "MCP server key used in agent settings."
+        },
+        "template": {
+          "description": "MCP server config as a relative JSON template path or inline config.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/McpServerConfig"
+            }
+          ]
+        },
+        "instruction": {
+          "type": "string",
+          "description": "Optional setup instruction shown after MCP configuration."
+        }
+      }
+    },
+    "McpServerConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Executable command for the MCP server."
+        },
+        "args": {
+          "type": "array",
+          "description": "Command-line arguments for the MCP server.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "object",
+          "description": "Environment variables for the MCP server process.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/extension.schema.json
+++ b/schemas/extension.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ai-factory.dev/schemas/extension.schema.json",
+  "$id": "https://raw.githubusercontent.com/lee-to/ai-factory/2.x/schemas/extension.schema.json",
   "title": "AI Factory Extension Manifest",
   "description": "Manifest file for an AI Factory extension.",
   "type": "object",

--- a/scripts/test-extension-schema.mjs
+++ b/scripts/test-extension-schema.mjs
@@ -9,6 +9,8 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(scriptDir, '..');
 const schemaPath = path.join(rootDir, 'schemas', 'extension.schema.json');
 const manifestPath = path.join(rootDir, 'examples', 'extensions', 'aif-ext-hello', 'extension.json');
+const docsPath = path.join(rootDir, 'docs', 'extensions.md');
+const publicSchemaId = 'https://raw.githubusercontent.com/lee-to/ai-factory/2.x/schemas/extension.schema.json';
 const packedSchemaPath = 'schemas/extension.schema.json';
 
 function readJson(filePath) {
@@ -28,11 +30,32 @@ function assertFileExists(filePath, label) {
 function compileSchema() {
   assertFileExists(schemaPath, 'Extension schema');
   const schema = readJson(schemaPath);
+  assert.equal(schema.$id, publicSchemaId, 'Extension schema $id must be a public, resolvable URI');
   const ajv = new Ajv2020({
     allErrors: true,
     strict: true,
   });
   return ajv.compile(schema);
+}
+
+function assertSchemaReferencesDocumented() {
+  assertFileExists(docsPath, 'Extensions documentation');
+  const docs = fs.readFileSync(docsPath, 'utf8');
+
+  assert.ok(
+    docs.includes(publicSchemaId),
+    `Extensions documentation must recommend the public schema URL: ${publicSchemaId}`,
+  );
+  assert.ok(
+    docs.includes('./node_modules/ai-factory/schemas/extension.schema.json'),
+    'Extensions documentation must document the package-local schema path for local installs',
+  );
+  assert.ok(
+    docs.includes('globally'),
+    'Extensions documentation must distinguish global CLI installs from local package installs',
+  );
+
+  console.log('pass: extension schema references documented for global and local installs');
 }
 
 function assertExampleManifestValid(validate) {
@@ -94,3 +117,4 @@ const validate = compileSchema();
 assertExampleManifestValid(validate);
 assertStringAgentFilesInvalid(validate);
 assertSchemaPacked();
+assertSchemaReferencesDocumented();

--- a/scripts/test-extension-schema.mjs
+++ b/scripts/test-extension-schema.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptDir, '..');
+const schemaPath = path.join(rootDir, 'schemas', 'extension.schema.json');
+const manifestPath = path.join(rootDir, 'examples', 'extensions', 'aif-ext-hello', 'extension.json');
+const packedSchemaPath = 'schemas/extension.schema.json';
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function formatErrors(errors) {
+  return (errors ?? [])
+    .map(error => `${error.instancePath || '/'} ${error.message} (${error.keyword})`)
+    .join('; ');
+}
+
+function assertFileExists(filePath, label) {
+  assert.ok(fs.existsSync(filePath), `${label} not found: ${filePath}`);
+}
+
+function compileSchema() {
+  assertFileExists(schemaPath, 'Extension schema');
+  const schema = readJson(schemaPath);
+  const ajv = new Ajv2020({
+    allErrors: true,
+    strict: true,
+  });
+  return ajv.compile(schema);
+}
+
+function assertExampleManifestValid(validate) {
+  assertFileExists(manifestPath, 'Example extension manifest');
+  const manifest = readJson(manifestPath);
+  const isValid = validate(manifest);
+
+  assert.ok(
+    isValid,
+    `Example manifest must validate against ${schemaPath}: ${formatErrors(validate.errors)}`,
+  );
+
+  console.log(`pass: example manifest validates (${manifestPath})`);
+}
+
+function assertStringAgentFilesInvalid(validate) {
+  const invalidManifest = {
+    name: 'aif-ext-invalid-agent-files',
+    version: '1.0.0',
+    agentFiles: ['bad'],
+  };
+  const isValid = validate(invalidManifest);
+
+  assert.equal(isValid, false, 'agentFiles as an array of strings must fail schema validation');
+  assert.ok(
+    (validate.errors ?? []).some(error => error.instancePath === '/agentFiles/0'),
+    `agentFiles string-array failure should point to /agentFiles/0: ${formatErrors(validate.errors)}`,
+  );
+
+  console.log('pass: negative agentFiles string-array fixture fails validation');
+}
+
+function assertSchemaPacked() {
+  const npmExecPath = process.env.npm_execpath;
+  const command = npmExecPath ? process.execPath : (process.platform === 'win32' ? 'npm.cmd' : 'npm');
+  const args = [
+    ...(npmExecPath ? [npmExecPath] : []),
+    'pack',
+    '--dry-run',
+    '--json',
+  ];
+  const output = execFileSync(command, args, {
+    cwd: rootDir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const [packResult] = JSON.parse(output);
+  const files = (packResult?.files ?? []).map(file => file.path);
+
+  assert.ok(
+    files.includes(packedSchemaPath),
+    `npm pack --dry-run --json must include ${packedSchemaPath}; packed files sample: ${files.slice(0, 20).join(', ')}`,
+  );
+
+  console.log(`pass: npm package dry-run includes ${packedSchemaPath}`);
+}
+
+const validate = compileSchema();
+assertExampleManifestValid(validate);
+assertStringAgentFilesInvalid(validate);
+assertSchemaPacked();

--- a/scripts/test-extensions.sh
+++ b/scripts/test-extensions.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+node "$ROOT_DIR/scripts/test-extension-schema.mjs"
+
 ROOT_DIR="$ROOT_DIR" node --input-type=module <<'EOF'
 import assert from 'node:assert/strict';
 import path from 'node:path';


### PR DESCRIPTION
## Summary

Closes #86.

- Added `schemas/extension.schema.json` for public `extension.json` manifests using JSON Schema draft 2020-12 and `$defs`.
- Covered runtime-aware fields including `agentFiles`, `agents[].agentsDir`, `agents[].agentFileExtension`, and MCP server templates.
- Added `$schema` to the example extension manifest.
- Added Ajv-based schema smoke tests for the positive example and negative `agentFiles: ["bad"]` case.
- Ensured the schema is included in the npm package via `package.json.files` and `npm pack --dry-run --json`.
- Documented schema usage and the boundary between schema validation and AI Factory runtime semantic checks.

## Scope Notes

This intentionally targets `extension.json` only. It does not add or edit `.ai-factory.json` schema/config validation.

## Verification

- `npm run build`
- `npm run test:extensions`
- `npm run lint`
- `npm pack --dry-run --json`
- `git diff --check`
- `npm audit --omit=dev`
