### PR TITLE
Make aif-qa honor UI and artifact language settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,7 @@ Offers to delete PLAN.md when done (keeps feature-*.md)
 Reads .ai-factory/DESCRIPTION.md + ARCHITECTURE.md + config.yaml for context
     ↓
 change-summary → collects git diff, checks commit/diff size limits, explores key files in parallel
+               → if git is disabled or refs cannot be resolved, asks for manual change context instead of failing
                → saves .ai-factory/qa/<branch-slug>/change-summary.md
     ↓
 test-plan      → reads change-summary → determines scope and test types → saves test-plan.md

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -53,8 +53,8 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
 | `language.ui` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-reference`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa` | UI language for prompts, questions, and summaries; `/aif` resolves it before downstream setup questions |
-| `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-roadmap`, `/aif-implement`, `/aif-loop`, `/aif-docs`, `/aif-evolve` | Language for generated artifacts; `/aif` locks it before the first setup artifact so DESCRIPTION/rules base/AGENTS/ARCHITECTURE stay aligned in one run |
-| `language.technical_terms` | `keep` | No dedicated built-in reader yet | Present in schema and template; `/aif` preserves an existing value when present and otherwise writes the default `keep`, while the wider translation policy stays reserved for future use |
+| `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-roadmap`, `/aif-implement`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-qa` | Language for generated artifacts; `/aif` locks it before the first setup artifact so DESCRIPTION/rules base/AGENTS/ARCHITECTURE stay aligned in one run; `/aif-qa` uses it for QA markdown artifacts with fallback to `language.ui` |
+| `language.technical_terms` | `keep` | `/aif-qa` | Present in schema and template; `/aif` preserves an existing value when present and otherwise writes the default `keep`; `/aif-qa` uses it to decide whether human-readable QA terminology should stay in English, be translated, or use mixed style |
 
 ### `paths`
 
@@ -92,7 +92,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
-| `git.enabled` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check` | Disables branch/worktree assumptions when false |
+| `git.enabled` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-qa` | Disables branch/worktree assumptions when false; `/aif-qa` switches to manual change context instead of git diffing |
 | `git.base_branch` | `main` with auto-detect fallback | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check` | Target branch for diff, merge, and verification guidance |
 | `git.create_branches` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify` | Full plans may still exist when false; they just skip auto branch creation |
 | `git.branch_prefix` | `feature/` | `/aif`, `/aif-plan` | Prefix for auto-created full-plan branches |
@@ -134,7 +134,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | `/aif-evolve` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.rules`, `paths.patches`, `paths.evolutions`, `language.ui`, `language.artifacts`, `rules.base`, `rules.<area>` |
 | `/aif-reference` | Yes | No | `paths.references`, `paths.rules_file`, `language.ui` |
 | `/aif-security-checklist` | Yes | No | `paths.security`, `language.ui` |
-| `/aif-qa` | Yes | No | `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, `git.base_branch` |
+| `/aif-qa` | Yes | No | `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, `language.artifacts`, `language.technical_terms`, `git.enabled`, `git.base_branch` |
 
 ### Config-Agnostic Built-ins
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -60,8 +60,8 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
-| `paths.description` | `.ai-factory/DESCRIPTION.md` | `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-docs` | Core project description artifact |
-| `paths.architecture` | `.ai-factory/ARCHITECTURE.md` | `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-docs`, `/aif-loop`, `/aif-evolve` | Architecture source of truth |
+| `paths.description` | `.ai-factory/DESCRIPTION.md` | `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-docs`, `/aif-qa` | Core project description artifact |
+| `paths.architecture` | `.ai-factory/ARCHITECTURE.md` | `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-docs`, `/aif-loop`, `/aif-evolve`, `/aif-qa` | Architecture source of truth |
 | `paths.docs` | `docs/` | `/aif-docs` | Detailed docs directory; `README.md` stays fixed in project root |
 | `paths.roadmap` | `.ai-factory/ROADMAP.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-loop` | Strategic roadmap artifact |
 | `paths.research` | `.ai-factory/RESEARCH.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-improve`, `/aif-loop` | Persisted exploration context |
@@ -93,7 +93,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
 | `git.enabled` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-qa` | Disables branch/worktree assumptions when false; `/aif-qa` switches to manual change context instead of git diffing |
-| `git.base_branch` | `main` with auto-detect fallback | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check` | Target branch for diff, merge, and verification guidance |
+| `git.base_branch` | `main` with auto-detect fallback | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-qa` | Target branch for diff, merge, and verification guidance |
 | `git.create_branches` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify` | Full plans may still exist when false; they just skip auto branch creation |
 | `git.branch_prefix` | `feature/` | `/aif`, `/aif-plan` | Prefix for auto-created full-plan branches |
 | `git.skip_push_after_commit` | `false` | `/aif-commit` | When true, `/aif-commit` skips push prompt and ends after local commit |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,7 +114,7 @@ language:
   # Language for generated artifacts (plans, specs, documentation)
   artifacts: en
 
-  # How to handle technical terms: keep | translate
+  # How to handle technical terms: keep | translate | mixed
   technical_terms: keep
 
 # Path Configuration (all relative to project root)

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -539,11 +539,11 @@ Each stage builds on the previous one and saves its artifact to `paths.qa/<branc
 | `test-plan`      | `test-plan.md`      | Scoped test plan with types and acceptance criteria |
 | `test-cases`     | `test-cases.md`     | Concrete TC-NNN scenarios with steps and test data  |
 
-For large branches the `change-summary` stage checks commit count (>20) and diff size (>1000 lines) before proceeding — both gates ask the user how to continue rather than silently truncating.
+For large branches the `change-summary` stage checks commit count (>20) and diff size (>1000 lines) before proceeding — both gates ask the user how to continue rather than silently truncating. When `git.enabled=false` or git refs cannot be resolved, `/aif-qa` asks for manual change context instead of failing on git commands.
 
 The `--all` flag runs all three stages in sequence without inter-stage prompts. If any stage fails, the pipeline stops and reports the failing stage.
 
-- Config policy: config-aware; reads `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, `git.base_branch`
+- Config policy: config-aware; reads `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, `language.artifacts`, `language.technical_terms`, `git.enabled`, `git.base_branch`
 
 ## See Also
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -180,6 +180,8 @@ Optional conventions step: use `/aif-rules` to append or refine project-wide axi
 | `/aif-verify` | Post-implementation quality check | No | No (reads existing) |
 | `/aif-qa` | Manual QA for a feature/fix: change summary → test plan → test cases | No | `paths.qa/<branch-slug>/*.md` (default: `.ai-factory/qa/<branch-slug>/`) |
 
+`/aif-qa change-summary` normally derives context from git diffs. When `git.enabled=false` or the target/base refs cannot be resolved locally or through `origin/<base_branch>`, it asks for manual change context instead of failing on git commands.
+
 ## Artifact Ownership and Context Gates
 
 Ownership is command-scoped to avoid conflicting writers:

--- a/scripts/test-aif-qa.sh
+++ b/scripts/test-aif-qa.sh
@@ -314,6 +314,14 @@ else
     fail "docs must list /aif-qa as reading language.artifacts, language.technical_terms, git.enabled, and git.base_branch"
 fi
 
+if grep -F '| `paths.description` |' "$config_reference_doc" | grep -Fq '/aif-qa' \
+    && grep -F '| `paths.architecture` |' "$config_reference_doc" | grep -Fq '/aif-qa' \
+    && grep -F '| `git.base_branch` |' "$config_reference_doc" | grep -Fq '/aif-qa'; then
+    pass "config-reference key rows list /aif-qa for description, architecture, and git.base_branch"
+else
+    fail "config-reference key rows must list /aif-qa for paths.description, paths.architecture, and git.base_branch"
+fi
+
 # Contract: allowed-tools covers both Bash(git *) and Bash(mkdir *)
 # (an earlier PR review caught a mismatch between instructions and permissions)
 allowed_line=$(grep -E '^allowed-tools:' "$SKILL_DIR/SKILL.md" || true)

--- a/scripts/test-aif-qa.sh
+++ b/scripts/test-aif-qa.sh
@@ -155,19 +155,79 @@ fi
 change_summary_ref="$SKILL_DIR/references/CHANGE-SUMMARY.md"
 test_plan_ref="$SKILL_DIR/references/TEST-PLAN.md"
 test_cases_ref="$SKILL_DIR/references/TEST-CASES.md"
+config_reference_doc="$ROOT_DIR/docs/config-reference.md"
+skills_doc="$ROOT_DIR/docs/skills.md"
 
-# Contract: follow-up handoff commands keep the exact prompt option lines intact
-assert_exact_line \
-    "$change_summary_ref" \
-    '1. Yes — run /aif-qa test-plan <resolved_branch>' \
-    "CHANGE-SUMMARY.md keeps exact test-plan handoff line" \
-    "CHANGE-SUMMARY.md must contain the exact handoff line '1. Yes — run /aif-qa test-plan <resolved_branch>'"
+# Contract: /aif-qa follows the same language.ui/language.artifacts split as other artifact writers.
+if grep -Fq 'ui_language' "$SKILL_DIR/SKILL.md" \
+    && grep -Fq 'artifact_language' "$SKILL_DIR/SKILL.md" \
+    && grep -Fq 'language.artifacts' "$SKILL_DIR/SKILL.md" \
+    && grep -Fq 'language.technical_terms' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md defines resolved UI, artifact, and technical-terms language policy"
+else
+    fail "SKILL.md must define ui_language, artifact_language, language.artifacts, and language.technical_terms"
+fi
 
-assert_exact_line \
-    "$test_plan_ref" \
-    '1. Yes — run /aif-qa test-cases <resolved_branch>' \
-    "TEST-PLAN.md keeps exact test-cases handoff line" \
-    "TEST-PLAN.md must contain the exact handoff line '1. Yes — run /aif-qa test-cases <resolved_branch>'"
+if grep -Fq 'All AskUserQuestion prompts, user-visible explanations, stage completion messages, and next-step guidance MUST be written in `ui_language`.' "$SKILL_DIR/SKILL.md" \
+    && grep -Fq 'All generated artifacts (`change-summary.md`, `test-plan.md`, `test-cases.md`) MUST be written in `artifact_language`.' "$SKILL_DIR/SKILL.md" \
+    && grep -Fq 'Templates define structure, not language.' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md enforces UI vs artifact language split"
+else
+    fail "SKILL.md must enforce UI prompts in ui_language and QA artifacts in artifact_language"
+fi
+
+# Contract: user prompts are semantic instructions, not hardcoded English output.
+if grep -R '^AskUserQuestion:' "$SKILL_DIR/SKILL.md" "$SKILL_DIR/references" >/dev/null; then
+    fail "aif-qa must not contain hardcoded 'AskUserQuestion:' output lines"
+else
+    pass "aif-qa prompt blocks are not hardcoded English AskUserQuestion output"
+fi
+
+if grep -Fq 'AskUserQuestion in `ui_language`' "$SKILL_DIR/SKILL.md" \
+    && grep -Fq 'AskUserQuestion in `ui_language`' "$change_summary_ref" \
+    && grep -Fq 'AskUserQuestion in `ui_language`' "$test_plan_ref" \
+    && grep -Fq 'AskUserQuestion in `ui_language`' "$test_cases_ref"; then
+    pass "SKILL and references require AskUserQuestion text in ui_language"
+else
+    fail "SKILL and all references must require AskUserQuestion text in ui_language"
+fi
+
+# Contract: handoff commands remain literal while the surrounding prose is localized.
+if grep -Fq '`/aif-qa test-plan <resolved_branch>`' "$change_summary_ref"; then
+    pass "CHANGE-SUMMARY.md preserves test-plan handoff command"
+else
+    fail "CHANGE-SUMMARY.md must preserve /aif-qa test-plan <resolved_branch> as a literal command"
+fi
+
+if grep -Fq '`/aif-qa test-cases <resolved_branch>`' "$test_plan_ref"; then
+    pass "TEST-PLAN.md preserves test-cases handoff command"
+else
+    fail "TEST-PLAN.md must preserve /aif-qa test-cases <resolved_branch> as a literal command"
+fi
+
+if grep -Fq 'Before saving' "$change_summary_ref" \
+    && grep -Fq 'Before saving' "$test_plan_ref" \
+    && grep -Fq 'Before saving' "$test_cases_ref" \
+    && grep -Fq 'artifact_language' "$change_summary_ref" \
+    && grep -Fq 'artifact_language' "$test_plan_ref" \
+    && grep -Fq 'artifact_language' "$test_cases_ref"; then
+    pass "all QA artifact stages self-check artifact_language before saving"
+else
+    fail "each QA reference must self-check artifact_language before saving"
+fi
+
+if grep -Fq 'canonical English templates' "$SKILL_DIR/SKILL.md" \
+    && grep -Fq 'translate them to `artifact_language`' "$SKILL_DIR/SKILL.md" \
+    && [[ -f "$SKILL_DIR/templates/CHANGE-SUMMARY.md" ]] \
+    && [[ -f "$SKILL_DIR/templates/TEST-PLAN.md" ]] \
+    && [[ -f "$SKILL_DIR/templates/TEST-CASES.md" ]] \
+    && [[ ! -d "$SKILL_DIR/templates/en" ]] \
+    && [[ ! -d "$SKILL_DIR/templates/ru" ]] \
+    && ! grep -R 'templates/<artifact_language>/' "$SKILL_DIR/SKILL.md" "$SKILL_DIR/references" >/dev/null; then
+    pass "QA uses only canonical English templates with translate-to-artifact-language fallback"
+else
+    fail "aif-qa must use only canonical English templates and translate them to artifact_language when needed"
+fi
 
 # Contract: final-stage guidance still carries the resolved branch context
 if [[ -f "$test_cases_ref" ]] && grep -q 'resolved_branch' "$test_cases_ref"; then
@@ -199,6 +259,59 @@ if grep -q 'reduced commit scope and diff scope aligned' "$change_summary_ref"; 
     pass "CHANGE-SUMMARY.md explicitly links reduced commit scope to diff scope"
 else
     fail "CHANGE-SUMMARY.md must explicitly state that reduced commit scope and diff scope stay aligned"
+fi
+
+if grep -Fq 'git rev-parse --verify <resolved_branch>' "$change_summary_ref" \
+    && grep -Fq 'git rev-parse --verify <effective_base>' "$change_summary_ref" \
+    && grep -Fq 'git fetch --all --prune' "$change_summary_ref" \
+    && grep -Fq 'origin/<base_branch>' "$change_summary_ref"; then
+    pass "CHANGE-SUMMARY.md validates branch/base refs and documents remote fallback"
+else
+    fail "CHANGE-SUMMARY.md must validate branch/base refs and try origin/<base_branch> fallback"
+fi
+
+if grep -Fq 'git.enabled' "$SKILL_DIR/SKILL.md" \
+    && grep -Fq 'manual change context' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md handles git.enabled=false/manual change context"
+else
+    fail "SKILL.md must read git.enabled and describe manual change context fallback"
+fi
+
+if grep -Fq 'git diff --stat' "$change_summary_ref" \
+    && grep -Fq 'generated files, lock files, dependency snapshots, build artifacts, minified assets, or vendored code' "$change_summary_ref"; then
+    pass "CHANGE-SUMMARY.md documents large-diff triage and skip rules"
+else
+    fail "CHANGE-SUMMARY.md must include diff stat triage and generated/vendor skip rules"
+fi
+
+if grep -Fq 'model: sonnet' "$change_summary_ref"; then
+    fail "CHANGE-SUMMARY.md must not hardcode model: sonnet for Explore agents"
+else
+    pass "CHANGE-SUMMARY.md does not hardcode model: sonnet"
+fi
+
+if grep -Fq 'Do not replace the manual QA plan with automated test implementation details.' "$SKILL_DIR/SKILL.md" \
+    && grep -Fq 'You may mention existing automated checks only as supporting verification' "$SKILL_DIR/SKILL.md"; then
+    pass "SKILL.md keeps manual QA primary while allowing supporting automated checks"
+else
+    fail "SKILL.md must soften automated-test wording without replacing manual QA"
+fi
+
+if grep -Fq '### Evidence' "$SKILL_DIR/templates/CHANGE-SUMMARY.md" \
+    && grep -Fq 'Every high-risk item must be backed by observed code/diff evidence or explicitly marked as an assumption.' "$change_summary_ref"; then
+    pass "change-summary includes evidence section and high-risk evidence rule"
+else
+    fail "change-summary template/reference must include evidence section and high-risk evidence rule"
+fi
+
+if grep -Fq '| `language.artifacts` | `en` |' "$config_reference_doc" \
+    && grep -Fq '/aif-qa' "$config_reference_doc" \
+    && grep -Fq 'language.technical_terms' "$config_reference_doc" \
+    && grep -Fq 'git.enabled' "$config_reference_doc" \
+    && grep -Fq 'paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, `language.artifacts`, `language.technical_terms`, `git.enabled`, `git.base_branch' "$skills_doc"; then
+    pass "docs describe /aif-qa language and git config readers"
+else
+    fail "docs must list /aif-qa as reading language.artifacts, language.technical_terms, git.enabled, and git.base_branch"
 fi
 
 # Contract: allowed-tools covers both Bash(git *) and Bash(mkdir *)

--- a/scripts/test-aif-qa.sh
+++ b/scripts/test-aif-qa.sh
@@ -245,15 +245,34 @@ fi
 
 assert_exact_line \
     "$change_summary_ref" \
-    'git diff <analysis_base>...<resolved_branch> --name-status' \
-    "CHANGE-SUMMARY.md keeps exact name-status diff line" \
-    "CHANGE-SUMMARY.md must contain the exact line 'git diff <analysis_base>...<resolved_branch> --name-status'"
+    'git log <effective_base>..<analysis_target> --oneline' \
+    "CHANGE-SUMMARY.md keeps exact full-range log line with analysis_target" \
+    "CHANGE-SUMMARY.md must contain the exact line 'git log <effective_base>..<analysis_target> --oneline'"
 
 assert_exact_line \
     "$change_summary_ref" \
-    'git diff <analysis_base>...<resolved_branch>' \
-    "CHANGE-SUMMARY.md keeps exact full diff line" \
-    "CHANGE-SUMMARY.md must contain the exact line 'git diff <analysis_base>...<resolved_branch>'"
+    'git log <analysis_base>..<analysis_target> --oneline' \
+    "CHANGE-SUMMARY.md keeps exact scoped log line with analysis_target" \
+    "CHANGE-SUMMARY.md must contain the exact line 'git log <analysis_base>..<analysis_target> --oneline'"
+
+assert_exact_line \
+    "$change_summary_ref" \
+    'git diff <analysis_base>...<analysis_target> --name-status' \
+    "CHANGE-SUMMARY.md keeps exact name-status diff line with analysis_target" \
+    "CHANGE-SUMMARY.md must contain the exact line 'git diff <analysis_base>...<analysis_target> --name-status'"
+
+assert_exact_line \
+    "$change_summary_ref" \
+    'git diff <analysis_base>...<analysis_target>' \
+    "CHANGE-SUMMARY.md keeps exact full diff line with analysis_target" \
+    "CHANGE-SUMMARY.md must contain the exact line 'git diff <analysis_base>...<analysis_target>'"
+
+if grep -Fq 'analysis_target = <resolved_branch>' "$change_summary_ref" \
+    && grep -Fq 'analysis_target = origin/<resolved_branch>' "$change_summary_ref"; then
+    pass "CHANGE-SUMMARY.md defines analysis_target for local and remote target refs"
+else
+    fail "CHANGE-SUMMARY.md must define analysis_target for local and remote target refs"
+fi
 
 if grep -q 'reduced commit scope and diff scope aligned' "$change_summary_ref"; then
     pass "CHANGE-SUMMARY.md explicitly links reduced commit scope to diff scope"

--- a/scripts/test-aif-qa.sh
+++ b/scripts/test-aif-qa.sh
@@ -264,10 +264,11 @@ fi
 if grep -Fq 'git rev-parse --verify <resolved_branch>' "$change_summary_ref" \
     && grep -Fq 'git rev-parse --verify <effective_base>' "$change_summary_ref" \
     && grep -Fq 'git fetch --all --prune' "$change_summary_ref" \
-    && grep -Fq 'origin/<base_branch>' "$change_summary_ref"; then
-    pass "CHANGE-SUMMARY.md validates branch/base refs and documents remote fallback"
+    && grep -Fq 'origin/<base_branch>' "$change_summary_ref" \
+    && grep -Fq 'origin/<resolved_branch>' "$change_summary_ref"; then
+    pass "CHANGE-SUMMARY.md validates branch/base refs and documents remote fallback for base and target branch"
 else
-    fail "CHANGE-SUMMARY.md must validate branch/base refs and try origin/<base_branch> fallback"
+    fail "CHANGE-SUMMARY.md must validate branch/base refs and try origin/<base_branch> plus origin/<resolved_branch> fallback"
 fi
 
 if grep -Fq 'git.enabled' "$SKILL_DIR/SKILL.md" \
@@ -275,6 +276,13 @@ if grep -Fq 'git.enabled' "$SKILL_DIR/SKILL.md" \
     pass "SKILL.md handles git.enabled=false/manual change context"
 else
     fail "SKILL.md must read git.enabled and describe manual change context fallback"
+fi
+
+if grep -Fq 'If you only have a PR description or short implementation summary, derive a best-effort `changed_files` list' "$change_summary_ref" \
+    && grep -Fq 'If no reliable file list can be derived, skip file exploration' "$change_summary_ref"; then
+    pass "CHANGE-SUMMARY.md handles manual mode without requiring --name-status output"
+else
+    fail "CHANGE-SUMMARY.md must handle manual mode when no --name-status output exists"
 fi
 
 if grep -Fq 'git diff --stat' "$change_summary_ref" \
@@ -320,6 +328,17 @@ if grep -F '| `paths.description` |' "$config_reference_doc" | grep -Fq '/aif-qa
     pass "config-reference key rows list /aif-qa for description, architecture, and git.base_branch"
 else
     fail "config-reference key rows must list /aif-qa for paths.description, paths.architecture, and git.base_branch"
+fi
+
+config_template="$ROOT_DIR/skills/aif/references/config-template.yaml"
+configuration_doc="$ROOT_DIR/docs/configuration.md"
+
+if grep -Fq 'mixed' "$SKILL_DIR/SKILL.md" \
+    && grep -Fq 'mixed' "$config_template" \
+    && grep -Fq 'mixed' "$configuration_doc"; then
+    pass "technical_terms mixed policy is documented consistently in skill, config template, and configuration docs"
+else
+    fail "technical_terms mixed policy must be documented consistently everywhere it is supported"
 fi
 
 # Contract: allowed-tools covers both Bash(git *) and Bash(mkdir *)

--- a/skills/aif-qa/SKILL.md
+++ b/skills/aif-qa/SKILL.md
@@ -29,15 +29,47 @@ The skill operates in three sequential modes.
 
 **FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
 - **Paths:** `paths.description`, `paths.architecture`, `paths.qa` (default: `.ai-factory/qa`)
-- **Language:** `language.ui` for prompts
-- **Git:** `git.base_branch` for branch comparison
+- **Language:**
+  - `language.ui` for AskUserQuestion prompts, progress messages, final summaries, and next-step guidance
+  - `language.artifacts` for generated QA artifacts
+  - `language.technical_terms` for human-readable technical terminology style when generating artifacts
+  - If `language.artifacts` is missing, use `language.ui`
+  - If both are missing, use `en`
+- **Git:** `git.enabled` and `git.base_branch` for branch comparison
 
 If config.yaml doesn't exist, use defaults:
 - DESCRIPTION.md: `.ai-factory/DESCRIPTION.md`
 - ARCHITECTURE.md: `.ai-factory/ARCHITECTURE.md`
 - QA artifacts: `.ai-factory/qa/`
-- Language: `en` (English)
+- `ui_language`: `en`
+- `artifact_language`: `en`
+- `technical_terms_policy`: `keep`
+- Git enabled: `true`
 - Git base branch: `main`
+
+Store:
+- `ui_language = language.ui || "en"`
+- `artifact_language = language.artifacts || language.ui || "en"`
+- `technical_terms_policy = language.technical_terms || "keep"`
+- `git_enabled = git.enabled` when present, otherwise `true`
+- `base_branch = git.base_branch || "main"`
+
+All AskUserQuestion prompts, user-visible explanations, stage completion messages, and next-step guidance MUST be written in `ui_language`.
+
+All generated artifacts (`change-summary.md`, `test-plan.md`, `test-cases.md`) MUST be written in `artifact_language`.
+
+Templates define structure, not language. Use the canonical English templates in `templates/*.md`. If `artifact_language` is not `en`, translate them to `artifact_language` before saving: headings, labels, checklist items, placeholders, enum labels, risk labels, and explanatory text must be in `artifact_language`.
+
+Do not use English templates verbatim when `artifact_language` is not `en`. Preserve markdown structure, table shapes, checkbox syntax, test case IDs (`TC-001`), code identifiers, paths, commands, branch names, config keys, API names, package names, and raw error messages.
+
+For `artifact_language = ru`, write human-readable prose, headings, risks, priorities, recommendations, test steps, and expected results in Russian. Keep code identifiers, filenames, branch names, commands, config keys, API names, and raw error text unchanged.
+
+Apply `technical_terms_policy` while writing artifacts:
+- `keep` — keep common technical terms such as `commit`, `branch`, `diff`, `endpoint`, `payload`, `rollback`, `regression`, and `fixture` when that is clearer for the project audience
+- `translate` — translate human-readable technical terms where a natural target-language term exists
+- `mixed` — translate ordinary prose terms while keeping code, infrastructure, and ecosystem terms unchanged
+
+If `git_enabled = false` or the current directory is not a git work tree, do not run git diff/log commands. Use manual change context mode instead: ask the user in `ui_language` to provide one of these sources of change context before running `change-summary`: pasted diff, changed file list, short implementation description, or cancel.
 
 ### Step 0.1: Load Project Context
 
@@ -75,8 +107,13 @@ Parse `$ARGUMENTS` fully before doing anything else:
 **Resolve the working branch:**
 
 ```text
-If branch was provided in arguments → use it as the resolved branch
-Otherwise → run: git branch --show-current
+If git_enabled = false or the repository is not a git work tree:
+  If branch was provided in arguments → use it as the resolved branch label
+  Otherwise → set resolved_branch = "manual"
+  Use manual change context mode for analysis
+If git_enabled = true and the repository is a git work tree:
+  If branch was provided in arguments → use it as the resolved branch
+  Otherwise → run: git branch --show-current
 ```
 
 Store both values for use in all reference files:
@@ -94,16 +131,16 @@ Store both values for use in all reference files:
   - `main` → `safe_slug=main`, `hash8=<computed>` → `main-<hash8>`
 - `all_mode` — whether to skip inter-stage prompts
 
-**If no mode was provided and `all_mode = false` — ask the user:**
+**If no mode was provided and `all_mode = false` — ask the user in `ui_language`:**
 
 ```text
-AskUserQuestion: Which QA mode would you like to run?
-
-Options:
-1. Change summary (change-summary) — analyze what changed, assess risks, produce a summary
-2. Test plan (test-plan) — create a structured test plan based on the change summary
-3. Test cases (test-cases) — describe concrete test scenarios based on the plan
-4. Full pipeline (--all) — run all three modes in sequence
+AskUserQuestion in `ui_language`.
+Meaning: ask which QA mode to run.
+Options meaning:
+1. Change summary (`change-summary`) — analyze what changed, assess risks, produce a summary
+2. Test plan (`test-plan`) — create a structured test plan based on the change summary
+3. Test cases (`test-cases`) — describe concrete test scenarios based on the plan
+4. Full pipeline (`--all`) — run all three modes in sequence
 ```
 
 ### Step 1: Execute the Selected Mode
@@ -159,11 +196,14 @@ If any stage fails (e.g. git error, diff too large and user cancels) — stop th
 
 ### DO NOT:
 
-- Suggest automated tests or mention testing frameworks
+- Replace the manual QA plan with automated test implementation details
 - Make assumptions about business logic without reading the code
 - Skip negative scenarios
 - Write test cases for everything — focus on risky areas
 - Ignore data edge cases
+
+Do not replace the manual QA plan with automated test implementation details.
+You may mention existing automated checks only as supporting verification; the primary output must remain manual QA scenarios.
 
 ---
 
@@ -179,7 +219,7 @@ If any stage fails (e.g. git error, diff too large and user cancels) — stop th
 
 - Primary ownership: QA artifacts under `<paths.qa>/<branch-slug>/` — specifically `change-summary.md`, `test-plan.md`, and `test-cases.md`. The `--all` flag respects the same boundary.
 - Write policy: persistent writes are limited to the three owned artifacts above; no other files are created or modified.
-- Config policy: config-aware, read-only. Reads `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, and `git.base_branch`; never writes `config.yaml`.
+- Config policy: config-aware, read-only. Reads `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, `language.artifacts`, `language.technical_terms`, `git.enabled`, and `git.base_branch`; never writes `config.yaml`.
 
 ## Critical Rules
 

--- a/skills/aif-qa/references/CHANGE-SUMMARY.md
+++ b/skills/aif-qa/references/CHANGE-SUMMARY.md
@@ -44,6 +44,8 @@ Use this flow only when `git_enabled = true` and the repository is a git work tr
 > git rev-parse --verify <effective_base>
 > ```
 >
+> If `<resolved_branch>` resolves locally, set `analysis_target = <resolved_branch>`.
+>
 > If `<resolved_branch>` is not available locally, try refreshing remotes and then resolve the remote target ref:
 >
 > ```bash
@@ -51,7 +53,7 @@ Use this flow only when `git_enabled = true` and the repository is a git work tr
 > git rev-parse --verify origin/<resolved_branch>
 > ```
 >
-> If `origin/<resolved_branch>` resolves, use that remote ref for git log/diff commands while keeping `resolved_branch` unchanged as the artifact label. If neither local nor remote target branch resolves, switch to manual change context mode and ask the user in `ui_language` for the comparison source.
+> If `origin/<resolved_branch>` resolves, set `analysis_target = origin/<resolved_branch>`. Keep `resolved_branch` unchanged as the artifact label, branch slug input, and user-facing command argument. If neither local nor remote target branch resolves, switch to manual change context mode and ask the user in `ui_language` for the comparison source.
 >
 > If `<effective_base>` is not available locally, try refreshing remotes and then resolve the remote base:
 >
@@ -62,14 +64,14 @@ Use this flow only when `git_enabled = true` and the repository is a git work tr
 >
 > If `origin/<base_branch>` resolves, set `effective_base = origin/<base_branch>`. If neither local nor remote base resolves, switch to manual change context mode and ask the user in `ui_language` for the comparison source.
 >
-> Build the full commit range from `effective_base..<resolved_branch>`.
+> Build the full commit range from `effective_base..<analysis_target>`.
 > Start with `analysis_base = <effective_base>`.
-> This special case stays anchored to `resolved_branch`, not to the current checkout.
+> This special case stays anchored to `analysis_target`, not to the current checkout.
 
 **Get the full commit list:**
 
 ```bash
-git log <effective_base>..<resolved_branch> --oneline
+git log <effective_base>..<analysis_target> --oneline
 ```
 
 **Check commit count — if more than 20, ask before proceeding:**
@@ -90,7 +92,7 @@ Based on choice:
 **Finalize the scoped commit list:**
 
 ```bash
-git log <analysis_base>..<resolved_branch> --oneline
+git log <analysis_base>..<analysis_target> --oneline
 ```
 
 Use `analysis_base` for the final commit list and for all diff commands below. This keeps the reduced commit scope and diff scope aligned.
@@ -98,9 +100,9 @@ Use `analysis_base` for the final commit list and for all diff commands below. T
 **Get diff statistics, changed files, and diff:**
 
 ```bash
-git diff --stat <analysis_base>...<resolved_branch>
-git diff <analysis_base>...<resolved_branch> --name-status
-git diff <analysis_base>...<resolved_branch>
+git diff --stat <analysis_base>...<analysis_target>
+git diff <analysis_base>...<analysis_target> --name-status
+git diff <analysis_base>...<analysis_target>
 ```
 
 **Check diff size — if the diff exceeds ~1000 lines, warn before proceeding:**
@@ -117,7 +119,7 @@ Based on choice:
 - "Read files individually" → skip the raw full diff; proceed to Step 2 and read targeted per-file diffs/content
 - "Cancel" → **STOP**
 
-For large diffs, never load generated files, lock files, dependency snapshots, build artifacts, minified assets, or vendored code unless the change itself is about them. Start from `git diff --stat`, then `git diff <analysis_base>...<resolved_branch> --name-status`, then per-file diffs for important files. Treat deleted and renamed files explicitly: deleted files may indicate removed behavior; renamed files may require caller/import checks even when content is mostly unchanged.
+For large diffs, never load generated files, lock files, dependency snapshots, build artifacts, minified assets, or vendored code unless the change itself is about them. Start from `git diff --stat`, then `git diff <analysis_base>...<analysis_target> --name-status`, then per-file diffs for important files. Treat deleted and renamed files explicitly: deleted files may indicate removed behavior; renamed files may require caller/import checks even when content is mostly unchanged.
 
 ## Step 2: Explore Key Changed Files
 

--- a/skills/aif-qa/references/CHANGE-SUMMARY.md
+++ b/skills/aif-qa/references/CHANGE-SUMMARY.md
@@ -22,6 +22,11 @@ Options meaning:
 
 Use the supplied context as the primary evidence source. If the user cancels, stop without writing an artifact.
 
+If the user provides an explicit changed-file list, use it as `changed_files` for Step 2.
+If you only have a diff, derive `changed_files` from the touched paths in that diff.
+If you only have a PR description or short implementation summary, derive a best-effort `changed_files` list from any explicitly named files, modules, routes, commands, or components mentioned there.
+If no reliable file list can be derived, skip file exploration in Step 2 and continue with summary-level risk analysis based on the supplied evidence. In that case, mark file-level uncertainty explicitly in the generated artifact instead of falling back to git assumptions.
+
 ### Git Change Context
 
 Use this flow only when `git_enabled = true` and the repository is a git work tree.
@@ -38,6 +43,15 @@ Use this flow only when `git_enabled = true` and the repository is a git work tr
 > git rev-parse --verify <resolved_branch>
 > git rev-parse --verify <effective_base>
 > ```
+>
+> If `<resolved_branch>` is not available locally, try refreshing remotes and then resolve the remote target ref:
+>
+> ```bash
+> git fetch --all --prune
+> git rev-parse --verify origin/<resolved_branch>
+> ```
+>
+> If `origin/<resolved_branch>` resolves, use that remote ref for git log/diff commands while keeping `resolved_branch` unchanged as the artifact label. If neither local nor remote target branch resolves, switch to manual change context mode and ask the user in `ui_language` for the comparison source.
 >
 > If `<effective_base>` is not available locally, try refreshing remotes and then resolve the remote base:
 >
@@ -110,7 +124,9 @@ For large diffs, never load generated files, lock files, dependency snapshots, b
 **Use `Task` tool with `subagent_type: Explore` to understand the changed files in parallel.**
 This keeps the main context clean and speeds up analysis on large diffs.
 
-From the `--name-status` output, identify the most important changed files (focus on business logic, skip lock files, generated files, dependency snapshots, build artifacts, minified assets, vendored code, and formatting-only changes).
+If Step 1 produced `changed_files`, identify the most important files from that set (focus on business logic, skip lock files, generated files, dependency snapshots, build artifacts, minified assets, vendored code, and formatting-only changes).
+
+If `changed_files` is unavailable because manual mode only provided summary-level context, skip direct file exploration. Instead, summarize risks from the supplied evidence, note that file-level exploration could not be performed, and keep assumptions clearly labeled.
 
 Launch 1–2 Explore agents simultaneously. Use the default configured model unless the runtime explicitly supports model selection:
 

--- a/skills/aif-qa/references/CHANGE-SUMMARY.md
+++ b/skills/aif-qa/references/CHANGE-SUMMARY.md
@@ -6,13 +6,47 @@
 
 ## Step 1: Gather Change Information
 
-Use the `resolved_branch` and `artifact_dir` resolved in SKILL.md Step 0.2.
+Use the `resolved_branch`, `artifact_dir`, `ui_language`, `artifact_language`, `technical_terms_policy`, `git_enabled`, and `base_branch` resolved in SKILL.md Step 0 and Step 0.2.
+
+### Manual Change Context
+
+If `git_enabled = false`, the current directory is not a git work tree, or required refs cannot be resolved, do not fail with a raw git error.
+
+Use AskUserQuestion in `ui_language`.
+Meaning: ask the user to provide change context for the QA summary.
+Options meaning:
+1. Paste a diff or PR description
+2. Provide a changed-file list
+3. Provide a short implementation summary
+4. Cancel
+
+Use the supplied context as the primary evidence source. If the user cancels, stop without writing an artifact.
+
+### Git Change Context
+
+Use this flow only when `git_enabled = true` and the repository is a git work tree.
 
 **Resolve the comparison base:**
 
 > Use the `git.base_branch` value from config (default: `main`).
 > If `resolved_branch` IS the base branch, set `effective_base = <resolved_branch>~1`.
 > Otherwise, set `effective_base = <base_branch>`.
+>
+> Validate refs before running log or diff commands:
+>
+> ```bash
+> git rev-parse --verify <resolved_branch>
+> git rev-parse --verify <effective_base>
+> ```
+>
+> If `<effective_base>` is not available locally, try refreshing remotes and then resolve the remote base:
+>
+> ```bash
+> git fetch --all --prune
+> git rev-parse --verify origin/<base_branch>
+> ```
+>
+> If `origin/<base_branch>` resolves, set `effective_base = origin/<base_branch>`. If neither local nor remote base resolves, switch to manual change context mode and ask the user in `ui_language` for the comparison source.
 >
 > Build the full commit range from `effective_base..<resolved_branch>`.
 > Start with `analysis_base = <effective_base>`.
@@ -26,14 +60,12 @@ git log <effective_base>..<resolved_branch> --oneline
 
 **Check commit count — if more than 20, ask before proceeding:**
 
-```text
-AskUserQuestion: Found <N> commits to analyze. Processing all of them may consume significant context. How to proceed?
-
-Options:
-1. Analyze all <N> commits
+Use AskUserQuestion in `ui_language`.
+Meaning: tell the user that `<N>` commits were found and ask whether to analyze all commits, only the last 20, or cancel.
+Options meaning:
+1. Analyze all `<N>` commits
 2. Analyze only the last 20
 3. Cancel
-```
 
 Based on choice:
 - "Analyze all" → keep `analysis_base = <effective_base>`
@@ -47,49 +79,50 @@ Based on choice:
 git log <analysis_base>..<resolved_branch> --oneline
 ```
 
-Use `analysis_base` for the final commit list and for both diff commands below. This keeps the reduced commit scope and diff scope aligned.
+Use `analysis_base` for the final commit list and for all diff commands below. This keeps the reduced commit scope and diff scope aligned.
 
-**Get changed files and diff:**
+**Get diff statistics, changed files, and diff:**
 
 ```bash
+git diff --stat <analysis_base>...<resolved_branch>
 git diff <analysis_base>...<resolved_branch> --name-status
 git diff <analysis_base>...<resolved_branch>
 ```
 
 **Check diff size — if the diff exceeds ~1000 lines, warn before proceeding:**
 
-```text
-AskUserQuestion: The diff is large (<N> lines). Reading it in full will consume significant context. How to proceed?
-
-Options:
-1. Continue — read the full diff
+Use AskUserQuestion in `ui_language`.
+Meaning: tell the user that the diff is large (`<N>` lines) and ask whether to read it fully, analyze important files individually, or cancel.
+Options meaning:
+1. Continue and read the full diff
 2. Read changed files individually instead (recommended for large diffs)
 3. Cancel
-```
 
 Based on choice:
 - "Continue" → use the full diff as-is
-- "Read files individually" → skip the raw diff; proceed to Step 2 where Explore agents will read the files
+- "Read files individually" → skip the raw full diff; proceed to Step 2 and read targeted per-file diffs/content
 - "Cancel" → **STOP**
+
+For large diffs, never load generated files, lock files, dependency snapshots, build artifacts, minified assets, or vendored code unless the change itself is about them. Start from `git diff --stat`, then `git diff <analysis_base>...<resolved_branch> --name-status`, then per-file diffs for important files. Treat deleted and renamed files explicitly: deleted files may indicate removed behavior; renamed files may require caller/import checks even when content is mostly unchanged.
 
 ## Step 2: Explore Key Changed Files
 
 **Use `Task` tool with `subagent_type: Explore` to understand the changed files in parallel.**
 This keeps the main context clean and speeds up analysis on large diffs.
 
-From the `--name-status` output, identify the most important changed files (focus on business logic, skip lock files, generated files, and formatting-only changes).
+From the `--name-status` output, identify the most important changed files (focus on business logic, skip lock files, generated files, dependency snapshots, build artifacts, minified assets, vendored code, and formatting-only changes).
 
-Launch 1–2 Explore agents simultaneously:
+Launch 1–2 Explore agents simultaneously. Use the default configured model unless the runtime explicitly supports model selection:
 
 ```text
 Agent 1 — Core changes:
-Task(subagent_type: Explore, model: sonnet, prompt:
+Task(subagent_type: Explore, prompt:
   "Read and summarize the key changed files: [list of most important files].
    Focus on: what logic changed, what inputs/outputs changed, what side effects are possible.
    Thoroughness: medium. Be concise.")
 
 Agent 2 — Integration points (if needed):
-Task(subagent_type: Explore, model: sonnet, prompt:
+Task(subagent_type: Explore, prompt:
   "Find all callers and consumers of [changed modules/functions].
    Identify what adjacent functionality might be affected.
    Thoroughness: quick.")
@@ -101,6 +134,7 @@ After agents return, synthesize findings to understand:
 - What business logic actually changed
 - What dependent code could be affected
 - What integration points are at risk
+- Which findings are confirmed by code/diff evidence and which are assumptions
 
 ## Step 3: Risk Analysis
 
@@ -126,11 +160,23 @@ For each changed component, assess:
 - What existing functionality might have broken?
 - Which adjacent features need re-verification?
 
+Every high-risk item must be backed by observed code/diff evidence or explicitly marked as an assumption.
+
 ## Step 4: Generate the Summary
 
-Use the template from `templates/CHANGE-SUMMARY.md`.
+Use the canonical English template `templates/CHANGE-SUMMARY.md` as the structure source. If `artifact_language` is not `en`, translate all human-readable headings, labels, checklist items, placeholders, enum labels, risk labels, and explanatory text into `artifact_language` before saving.
+
+Write the artifact in `artifact_language`. Apply `technical_terms_policy` from SKILL.md. Keep file paths, commands, code identifiers, branch names, config keys, API names, package names, and raw error messages unchanged.
+
+The summary must include an `Evidence` section (localized heading is allowed) that ties important findings to files, functions, commits, or diff observations.
 
 ## Step 5: Save Artifact
+
+Before saving:
+- Verify that the document is written in `artifact_language`.
+- If most headings or body text are in another language, rewrite it before saving.
+- For `artifact_language = ru`, human-readable prose, headings, risks, priorities, and recommendations must be in Russian.
+- Technical identifiers, code names, branch names, API names, CLI commands, file paths, config keys, and raw error messages may remain unchanged.
 
 **Ensure the directory exists before saving:**
 
@@ -146,10 +192,8 @@ Save the result to `<artifact_dir>/change-summary.md`.
 
 **Otherwise:**
 
-```text
-AskUserQuestion: Change summary saved. Proceed to writing the test plan?
-
-Options:
-1. Yes — run /aif-qa test-plan <resolved_branch>
-2. No — stop here
-```
+Use AskUserQuestion in `ui_language`.
+Meaning: tell the user that the change summary was saved and ask whether to proceed to the test plan.
+Options meaning:
+1. Proceed by running `/aif-qa test-plan <resolved_branch>`
+2. Stop here

--- a/skills/aif-qa/references/TEST-CASES.md
+++ b/skills/aif-qa/references/TEST-CASES.md
@@ -6,7 +6,7 @@
 
 ## Step 1: Verify Previous Stage Artifacts
 
-Use the `resolved_branch` and `artifact_dir` resolved in SKILL.md Step 0.2.
+Use the `resolved_branch`, `artifact_dir`, `ui_language`, `artifact_language`, and `technical_terms_policy` resolved in SKILL.md Step 0 and Step 0.2.
 
 Check for both files:
 
@@ -15,25 +15,21 @@ Check for both files:
 
 **If `change-summary.md` is NOT found — STOP:**
 
-```
-AskUserQuestion: The change-summary artifact was not found. Test cases cannot be written without a change summary.
-
-Options:
-1. Run change summary first — /aif-qa change-summary <resolved_branch>
+Use AskUserQuestion in `ui_language`.
+Meaning: explain that the `change-summary.md` artifact was not found and test cases cannot be written without it.
+Options meaning:
+1. Run change summary first with `/aif-qa change-summary <resolved_branch>`
 2. Cancel
-```
 
 **If `test-plan.md` is NOT found — STOP:**
 
-```
-AskUserQuestion: The test-plan artifact was not found. Test cases cannot be written without a test plan.
-
-Options:
-1. Create test plan first — /aif-qa test-plan <resolved_branch>
+Use AskUserQuestion in `ui_language`.
+Meaning: explain that the `test-plan.md` artifact was not found and test cases cannot be written without it.
+Options meaning:
+1. Create the test plan first with `/aif-qa test-plan <resolved_branch>`
 2. Cancel
-```
 
-→ Do not continue until both artifacts are present.
+Do not continue until both artifacts are present.
 
 **If both files are found** — read them and use as the basis. Proceed to Step 2.
 
@@ -41,12 +37,14 @@ Options:
 
 ## Step 2: Determine What to Test
 
-**Prioritize:**
+Prioritize:
 
 1. Core business logic of the changes
 2. Edge cases and non-standard inputs
 3. Negative scenarios (errors, invalid data)
 4. Regression checks on adjacent functionality
+
+Use the evidence and assumptions from `change-summary.md` and `test-plan.md` to keep test cases grounded.
 
 ## Step 3: Coverage Strategy
 
@@ -78,29 +76,41 @@ For each changed area, write test cases grouped as follows:
 - Adjacent functionality that might have broken
 - Integrations with other system components
 
+Render these group headings and descriptions in `artifact_language` in the saved artifact.
+
 ## Step 4: Write Test Cases
+
+Use the canonical English template `templates/TEST-CASES.md` as the structure source. If `artifact_language` is not `en`, translate all human-readable headings, labels, placeholders, enum labels, priority labels, test names, steps, expected results, and explanatory text into `artifact_language` before saving.
 
 Write test cases following these rules:
 
-- Use the test case and test data templates from `templates/TEST-CASES.md`
-- Fill in all `[...]` placeholders with the actual data for your test cases
-- Optional fields in the template may be omitted when not applicable
-- Negative tests are optional but recommended
-- High-priority tests are mandatory
+- Fill in all placeholders with actual data for the current change.
+- Optional fields in the template may be omitted when not applicable.
+- Negative tests are optional but recommended.
+- High-priority tests are mandatory.
+- Test case IDs such as `TC-001` stay unchanged across languages.
+- Human-readable titles, preconditions, steps, expected results, priorities, and test data notes must be written in `artifact_language`.
+- Technical identifiers, code names, branch names, API names, CLI commands, file paths, config keys, and raw error messages may remain unchanged.
+
+Apply `technical_terms_policy` from SKILL.md.
 
 ## Step 5: Save Artifact
+
+Before saving:
+- Verify that the document is written in `artifact_language`.
+- If most headings or body text are in another language, rewrite it before saving.
+- For `artifact_language = ru`, human-readable prose, headings, priorities, test names, preconditions, steps, expected results, and test data explanations must be in Russian.
+- Technical identifiers, code names, branch names, API names, CLI commands, file paths, config keys, and raw error messages may remain unchanged.
 
 Save the result to `<artifact_dir>/test-cases.md`.
 
 ## Step 6: Context Cleanup
 
-After saving, offer to free up context:
+After saving, offer to free up context.
 
-```
-AskUserQuestion: Test cases saved. Free up context?
-
-Options:
-1. /clear — Full reset (recommended)
-2. /compact — Compress history
+Use AskUserQuestion in `ui_language`.
+Meaning: tell the user that test cases were saved and ask whether to clear, compact, or continue.
+Options meaning:
+1. `/clear` — full reset (recommended)
+2. `/compact` — compress history
 3. Continue as-is
-```

--- a/skills/aif-qa/references/TEST-PLAN.md
+++ b/skills/aif-qa/references/TEST-PLAN.md
@@ -6,21 +6,19 @@
 
 ## Step 1: Verify Previous Stage Artifact
 
-Use the `resolved_branch` and `artifact_dir` resolved in SKILL.md Step 0.2.
+Use the `resolved_branch`, `artifact_dir`, `ui_language`, `artifact_language`, and `technical_terms_policy` resolved in SKILL.md Step 0 and Step 0.2.
 
 Check for the file `<artifact_dir>/change-summary.md`.
 
 **If the file is NOT found — STOP:**
 
-```
-AskUserQuestion: The change-summary artifact was not found. A test plan cannot be created without a change summary.
-
-Options:
-1. Run change summary first — /aif-qa change-summary <resolved_branch>
+Use AskUserQuestion in `ui_language`.
+Meaning: explain that the `change-summary.md` artifact was not found and a test plan cannot be created without it.
+Options meaning:
+1. Run change summary first with `/aif-qa change-summary <resolved_branch>`
 2. Cancel
-```
 
-→ Do not continue until the artifact is created.
+Do not continue until the artifact is created.
 
 **If the file is found** — read `<artifact_dir>/change-summary.md` and use it as the basis for the test plan. Proceed to Step 2.
 
@@ -28,7 +26,7 @@ Options:
 
 ## Step 2: Clarify Context
 
-Ask the user only if something is not obvious from the code and change-summary:
+Ask the user in `ui_language` only if something is not obvious from the code and change-summary:
 
 - What feature or fix was implemented?
 - Are there existing test cases for this area?
@@ -52,26 +50,31 @@ Based on the change analysis, determine:
 - Unrelated functionality
 - Components without changes and without dependencies on changed ones
 
+Render these headings and descriptions in `artifact_language` in the saved artifact.
+
 ## Step 4: Define Test Types
 
-| Type              | Priority   | When to apply                                            |
-|-------------------|------------|----------------------------------------------------------|
-| Functional        | 🔴 High    | Always — verify core logic of the changes                |
-| Regression        | 🟡 Medium  | Adjacent functionality, potential breakage               |
-| Edge cases        | 🟡 Medium  | Non-standard inputs, boundary data                       |
-| Negative          | 🟡 Medium  | Invalid data, errors, service failures                   |
-| Security          | 🔴 High    | When authorization or user data is affected              |
-| Performance       | 🟢 Low     | When queries, algorithms, or caching were changed        |
+Use functional, regression, edge-case, negative, security, and performance categories when relevant. Translate human-readable type labels and priority labels into `artifact_language`, unless `technical_terms_policy` indicates that the term should remain in English.
 
 ## Step 5: Build the Verification Checklist
 
-Describe checks as a checklist with priority labels (high / medium / low).
+Describe checks as a checklist with priority labels (high / medium / low). Write the checklist in `artifact_language`.
 
 ## Step 6: Generate the Test Plan
 
-Use the template from `templates/TEST-PLAN.md`.
+Use the canonical English template `templates/TEST-PLAN.md` as the structure source. If `artifact_language` is not `en`, translate all human-readable headings, labels, checklist items, placeholders, enum labels, priority labels, and explanatory text into `artifact_language` before saving.
+
+The generated test plan must be written in `artifact_language`. Apply `technical_terms_policy` from SKILL.md. Keep file paths, commands, code identifiers, branch names, config keys, API names, package names, and raw error messages unchanged.
+
+Use the change summary evidence when prioritizing checks. If a high-priority test is based on an assumption rather than observed code/diff evidence, mark that assumption explicitly.
 
 ## Step 7: Save Artifact
+
+Before saving:
+- Verify that the document is written in `artifact_language`.
+- If most headings or body text are in another language, rewrite it before saving.
+- For `artifact_language = ru`, human-readable prose, headings, risks, priorities, checklist items, and acceptance criteria must be in Russian.
+- Technical identifiers, code names, branch names, API names, CLI commands, file paths, config keys, and raw error messages may remain unchanged.
 
 Save the result to `<artifact_dir>/test-plan.md`.
 
@@ -81,10 +84,8 @@ Save the result to `<artifact_dir>/test-plan.md`.
 
 **Otherwise:**
 
-```
-AskUserQuestion: Test plan saved. Proceed to writing test cases?
-
-Options:
-1. Yes — run /aif-qa test-cases <resolved_branch>
-2. No — stop here
-```
+Use AskUserQuestion in `ui_language`.
+Meaning: tell the user that the test plan was saved and ask whether to proceed to writing test cases.
+Options meaning:
+1. Proceed by running `/aif-qa test-cases <resolved_branch>`
+2. Stop here

--- a/skills/aif-qa/templates/CHANGE-SUMMARY.md
+++ b/skills/aif-qa/templates/CHANGE-SUMMARY.md
@@ -21,6 +21,14 @@
 
 ---
 
+### Evidence
+
+| Finding        | Evidence                          |
+|----------------|-----------------------------------|
+| [What changed] | [file/function/commit/diff proof] |
+
+---
+
 ### Risks
 
 🔴 **Critical** (must verify):

--- a/skills/aif/references/config-template.yaml
+++ b/skills/aif/references/config-template.yaml
@@ -22,6 +22,7 @@ language:
   # Options:
   #   - keep: preserve original English terms (API, database, etc.)
   #   - translate: translate where common translation exists
+  #   - mixed: translate prose terms but keep code/infrastructure ecosystem terms
   # Default: keep
   technical_terms: keep
 


### PR DESCRIPTION
## Summary

Closes #103.

- Make `/aif-qa` resolve separate `ui_language` and `artifact_language` values from `config.yaml`
- Require all `AskUserQuestion` prompts and user-facing guidance to use `language.ui`
- Require generated QA artifacts to use `language.artifacts`, falling back to `language.ui`, then `en`
- Treat QA templates as canonical English structure only; translate headings, labels, placeholders, checklist text, and prose before saving when `artifact_language != en`
- Add git robustness for missing refs, `origin/<base_branch>` fallback, `git.enabled=false`, and manual change-context mode
- Remove hardcoded `model: sonnet` from QA Explore agent examples
- Update config docs and `/aif-qa` smoke contract

## Testing

- `bash scripts/test-aif-qa.sh`
- `npm test`
- `git diff --check`
