### PR TITLE
feat: add Codex app connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,9 @@ jobs:
 
       - name: Validate skills
         run: npm test
+
+      - name: Init smoke tests
+        run: npm run test:init
+
+      - name: Update smoke tests
+        run: npm run test:update

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@
 1. **CLI tool** (`ai-factory init/update/upgrade`) — installs skills and configures MCP
 2. **Built-in skills** (25 skills, all `aif-*` prefixed) — workflow commands for spec-driven development
 3. **Spec-driven workflow** — structured approach: plan → implement → commit
-4. **Multi-agent support** — 15 agents (Claude Code, Cursor, Windsurf, Roo Code, Kilo Code, Antigravity, OpenCode, Warp,
-   Zencoder, Codex CLI, GitHub Copilot, Gemini CLI, Junie, Qwen Code, Universal)
+4. **Multi-agent support** — 16 agents (Claude Code, Cursor, Windsurf, Roo Code, Kilo Code, Antigravity, OpenCode, Warp,
+   Zencoder, Codex CLI, Codex app, GitHub Copilot, Gemini CLI, Junie, Qwen Code, Universal)
 
 ## Project Structure
 
@@ -376,7 +376,7 @@ ai-factory upgrade
 | `src/cli/commands/update.ts` | Re-install all skills, preserve custom skills |
 | `src/cli/commands/upgrade.ts` | v1→v2 migration: remove old bare names, install prefixed |
 | `src/cli/wizard/prompts.ts` | Interactive CLI questions |
-| `src/core/agents.ts` | Agent registry (15 agents) |
+| `src/core/agents.ts` | Agent registry (16 agents) |
 | `src/core/installer.ts` | Copies skills to project |
 | `src/core/mcp.ts` | MCP server configuration |
 | `src/core/template.ts` | `{{var}}` template substitution in SKILL.md |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ai-factory init
 - **Spec-driven development** — AI follows plans, not random exploration. Predictable, resumable, reviewable
 - **Community skills** — leverage [skills.sh](https://skills.sh) ecosystem or generate custom skills
 - **Stack-agnostic** — works with any language, framework, or platform
-- **Multi-agent support** — Claude Code, Cursor, Windsurf, Roo Code, Kilo Code, Antigravity, OpenCode, Warp, Zencoder, Codex CLI, GitHub Copilot, Gemini CLI, Junie, Qwen Code, or [any agent](docs/getting-started.md#supported-agents)
+- **Multi-agent support** — Claude Code, Cursor, Windsurf, Roo Code, Kilo Code, Antigravity, OpenCode, Warp, Zencoder, Codex CLI, Codex app, GitHub Copilot, Gemini CLI, Junie, Qwen Code, or [any agent](docs/getting-started.md#supported-agents)
 
 ---
 
@@ -71,6 +71,8 @@ Then open your AI agent and start working:
 ```
 /aif
 ```
+
+Codex CLI and Codex app use `$aif` style invocations after installation.
 
 Need CLI flags, update/upgrade details, or extension commands? See [Getting Started](docs/getting-started.md). Need slash-command reference? See [Core Skills](docs/skills.md).
 
@@ -141,6 +143,7 @@ See the full [Development Workflow](docs/workflow.md) with diagram and decision 
 - [Warp](https://www.warp.dev) - Intelligent terminal with AI agent
 - [Zencoder](https://zencoder.ai) - AI coding agent for VS Code and JetBrains
 - [Codex CLI](https://github.com/openai/codex) - OpenAI's coding agent
+- [Codex app](https://openai.com/codex/) - OpenAI's coding agent app
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) - Google's coding agent
 - [Antigravity](https://antigravity.dev) - AI coding agent
 - [Junie](https://www.jetbrains.com/junie/) - JetBrains' AI coding agent

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,6 +54,18 @@
         "chromeDevtools": false,
         "playwright": false
       }
+    },
+    {
+      "id": "codex-app",
+      "skillsDir": ".agents/skills",
+      "installedSkills": ["aif", "aif-plan"],
+      "mcp": {
+        "github": true,
+        "postgres": false,
+        "filesystem": true,
+        "chromeDevtools": false,
+        "playwright": true
+      }
     }
   ],
   "extensions": [
@@ -66,7 +78,7 @@
 }
 ```
 
-The `agents` array can include any built-in agent IDs plus runtime IDs provided by installed extensions. Each agent keeps its own `skillsDir`, installed skills list, and MCP preferences. Runtimes that support custom agent files also persist `agentsDir` and `installedAgentFiles`, so `ai-factory update` can refresh package-managed agent files alongside skills. AI Factory additionally stores internal `managedSkills`, `managedAgentFiles`, and `agentFileSources` maps in `.ai-factory.json`; they are omitted from the example above for brevity. `managedAgentFiles` keeps source/install hashes, while `agentFileSources` records whether each tracked agent file comes from the bundled package inventory or from an extension manifest. `loadConfig()` still reads legacy Claude-only `subagentsDir`, `installedSubagents`, and `managedSubagents` keys for backward compatibility, but new saves use the universal field names and backfill `agentFileSources` when the source can be recovered from bundled inventory or installed extension manifests.
+The `agents` array can include any built-in agent IDs plus runtime IDs provided by installed extensions. Each agent keeps its own `skillsDir`, installed skills list, and MCP preferences. Runtimes that support custom agent files also persist `agentsDir` and `installedAgentFiles`, so `ai-factory update` can refresh package-managed agent files alongside skills. Codex app is currently skills-first: it installs Codex-style skills into `.agents/skills` and can write MCP config to `.codex/config.toml`, but it does not define a runtime-global `agentsDir`. AI Factory additionally stores internal `managedSkills`, `managedAgentFiles`, and `agentFileSources` maps in `.ai-factory.json`; they are omitted from the example above for brevity. `managedAgentFiles` keeps source/install hashes, while `agentFileSources` records whether each tracked agent file comes from the bundled package inventory or from an extension manifest. `loadConfig()` still reads legacy Claude-only `subagentsDir`, `installedSubagents`, and `managedSubagents` keys for backward compatibility, but new saves use the universal field names and backfill `agentFileSources` when the source can be recovered from bundled inventory or installed extension manifests.
 
 Extension-provided agent files can target non-Claude runtimes such as Codex. Those files are often bounded helper workers (for example, one-shot reviewers or plan polishers), not automatic equivalents of the bundled Claude coordinator agents. Documentation and prompts should describe those support boundaries explicitly instead of implying full parity across runtimes. AI Factory copies those runtime-specific agent files verbatim; runtime-local keys such as `model`, `model_reasoning_effort`, `sandbox_mode`, and `developer_instructions` belong in the agent file itself rather than in `.ai-factory.json` or workflow prompts. For bounded Codex helpers, prefer read-only advisory workers unless the runtime-native agent truly owns writes to a specific artifact.
 
@@ -213,7 +225,7 @@ AI Factory can configure these MCP servers:
 | Chrome Devtools | Browser inspection, debugging, performance | - |
 | Playwright | Browser automation, web testing | - |
 
-Configuration saved to agent's settings file (e.g. `.mcp.json` for Claude Code, `.cursor/mcp.json` for Cursor, `.vscode/mcp.json` for GitHub Copilot, `.roo/mcp.json` for Roo Code, `.kilocode/mcp.json` for Kilo Code, `opencode.json` for OpenCode).
+Configuration saved to agent's settings file (e.g. `.mcp.json` for Claude Code, `.cursor/mcp.json` for Cursor, `.vscode/mcp.json` for GitHub Copilot, `.roo/mcp.json` for Roo Code, `.kilocode/mcp.json` for Kilo Code, `opencode.json` for OpenCode, `.codex/config.toml` for Codex app).
 
 ### Runtime Format Contract
 
@@ -224,10 +236,11 @@ Quick key mapping:
 - Standard MCP runtimes use `mcpServers.<server>`
 - OpenCode uses `mcp.<server>`
 - GitHub Copilot uses `servers.<server>`
+- Codex app uses TOML tables under `mcp_servers.<server>`
 
 ### Environment Variables
 
-MCP configs use `${VAR}` placeholders for credentials. OpenCode stores credentials under `environment`, while GitHub Copilot receives `${env:VAR}` in `.vscode/mcp.json`. Set them before launching the agent:
+MCP configs use `${VAR}` placeholders for credentials. OpenCode stores credentials under `environment`, GitHub Copilot receives `${env:VAR}` in `.vscode/mcp.json`, and Codex app receives credential names in `env_vars` inside `.codex/config.toml`. Set them before launching the agent:
 
 ```bash
 export GITHUB_TOKEN="ghp_your_token"
@@ -311,6 +324,7 @@ your-project/
 │           ├── test-plan.md
 │           └── test-cases.md
 ├── .mcp.json                  # MCP servers config (Claude Code project scope)
+├── .codex/config.toml         # Codex app MCP config when Codex app is selected
 └── .ai-factory.json           # AI Factory config
 ```
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -376,7 +376,7 @@ Same format as built-in MCP templates:
 }
 ```
 
-The template is merged into the agent's settings file under `mcpServers.<key>` (or `servers.<key>` for GitHub Copilot, `mcp.<key>` for OpenCode, `[mcp_servers.<key>]` in `.codex/config.toml` for Codex app). Only agents with `supportsMcp: true` are configured. On `extension remove`, the key is deleted from the settings file; for Codex app, only the matching TOML server table and nested env table are removed.
+The template is merged into the agent's settings file under `mcpServers.<key>` (or `servers.<key>` for GitHub Copilot, `mcp.<key>` for OpenCode, `[mcp_servers.<key>]` in `.codex/config.toml` for Codex app). Only agents with `supportsMcp: true` are configured. On `extension remove`, the key is deleted from the settings file; for Codex app, the matching TOML server table and all nested subtables are removed.
 
 ---
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -376,7 +376,7 @@ Same format as built-in MCP templates:
 }
 ```
 
-The template is merged into the agent's settings file under `mcpServers.<key>` (or `servers.<key>` for GitHub Copilot, `mcp.<key>` for OpenCode). Only agents with `supportsMcp: true` are configured. On `extension remove`, the key is deleted from the settings file.
+The template is merged into the agent's settings file under `mcpServers.<key>` (or `servers.<key>` for GitHub Copilot, `mcp.<key>` for OpenCode, `[mcp_servers.<key>]` in `.codex/config.toml` for Codex app). Only agents with `supportsMcp: true` are configured. On `extension remove`, the key is deleted from the settings file; for Codex app, only the matching TOML server table and nested env table are removed.
 
 ---
 
@@ -428,6 +428,7 @@ Use `agentFiles` to provide runtime-specific custom agent assets without conflat
 
 Rules:
 - `runtime` must exist in the effective registry (built-in or provided by an installed extension, including the current manifest).
+- Codex app is skills-first and does not define a runtime-global `agentsDir`; extension `agentFiles` cannot target `codex-app` unless that runtime contract is added later.
 - `source` and `target` must be safe relative paths.
 - Source and target extensions must match the runtime's `agentFileExtension`.
 - Ownership is exclusive per `runtime + target`; conflicts with bundled Claude files or another extension are rejected before install.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,6 +27,7 @@ AI Factory works with any AI coding agent. During `ai-factory init`, you choose 
 | Warp | `.warp/` | `.warp/skills/` |
 | Zencoder | `.zencoder/` | `.zencoder/skills/` |
 | Codex CLI | `.codex/` | `.codex/skills/` |
+| Codex app | `.agents/` | `.agents/skills/` |
 | GitHub Copilot | `.github/` | `.github/skills/` |
 | Gemini CLI | `.gemini/` | `.gemini/skills/` |
 | Junie | `.junie/` | `.junie/skills/` |
@@ -35,7 +36,9 @@ AI Factory works with any AI coding agent. During `ai-factory init`, you choose 
 
 When Claude Code is selected, AI Factory installs bundled Claude agent files into `.claude/agents/` and tracks them in `.ai-factory.json` with the universal `agentsDir`, `installedAgentFiles`, and `managedAgentFiles` fields. Extensions can also provide agent files for Codex or extension-defined runtimes. Claude-specific bundled roles are documented in [Subagents](subagents.md).
 
-MCP server configuration is supported for Claude Code, Cursor, GitHub Copilot, Roo Code, Kilo Code, OpenCode, and Qwen Code. Other agents get skills installed with correct paths but without MCP auto-configuration.
+Codex CLI and Codex app receive Codex-style skill content and use `$aif-*` invocations. Slash-command runtimes keep `/aif-*` examples. Because Codex app and Universal both write to `.agents/skills/` with different invocation styles, select one of those runtimes per project.
+
+MCP server configuration is supported for Claude Code, Cursor, GitHub Copilot, Roo Code, Kilo Code, OpenCode, Qwen Code, and Codex app. Other agents get skills installed with correct paths but without MCP auto-configuration.
 
 ## Your First Project
 
@@ -52,6 +55,7 @@ ai-factory init
 
 # 4. Open your AI agent (Claude Code, Cursor, etc.) and run:
 /aif
+# Codex CLI and Codex app use: $aif
 
 # 5. Optional discovery before planning
 /aif-explore Add user authentication with OAuth

--- a/docs/security.md
+++ b/docs/security.md
@@ -82,7 +82,7 @@ python3 .claude/skills/aif-skill-generator/scripts/security-scan.py ./my-skill/S
 
 # For other agents, adjust the path accordingly:
 # python3 .codex/skills/aif-skill-generator/scripts/security-scan.py ./my-skill/
-# python3 .agents/skills/aif-skill-generator/scripts/security-scan.py ./my-skill/
+# python3 .agents/skills/aif-skill-generator/scripts/security-scan.py ./my-skill/  # Codex app or Universal
 ```
 
 ## Internal Self-Scan (AI Factory repo)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:dead": "knip --reporter compact",
     "lint": "npm run lint:unused && npm run lint:dead",
     "clean": "rm -rf dist",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run clean && npm run build",
     "link": "npm run build && npm link"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "claude",
     "cursor",
     "codex",
+    "codex-app",
     "opencode",
     "kilocode",
     "windsurf",

--- a/scripts/test-gate-result-contract.sh
+++ b/scripts/test-gate-result-contract.sh
@@ -180,15 +180,18 @@ assert_contains "$CONTRACT_REF" '/aif-commit' "contract documents commit as clea
 
 echo -e "\n${BOLD}=== Gate skill output contracts ===${NC}\n"
 
-declare -A GATE_SKILLS=(
-  [verify]="$ROOT_DIR/skills/aif-verify/SKILL.md"
-  [review]="$ROOT_DIR/skills/aif-review/SKILL.md"
-  [security]="$ROOT_DIR/skills/aif-security-checklist/SKILL.md"
-  [rules]="$ROOT_DIR/skills/aif-rules-check/SKILL.md"
-)
+gate_skill_file() {
+    case "$1" in
+        verify) printf "%s\n" "$ROOT_DIR/skills/aif-verify/SKILL.md" ;;
+        review) printf "%s\n" "$ROOT_DIR/skills/aif-review/SKILL.md" ;;
+        security) printf "%s\n" "$ROOT_DIR/skills/aif-security-checklist/SKILL.md" ;;
+        rules) printf "%s\n" "$ROOT_DIR/skills/aif-rules-check/SKILL.md" ;;
+        *) return 1 ;;
+    esac
+}
 
 for gate in verify review security rules; do
-    file="${GATE_SKILLS[$gate]}"
+    file="$(gate_skill_file "$gate")"
     assert_contains "$file" '```aif-gate-result' "$gate skill includes aif-gate-result fence"
     assert_contains "$file" '"gate": "' "$gate skill includes gate field in JSON example"
     assert_contains "$file" '"status": "pass|warn|fail"' "$gate skill documents pass/warn/fail status"

--- a/scripts/test-init.sh
+++ b/scripts/test-init.sh
@@ -191,6 +191,11 @@ if (cd "$CONFLICT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agen
 fi
 assert_contains "$TMPDIR/init-codex-app-conflict.log" "universal, codex-app" "conflict error must include both runtime ids"
 assert_contains "$TMPDIR/init-codex-app-conflict.log" "\.agents/skills" "conflict error must include the shared skillsDir"
+if grep -Eq '^[[:space:]]+at ' "$TMPDIR/init-codex-app-conflict.log"; then
+  echo "Assertion failed: conflict error must not print a stack trace"
+  cat "$TMPDIR/init-codex-app-conflict.log"
+  exit 1
+fi
 
 echo "codex app init smoke tests passed"
 

--- a/scripts/test-init.sh
+++ b/scripts/test-init.sh
@@ -276,7 +276,8 @@ cat > "$CODEX_APP_MCP_EXTENSION_DIR/extension.json" << 'EOF'
         "args": ["server.js"],
         "env": {
           "AIF_TOKEN": "${AIF_TOKEN}",
-          "AIF_LITERAL": "literal-value"
+          "AIF_LITERAL": "literal-value",
+          "AIF.SCOPE": "literal-scope"
         }
       },
       "instruction": "Set AIF_TOKEN"
@@ -301,6 +302,7 @@ assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" 'args 
 assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" 'env_vars = \["AIF_TOKEN"\]' "Codex app extension MCP add must convert env references"
 assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" '^\[mcp_servers\.codex-app-smoke\.env\]$' "Codex app extension MCP add must write literal env table"
 assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" 'AIF_LITERAL = "literal-value"' "Codex app extension MCP add must preserve literal env values"
+assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" '"AIF\.SCOPE" = "literal-scope"' "Codex app extension MCP add must quote unsafe literal env keys"
 
 cat >> "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" << 'EOF'
 

--- a/scripts/test-init.sh
+++ b/scripts/test-init.sh
@@ -50,6 +50,20 @@ assert_not_exists() {
   fi
 }
 
+assert_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  local hint="$3"
+  if grep -qE "$pattern" "$file"; then
+    echo "Assertion failed: $hint"
+    echo "Pattern: $pattern"
+    echo "--- output ---"
+    cat "$file"
+    echo "--------------"
+    exit 1
+  fi
+}
+
 INIT_OUTPUT="$TMPDIR/init-claude.log"
 EXPECTED_SUBAGENTS=$(find "$ROOT_DIR/subagents" -type f | wc -l | tr -d ' ')
 
@@ -128,6 +142,110 @@ assert_exists "$FLAT_PROJECT_DIR/.agent/workflows/references/RULES-CHECK-CONTRAC
 assert_not_exists "$FLAT_PROJECT_DIR/.agent/skills/aif-rules-check" "workflow-classified skills must not remain under .agent/skills/"
 
 echo "flat workflow init smoke tests passed"
+
+# -------------------------------------------------------------------
+# Codex app skills smoke: Codex app uses the repository skills location
+# with Codex-style $aif invocations, while Universal remains unchanged.
+# -------------------------------------------------------------------
+
+CODEX_APP_PROJECT_DIR="$TMPDIR/init-smoke-codex-app"
+mkdir -p "$CODEX_APP_PROJECT_DIR"
+
+(cd "$CODEX_APP_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agents codex-app --skills aif,aif-plan > "$TMPDIR/init-codex-app.log" 2>&1)
+
+assert_contains "$TMPDIR/init-codex-app.log" "Codex app:" "Codex app summary must be printed"
+assert_exists "$CODEX_APP_PROJECT_DIR/.agents/skills/aif/SKILL.md" "Codex app must install aif into repo skills"
+assert_exists "$CODEX_APP_PROJECT_DIR/.agents/skills/aif-plan/SKILL.md" "Codex app must install aif-plan into repo skills"
+assert_contains "$CODEX_APP_PROJECT_DIR/.agents/skills/aif/SKILL.md" '\$aif-skill-generator' "Codex app skills must use Codex $ invocation"
+assert_not_contains "$CODEX_APP_PROJECT_DIR/.agents/skills/aif/SKILL.md" '(^|[^$])`/aif-skill-generator`' "Codex app skills must not keep slash invocation examples"
+assert_contains "$CODEX_APP_PROJECT_DIR/.agents/skills/aif/SKILL.md" '~/.agents/skills/aif-skill-generator/scripts/security-scan\.py' "Codex app transformer must not rewrite skill directory paths"
+assert_contains "$CODEX_APP_PROJECT_DIR/.agents/skills/aif/SKILL.md" '\.\./aif-skill-generator/SKILL\.md' "Codex app transformer must not rewrite relative markdown links"
+node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];if(a.id!=='codex-app')process.exit(1);if(a.skillsDir!=='.agents/skills')process.exit(1);if(a.agentsDir)process.exit(1);" "$CODEX_APP_PROJECT_DIR/.ai-factory.json"
+
+CODEX_APP_MCP_PROJECT_DIR="$TMPDIR/init-smoke-codex-app-mcp"
+mkdir -p "$CODEX_APP_MCP_PROJECT_DIR"
+
+(cd "$CODEX_APP_MCP_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agents codex-app --skills aif --mcp filesystem,playwright,github > "$TMPDIR/init-codex-app-mcp.log" 2>&1)
+
+assert_exists "$CODEX_APP_MCP_PROJECT_DIR/.codex/config.toml" "Codex app MCP init must write project config.toml"
+assert_contains "$CODEX_APP_MCP_PROJECT_DIR/.codex/config.toml" '^\[mcp_servers\.filesystem\]$' "Codex app MCP init must write filesystem server table"
+assert_contains "$CODEX_APP_MCP_PROJECT_DIR/.codex/config.toml" 'args = \["-y", "@modelcontextprotocol/server-filesystem", "\."\]' "Codex app filesystem MCP args must be TOML array syntax"
+assert_contains "$CODEX_APP_MCP_PROJECT_DIR/.codex/config.toml" '^\[mcp_servers\.playwright\]$' "Codex app MCP init must write playwright server table"
+assert_contains "$CODEX_APP_MCP_PROJECT_DIR/.codex/config.toml" '^\[mcp_servers\.github\]$' "Codex app MCP init must write github server table"
+assert_contains "$CODEX_APP_MCP_PROJECT_DIR/.codex/config.toml" 'env_vars = \["GITHUB_TOKEN"\]' "Codex app MCP env references must become env_vars"
+node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];if(a.id!=='codex-app')process.exit(1);if(a.mcp.github!==true||a.mcp.filesystem!==true||a.mcp.playwright!==true)process.exit(1);" "$CODEX_APP_MCP_PROJECT_DIR/.ai-factory.json"
+
+UNIVERSAL_PROJECT_DIR="$TMPDIR/init-smoke-universal"
+mkdir -p "$UNIVERSAL_PROJECT_DIR"
+
+(cd "$UNIVERSAL_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agents universal --skills aif > "$TMPDIR/init-universal.log" 2>&1)
+assert_exists "$UNIVERSAL_PROJECT_DIR/.agents/skills/aif/SKILL.md" "Universal must still install aif into repo skills"
+assert_contains "$UNIVERSAL_PROJECT_DIR/.agents/skills/aif/SKILL.md" '`/aif-skill-generator`' "Universal must keep slash invocation examples"
+
+CONFLICT_PROJECT_DIR="$TMPDIR/init-smoke-codex-app-universal-conflict"
+mkdir -p "$CONFLICT_PROJECT_DIR"
+if (cd "$CONFLICT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agents universal,codex-app --skills aif > "$TMPDIR/init-codex-app-conflict.log" 2>&1); then
+  echo "Assertion failed: universal and codex-app must not be allowed to share .agents/skills"
+  cat "$TMPDIR/init-codex-app-conflict.log"
+  exit 1
+fi
+assert_contains "$TMPDIR/init-codex-app-conflict.log" "universal, codex-app" "conflict error must include both runtime ids"
+assert_contains "$TMPDIR/init-codex-app-conflict.log" "\.agents/skills" "conflict error must include the shared skillsDir"
+
+echo "codex app init smoke tests passed"
+
+# -------------------------------------------------------------------
+# Codex app extension MCP smoke: extension-provided MCP servers must
+# be added to and removed from Codex project-scoped TOML settings.
+# -------------------------------------------------------------------
+
+CODEX_APP_MCP_EXTENSION_DIR="$TMPDIR/codex-app-mcp-extension"
+CODEX_APP_MCP_EXTENSION_PROJECT_DIR="$TMPDIR/init-smoke-codex-app-mcp-extension"
+mkdir -p "$CODEX_APP_MCP_EXTENSION_DIR" "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex"
+
+cat > "$CODEX_APP_MCP_EXTENSION_DIR/extension.json" << 'EOF'
+{
+  "name": "aif-ext-codex-app-mcp",
+  "version": "1.0.0",
+  "mcpServers": [
+    {
+      "key": "codex-app-smoke",
+      "template": {
+        "command": "node",
+        "args": ["server.js"],
+        "env": {
+          "AIF_TOKEN": "${AIF_TOKEN}",
+          "AIF_LITERAL": "literal-value"
+        }
+      },
+      "instruction": "Set AIF_TOKEN"
+    }
+  ]
+}
+EOF
+
+cat > "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" << 'EOF'
+[sandbox_workspace_write]
+network_access = false
+EOF
+
+(cd "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agents codex-app --skills aif > "$TMPDIR/init-codex-app-mcp-extension-base.log" 2>&1)
+(cd "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" extension add "$CODEX_APP_MCP_EXTENSION_DIR" > "$TMPDIR/init-codex-app-mcp-extension-add.log" 2>&1)
+
+assert_contains "$TMPDIR/init-codex-app-mcp-extension-add.log" "MCP servers configured: codex-app-smoke" "Codex app extension MCP add must report configured server"
+assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" '^\[sandbox_workspace_write\]$' "Codex app extension MCP add must preserve unrelated TOML settings"
+assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" '^\[mcp_servers\.codex-app-smoke\]$' "Codex app extension MCP add must write server table"
+assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" 'command = "node"' "Codex app extension MCP add must write command"
+assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" 'args = \["server\.js"\]' "Codex app extension MCP add must write args"
+assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" 'env_vars = \["AIF_TOKEN"\]' "Codex app extension MCP add must convert env references"
+assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" '^\[mcp_servers\.codex-app-smoke\.env\]$' "Codex app extension MCP add must write literal env table"
+assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" 'AIF_LITERAL = "literal-value"' "Codex app extension MCP add must preserve literal env values"
+
+(cd "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" extension remove aif-ext-codex-app-mcp > "$TMPDIR/init-codex-app-mcp-extension-remove.log" 2>&1)
+assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" '^\[sandbox_workspace_write\]$' "Codex app extension MCP remove must preserve unrelated TOML settings"
+assert_not_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" 'codex-app-smoke' "Codex app extension MCP remove must remove server tables"
+
+echo "codex app extension MCP smoke tests passed"
 
 # -------------------------------------------------------------------
 # Extension agent files + dynamic runtime smoke: init should accept

--- a/scripts/test-init.sh
+++ b/scripts/test-init.sh
@@ -197,6 +197,62 @@ if grep -Eq '^[[:space:]]+at ' "$TMPDIR/init-codex-app-conflict.log"; then
   exit 1
 fi
 
+INTERACTIVE_CONFLICT_PROJECT_DIR="$TMPDIR/init-smoke-codex-app-universal-interactive-conflict"
+mkdir -p "$INTERACTIVE_CONFLICT_PROJECT_DIR"
+AIF_TEST_ROOT_DIR="$ROOT_DIR" AIF_TEST_PROJECT_DIR="$INTERACTIVE_CONFLICT_PROJECT_DIR" node --input-type=module > "$TMPDIR/init-codex-app-interactive-conflict.log" 2>&1 <<'EOF'
+import inquirer from 'inquirer';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+const promptQueue = [
+  { selectedAgents: ['universal', 'codex-app'], selectedSkills: ['aif'] },
+  { configureMcp: false },
+];
+
+const originalPrompt = inquirer.prompt.bind(inquirer);
+const originalExit = process.exit;
+let exitCode = null;
+
+inquirer.prompt = async (questions) => {
+  const next = promptQueue.shift();
+  if (!next) {
+    throw new Error(`Unexpected prompt: ${JSON.stringify(questions)}`);
+  }
+  return next;
+};
+process.exit = (code = 0) => {
+  exitCode = code;
+  throw new Error(`PROCESS_EXIT:${code}`);
+};
+
+process.chdir(process.env.AIF_TEST_PROJECT_DIR);
+
+const moduleUrl = pathToFileURL(path.join(process.env.AIF_TEST_ROOT_DIR, 'dist/cli/commands/init.js')).href;
+const { initCommand } = await import(moduleUrl);
+
+try {
+  await initCommand();
+  throw new Error('initCommand unexpectedly succeeded');
+} catch (error) {
+  if (!String(error.message).startsWith('PROCESS_EXIT:')) {
+    throw error;
+  }
+  if (exitCode !== 1) {
+    throw new Error(`Expected exit code 1, got ${exitCode}`);
+  }
+} finally {
+  inquirer.prompt = originalPrompt;
+  process.exit = originalExit;
+}
+EOF
+assert_contains "$TMPDIR/init-codex-app-interactive-conflict.log" "universal, codex-app" "interactive conflict error must include both runtime ids"
+assert_contains "$TMPDIR/init-codex-app-interactive-conflict.log" "\.agents/skills" "interactive conflict error must include the shared skillsDir"
+if grep -Eq '^[[:space:]]+at ' "$TMPDIR/init-codex-app-interactive-conflict.log"; then
+  echo "Assertion failed: interactive conflict error must not print a stack trace"
+  cat "$TMPDIR/init-codex-app-interactive-conflict.log"
+  exit 1
+fi
+
 echo "codex app init smoke tests passed"
 
 # -------------------------------------------------------------------
@@ -246,9 +302,19 @@ assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" 'env_v
 assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" '^\[mcp_servers\.codex-app-smoke\.env\]$' "Codex app extension MCP add must write literal env table"
 assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" 'AIF_LITERAL = "literal-value"' "Codex app extension MCP add must preserve literal env values"
 
+cat >> "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" << 'EOF'
+
+[mcp_servers.codex-app-smoke.tools.search]
+approval = "never"
+
+[mcp_servers.unrelated.tools.keep]
+approval = "always"
+EOF
+
 (cd "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" extension remove aif-ext-codex-app-mcp > "$TMPDIR/init-codex-app-mcp-extension-remove.log" 2>&1)
 assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" '^\[sandbox_workspace_write\]$' "Codex app extension MCP remove must preserve unrelated TOML settings"
 assert_not_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" 'codex-app-smoke' "Codex app extension MCP remove must remove server tables"
+assert_contains "$CODEX_APP_MCP_EXTENSION_PROJECT_DIR/.codex/config.toml" '^\[mcp_servers\.unrelated\.tools\.keep\]$' "Codex app extension MCP remove must preserve unrelated nested TOML tables"
 
 echo "codex app extension MCP smoke tests passed"
 

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -125,6 +125,106 @@ assert_contains "$FORCE_OUTPUT" "force reinstall" "force reason should be visibl
 echo "update smoke tests passed"
 
 # -------------------------------------------------------------------
+# Codex app update smoke: repo skills should keep Codex $ invocations,
+# custom skills should be preserved, and incompatible shared repo skills
+# runtime configs should fail before mutation.
+# -------------------------------------------------------------------
+
+CODEX_APP_PROJECT_DIR="$TMPDIR/update-smoke-codex-app"
+mkdir -p "$CODEX_APP_PROJECT_DIR/.agents/skills/custom/local-helper"
+
+cat > "$CODEX_APP_PROJECT_DIR/.ai-factory.json" << 'EOF'
+{
+  "version": "2.4.0",
+  "agents": [
+    {
+      "id": "codex-app",
+      "skillsDir": ".agents/skills",
+      "installedSkills": ["aif", "aif-plan", "custom/local-helper"],
+      "mcp": {
+        "github": false,
+        "filesystem": false,
+        "postgres": false,
+        "chromeDevtools": false,
+        "playwright": false
+      }
+    }
+  ],
+  "extensions": []
+}
+EOF
+
+cat > "$CODEX_APP_PROJECT_DIR/.agents/skills/custom/local-helper/SKILL.md" << 'EOF'
+---
+name: local-helper
+description: local custom skill
+---
+EOF
+
+CODEX_APP_FIRST_OUTPUT="$TMPDIR/update-codex-app-first.log"
+CODEX_APP_FORCE_OUTPUT="$TMPDIR/update-codex-app-force.log"
+
+(cd "$CODEX_APP_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update > "$CODEX_APP_FIRST_OUTPUT" 2>&1)
+assert_contains "$CODEX_APP_FIRST_OUTPUT" "\[codex-app\] Status:" "codex-app status section must be printed"
+assert_contains "$CODEX_APP_FIRST_OUTPUT" "WARN: managed state recovered" "codex-app managed state recovery warning expected on first run"
+assert_exists "$CODEX_APP_PROJECT_DIR/.agents/skills/aif/SKILL.md" "codex-app update must install aif into repo skills"
+assert_contains "$CODEX_APP_PROJECT_DIR/.agents/skills/aif/SKILL.md" '\$aif-skill-generator' "codex-app update must keep Codex $ invocation"
+assert_not_contains "$CODEX_APP_PROJECT_DIR/.agents/skills/aif/SKILL.md" '(^|[^$])`/aif-skill-generator`' "codex-app update must not keep slash invocation examples"
+assert_exists "$CODEX_APP_PROJECT_DIR/.agents/skills/custom/local-helper/SKILL.md" "codex-app update must preserve custom skills"
+
+(cd "$CODEX_APP_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update --force > "$CODEX_APP_FORCE_OUTPUT" 2>&1)
+assert_contains "$CODEX_APP_FORCE_OUTPUT" "Force mode enabled" "codex-app force update must print force mode"
+assert_contains "$CODEX_APP_FORCE_OUTPUT" "aif \(force reinstall\)" "codex-app force update must reinstall base skills"
+assert_contains "$CODEX_APP_PROJECT_DIR/.agents/skills/aif/SKILL.md" '\$aif-skill-generator' "codex-app force update must keep Codex $ invocation"
+assert_exists "$CODEX_APP_PROJECT_DIR/.agents/skills/custom/local-helper/SKILL.md" "codex-app force update must preserve custom skills"
+node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];if(a.id!=='codex-app')process.exit(1);if(a.skillsDir!=='.agents/skills')process.exit(1);if(!Array.isArray(a.installedSkills)||!a.installedSkills.includes('custom/local-helper'))process.exit(1);if(!a.managedSkills||!a.managedSkills.aif||!a.managedSkills['aif-plan'])process.exit(1);" "$CODEX_APP_PROJECT_DIR/.ai-factory.json"
+
+CONFLICT_UPDATE_PROJECT_DIR="$TMPDIR/update-smoke-codex-app-universal-conflict"
+mkdir -p "$CONFLICT_UPDATE_PROJECT_DIR"
+cat > "$CONFLICT_UPDATE_PROJECT_DIR/.ai-factory.json" << 'EOF'
+{
+  "version": "2.4.0",
+  "agents": [
+    {
+      "id": "universal",
+      "skillsDir": ".agents/skills",
+      "installedSkills": ["aif"],
+      "mcp": {
+        "github": false,
+        "filesystem": false,
+        "postgres": false,
+        "chromeDevtools": false,
+        "playwright": false
+      }
+    },
+    {
+      "id": "codex-app",
+      "skillsDir": ".agents/skills",
+      "installedSkills": ["aif"],
+      "mcp": {
+        "github": false,
+        "filesystem": false,
+        "postgres": false,
+        "chromeDevtools": false,
+        "playwright": false
+      }
+    }
+  ],
+  "extensions": []
+}
+EOF
+
+if (cd "$CONFLICT_UPDATE_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update > "$TMPDIR/update-codex-app-conflict.log" 2>&1); then
+  echo "Assertion failed: update must reject universal and codex-app sharing .agents/skills"
+  cat "$TMPDIR/update-codex-app-conflict.log"
+  exit 1
+fi
+assert_contains "$TMPDIR/update-codex-app-conflict.log" "universal, codex-app" "update conflict error must include both runtime ids"
+assert_contains "$TMPDIR/update-codex-app-conflict.log" "\.agents/skills" "update conflict error must include the shared skillsDir"
+
+echo "codex app update smoke tests passed"
+
+# -------------------------------------------------------------------
 # Antigravity force behavior smoke: preserve custom workflow refs,
 # and clean stale files under .agent/skills/<skill>.
 # -------------------------------------------------------------------

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -509,6 +509,7 @@ AI Factory writes MCP config to `{{settings_file}}`, but the outer settings shap
 | Standard MCP runtimes (Claude Code, Cursor, Roo Code, Kilo Code, Qwen Code) | `mcpServers.<server>` | `{ "command": "...", "args": [...], "env": {...} }` |
 | OpenCode | `mcp.<server>` | `{ "type": "local", "command": ["...", "..."], "environment": {...} }` |
 | GitHub Copilot | `servers.<server>` | `{ "type": "stdio", "command": "...", "args": [...], "env": {...} }` |
+| Codex app | `[mcp_servers.<server>]` in `.codex/config.toml` | `command = "..."`, optional `args = [...]`, credential placeholders as `env_vars = ["VAR"]`, literal values under `[mcp_servers.<server>.env]` |
 
 Use the canonical server templates below as the source values, then wrap them using the runtime-specific format above.
 
@@ -606,7 +607,20 @@ GitHub Copilot (`servers` + `type: "stdio"`):
 }
 ```
 
-For GitHub Copilot, convert credential placeholders from `${VAR}` to `${env:VAR}` in the final config file. For OpenCode, use `environment` instead of `env` when the server requires credentials.
+Codex app (`.codex/config.toml` + `mcp_servers` TOML tables):
+
+```toml
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "."]
+
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env_vars = ["GITHUB_TOKEN"]
+```
+
+For GitHub Copilot, convert credential placeholders from `${VAR}` to `${env:VAR}` in the final config file. For OpenCode, use `environment` instead of `env` when the server requires credentials. For Codex app, convert credential placeholders from `${VAR}` to `env_vars = ["VAR"]`; only literal values belong under `[mcp_servers.<server>.env]`.
 
 ---
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -330,10 +330,13 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
       console.log(chalk.yellow('\nSetup cancelled.'));
       return;
     }
+    if (message.startsWith('Incompatible agent skill targets:')) {
+      console.error(chalk.red(`\nError: ${message}`));
+      process.exit(1);
+    }
     if (nonInteractive && (
       message.startsWith('Unknown ')
       || message.startsWith('At least one ')
-      || message.startsWith('Incompatible agent skill targets:')
     )) {
       console.error(chalk.red(`\nError: ${message}`));
       process.exit(1);

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -14,7 +14,7 @@ import {
 import { saveConfig, configExists, loadConfig, getCurrentVersion, type AgentInstallation } from '../../core/config.js';
 import { configureMcp, getMcpInstructions } from '../../core/mcp.js';
 import { getAgentConfig, getAvailableAgentIds, hydrateProjectAgentRegistry } from '../../core/agents.js';
-import { cleanupAgentSetup, getAgentOnboarding } from '../../core/transformer.js';
+import { assertCompatibleSkillTargets, cleanupAgentSetup, getAgentOnboarding } from '../../core/transformer.js';
 import { removeDirectory, removeFile, copyFile, fileExists, getSkillsDir } from '../../utils/fs.js';
 import { applyExtensionInjections } from '../../core/injections.js';
 import {
@@ -145,6 +145,13 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     } else {
       answers = await runWizard(existingAgentIds);
     }
+
+    assertCompatibleSkillTargets(
+      answers.agents.map(agent => ({
+        id: agent.id,
+        skillsDir: getAgentConfig(agent.id).skillsDir,
+      })),
+    );
 
     const selectedAgentIds = new Set(answers.agents.map(agent => agent.id));
     const removedAgents = (existingConfig?.agents ?? []).filter(agent => !selectedAgentIds.has(agent.id));
@@ -311,7 +318,10 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
       .filter(Boolean)
       .join('; ');
 
-    console.log(chalk.dim(`  ${installedAgents.length + 1}. Use /aif-plan and /aif-commit for daily workflow${invocationHints ? ` (${invocationHints})` : ''}`));
+    const dailyWorkflowStep = invocationHints
+      ? `Use daily workflow skills (${invocationHints})`
+      : 'Use /aif-plan and /aif-commit for daily workflow';
+    console.log(chalk.dim(`  ${installedAgents.length + 1}. ${dailyWorkflowStep}`));
     console.log('');
 
   } catch (error) {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -330,7 +330,11 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
       console.log(chalk.yellow('\nSetup cancelled.'));
       return;
     }
-    if (nonInteractive && (message.startsWith('Unknown ') || message.startsWith('At least one '))) {
+    if (nonInteractive && (
+      message.startsWith('Unknown ')
+      || message.startsWith('At least one ')
+      || message.startsWith('Incompatible agent skill targets:')
+    )) {
       console.error(chalk.red(`\nError: ${message}`));
       process.exit(1);
     }

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -18,6 +18,7 @@ import {
   updateSubagents,
 } from '../../core/installer.js';
 import {applyExtensionInjections} from '../../core/injections.js';
+import {assertCompatibleSkillTargets} from '../../core/transformer.js';
 import {
   installExtensionSkillsForAllAgents,
   installExtensionAgentFilesForAllAgents,
@@ -169,6 +170,8 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
   await hydrateProjectAgentRegistry(projectDir, {
     extensionNames: config.extensions?.map(extension => extension.name) ?? [],
   });
+
+  assertCompatibleSkillTargets(config.agents);
 
   const currentVersion = getCurrentVersion();
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,7 +16,7 @@ program
 program
   .command('init')
   .description('Initialize ai-factory in current project')
-  .option('--agents <agents>', 'Comma-separated list of agents (e.g. claude,codex,cursor)')
+  .option('--agents <agents>', 'Comma-separated list of agents (e.g. claude,codex,codex-app,cursor)')
   .option('--mcp <servers>', 'Comma-separated list of MCP servers (e.g. github,playwright,postgres,filesystem,chrome-devtools)')
   .option('--skills <skills>', 'Comma-separated list of skills or "all" for all skills (default: all)')
   .option('--no-skills', 'Skip installing base skills')

--- a/src/core/agents.ts
+++ b/src/core/agents.ts
@@ -68,6 +68,16 @@ const BUILTIN_AGENT_REGISTRY: Record<string, AgentConfig> = {
     skillsCliAgent: 'codex',
     source: 'builtin',
   },
+  'codex-app': {
+    id: 'codex-app',
+    displayName: 'Codex app',
+    configDir: '.agents',
+    skillsDir: '.agents/skills',
+    settingsFile: '.codex/config.toml',
+    supportsMcp: true,
+    skillsCliAgent: null,
+    source: 'builtin',
+  },
   copilot: {
     id: 'copilot',
     displayName: 'GitHub Copilot',

--- a/src/core/mcp-toml.ts
+++ b/src/core/mcp-toml.ts
@@ -88,7 +88,8 @@ function parseTomlTableName(line: string): string | null {
 
 function isManagedServerTable(tableName: string, keys: Set<string>): boolean {
   for (const key of keys) {
-    if (tableName === `mcp_servers.${key}` || tableName === `mcp_servers.${key}.env`) {
+    const serverTable = `mcp_servers.${key}`;
+    if (tableName === serverTable || tableName.startsWith(`${serverTable}.`)) {
       return true;
     }
   }

--- a/src/core/mcp-toml.ts
+++ b/src/core/mcp-toml.ts
@@ -8,6 +8,7 @@ interface CodexTomlServerConfig {
 }
 
 const SERVER_KEY_PATTERN = /^[A-Za-z0-9_-]+$/;
+const TOML_BARE_KEY_PATTERN = /^[A-Za-z0-9_-]+$/;
 const ENV_REF_PATTERN = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/;
 const TOML_TABLE_PATTERN = /^\s*\[([^\]]+)\]\s*(?:#.*)?$/;
 
@@ -19,6 +20,10 @@ function assertValidServerKey(key: string): void {
 
 function formatTomlString(value: string): string {
   return JSON.stringify(value);
+}
+
+function formatTomlKey(value: string): string {
+  return TOML_BARE_KEY_PATTERN.test(value) ? value : formatTomlString(value);
 }
 
 function formatTomlArray(values: string[]): string {
@@ -75,7 +80,7 @@ function serializeCodexMcpServer(key: string, template: McpServerConfig): string
   if (server.env) {
     lines.push('', `[mcp_servers.${key}.env]`);
     for (const [envKey, envValue] of Object.entries(server.env)) {
-      lines.push(`${envKey} = ${formatTomlString(envValue)}`);
+      lines.push(`${formatTomlKey(envKey)} = ${formatTomlString(envValue)}`);
     }
   }
 

--- a/src/core/mcp-toml.ts
+++ b/src/core/mcp-toml.ts
@@ -1,0 +1,134 @@
+import type { McpServerConfig } from './mcp.js';
+
+interface CodexTomlServerConfig {
+  command: string;
+  args?: string[];
+  envVars?: string[];
+  env?: Record<string, string>;
+}
+
+const SERVER_KEY_PATTERN = /^[A-Za-z0-9_-]+$/;
+const ENV_REF_PATTERN = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/;
+const TOML_TABLE_PATTERN = /^\s*\[([^\]]+)\]\s*(?:#.*)?$/;
+
+function assertValidServerKey(key: string): void {
+  if (!SERVER_KEY_PATTERN.test(key)) {
+    throw new Error(`MCP server "${key}": Codex TOML server keys may only contain letters, digits, "_" and "-"`);
+  }
+}
+
+function formatTomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function formatTomlArray(values: string[]): string {
+  return `[${values.map(formatTomlString).join(', ')}]`;
+}
+
+function toCodexTomlFormat(template: McpServerConfig): CodexTomlServerConfig {
+  const result: CodexTomlServerConfig = { command: template.command };
+
+  if (template.args && template.args.length > 0) {
+    result.args = [...template.args];
+  }
+
+  if (template.env && Object.keys(template.env).length > 0) {
+    const envVars: string[] = [];
+    const literalEnv: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(template.env)) {
+      const envRef = value.match(ENV_REF_PATTERN);
+      if (envRef) {
+        envVars.push(envRef[1]);
+      } else {
+        literalEnv[key] = value;
+      }
+    }
+
+    if (envVars.length > 0) {
+      result.envVars = envVars;
+    }
+    if (Object.keys(literalEnv).length > 0) {
+      result.env = literalEnv;
+    }
+  }
+
+  return result;
+}
+
+function serializeCodexMcpServer(key: string, template: McpServerConfig): string {
+  assertValidServerKey(key);
+  const server = toCodexTomlFormat(template);
+  const lines = [
+    `[mcp_servers.${key}]`,
+    `command = ${formatTomlString(server.command)}`,
+  ];
+
+  if (server.args) {
+    lines.push(`args = ${formatTomlArray(server.args)}`);
+  }
+
+  if (server.envVars) {
+    lines.push(`env_vars = ${formatTomlArray(server.envVars)}`);
+  }
+
+  if (server.env) {
+    lines.push('', `[mcp_servers.${key}.env]`);
+    for (const [envKey, envValue] of Object.entries(server.env)) {
+      lines.push(`${envKey} = ${formatTomlString(envValue)}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function parseTomlTableName(line: string): string | null {
+  return line.match(TOML_TABLE_PATTERN)?.[1] ?? null;
+}
+
+function isManagedServerTable(tableName: string, keys: Set<string>): boolean {
+  for (const key of keys) {
+    if (tableName === `mcp_servers.${key}` || tableName === `mcp_servers.${key}.env`) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function removeCodexMcpServersToml(content: string, keys: string[]): string {
+  const keySet = new Set(keys);
+  const lines = content.split(/\r?\n/);
+  const kept: string[] = [];
+  let skipping = false;
+
+  for (const line of lines) {
+    const tableName = parseTomlTableName(line);
+    if (tableName) {
+      skipping = isManagedServerTable(tableName, keySet);
+    }
+
+    if (!skipping) {
+      kept.push(line);
+    }
+  }
+
+  const trimmed = kept.join('\n').trimEnd();
+  return trimmed ? `${trimmed}\n` : '';
+}
+
+export function upsertCodexMcpServersToml(
+  content: string,
+  servers: { key: string; template: McpServerConfig }[],
+): string {
+  const keys = servers.map(server => server.key);
+  const base = removeCodexMcpServersToml(content, keys).trimEnd();
+  const blocks = servers
+    .map(server => serializeCodexMcpServer(server.key, server.template))
+    .join('\n\n');
+
+  if (!blocks) {
+    return base ? `${base}\n` : '';
+  }
+
+  return base ? `${base}\n\n${blocks}\n` : `${blocks}\n`;
+}

--- a/src/core/mcp.ts
+++ b/src/core/mcp.ts
@@ -1,6 +1,7 @@
 import path from 'path';
-import { readJsonFile, writeJsonFile, getMcpDir, ensureDir, fileExists } from '../utils/fs.js';
+import { readJsonFile, writeJsonFile, getMcpDir, ensureDir, fileExists, readTextFile, writeTextFile } from '../utils/fs.js';
 import { getAgentConfig } from './agents.js';
+import { removeCodexMcpServersToml, upsertCodexMcpServersToml } from './mcp-toml.js';
 
 export interface McpServerConfig {
   command: string;
@@ -58,7 +59,7 @@ export interface McpOptions {
   playwright: boolean;
 }
 
-type McpSettingsFormat = 'standard' | 'opencode' | 'vscode';
+type McpSettingsFormat = 'standard' | 'opencode' | 'vscode' | 'codex-toml';
 
 interface McpServerDefinition {
   key: keyof McpOptions;
@@ -151,6 +152,9 @@ async function loadSettings(settingsPath: string): Promise<Record<string, unknow
 }
 
 function resolveMcpSettingsFormat(agentId: string): McpSettingsFormat {
+  if (agentId === 'codex-app') {
+    return 'codex-toml';
+  }
   if (agentId === 'opencode') {
     return 'opencode';
   }
@@ -161,6 +165,9 @@ function resolveMcpSettingsFormat(agentId: string): McpSettingsFormat {
 }
 
 function getContainerKey(format: McpSettingsFormat): 'mcp' | 'mcpServers' | 'servers' {
+  if (format === 'codex-toml') {
+    throw new Error('Codex TOML MCP settings do not use a JSON container key');
+  }
   if (format === 'opencode') {
     return 'mcp';
   }
@@ -176,6 +183,10 @@ function applyServerConfig(
   key: string,
   template: McpServerConfig,
 ): void {
+  if (format === 'codex-toml') {
+    throw new Error('Codex TOML MCP settings must be written through the TOML settings editor');
+  }
+
   if (format === 'opencode') {
     ensureNestedRecord(settings, 'mcp')[key] = toOpenCodeFormat(template);
     return;
@@ -187,6 +198,34 @@ function applyServerConfig(
   }
 
   ensureNestedRecord(settings, 'mcpServers')[key] = template;
+}
+
+async function writeCodexTomlMcpSettings(
+  settingsPath: string,
+  servers: { key: string; template: McpServerConfig }[],
+): Promise<void> {
+  try {
+    const currentSettings = await readTextFile(settingsPath);
+    await writeTextFile(settingsPath, upsertCodexMcpServersToml(currentSettings ?? '', servers));
+  } catch (error) {
+    const keys = servers.map(server => server.key).join(', ');
+    throw new Error(`Failed to write Codex MCP TOML settings at ${settingsPath} for MCP server key(s) ${keys}: ${(error as Error).message}`);
+  }
+}
+
+async function removeCodexTomlMcpSettings(settingsPath: string, keys: string[]): Promise<void> {
+  try {
+    const currentSettings = await readTextFile(settingsPath);
+    if (currentSettings === null) {
+      return;
+    }
+    const nextSettings = removeCodexMcpServersToml(currentSettings, keys);
+    if (nextSettings !== currentSettings) {
+      await writeTextFile(settingsPath, nextSettings);
+    }
+  } catch (error) {
+    throw new Error(`Failed to remove Codex MCP TOML settings at ${settingsPath} for MCP server key(s) ${keys.join(', ')}: ${(error as Error).message}`);
+  }
 }
 
 export async function configureMcp(projectDir: string, options: McpOptions, agentId: string = 'claude'): Promise<string[]> {
@@ -204,7 +243,7 @@ export async function configureMcp(projectDir: string, options: McpOptions, agen
   await ensureDir(settingsDir);
 
   const mcpTemplatesDir = path.join(getMcpDir(), 'templates');
-  const settings = await loadSettings(settingsPath);
+  const selectedServers: { key: string; template: McpServerConfig }[] = [];
 
   for (const server of MCP_SERVERS) {
     if (!options[server.key]) {
@@ -216,11 +255,21 @@ export async function configureMcp(projectDir: string, options: McpOptions, agen
       continue;
     }
 
-    applyServerConfig(settings, format, server.key, template);
+    selectedServers.push({ key: server.key, template });
     configuredServers.push(server.key);
   }
 
-  if (configuredServers.length > 0) {
+  if (configuredServers.length === 0) {
+    return configuredServers;
+  }
+
+  if (format === 'codex-toml') {
+    await writeCodexTomlMcpSettings(settingsPath, selectedServers);
+  } else {
+    const settings = await loadSettings(settingsPath);
+    for (const server of selectedServers) {
+      applyServerConfig(settings, format, server.key, server.template);
+    }
     await writeJsonFile(settingsPath, settings);
   }
 
@@ -247,8 +296,14 @@ export async function configureExtensionMcpServers(
   const format = resolveMcpSettingsFormat(agentId);
   const settingsPath = path.join(projectDir, agent.settingsFile);
   await ensureDir(path.dirname(settingsPath));
-  const settings = await loadSettings(settingsPath);
   const configured: string[] = [];
+
+  if (format === 'codex-toml') {
+    await writeCodexTomlMcpSettings(settingsPath, servers);
+    return servers.map(server => server.key);
+  }
+
+  const settings = await loadSettings(settingsPath);
 
   for (const { key, template } of servers) {
     applyServerConfig(settings, format, key, template);
@@ -274,6 +329,12 @@ export async function removeExtensionMcpServers(
 
   const format = resolveMcpSettingsFormat(agentId);
   const settingsPath = path.join(projectDir, agent.settingsFile);
+
+  if (format === 'codex-toml') {
+    await removeCodexTomlMcpSettings(settingsPath, keys);
+    return;
+  }
+
   const settings = await loadSettings(settingsPath);
   const containerKey = getContainerKey(format);
   const container = settings[containerKey];

--- a/src/core/transformer.ts
+++ b/src/core/transformer.ts
@@ -24,6 +24,11 @@ export interface AgentOnboarding {
   invocationHint: string | null;
 }
 
+export interface SkillTargetRuntime {
+  id: string;
+  skillsDir: string;
+}
+
 export const WORKFLOW_SKILLS = new Set([
   'aif',
   'aif-commit',
@@ -66,7 +71,7 @@ export function removeFrontmatter(content: string): string {
   return content.replace(/^---\n[\s\S]*?\n---\n?/, '');
 }
 
-const INVOCATION_PATTERN = /(^|[^A-Za-z0-9_-])\/(aif(?:-[a-z0-9-]+)?)/g;
+const INVOCATION_PATTERN = /(^|[^A-Za-z0-9_.~\/}-])\/(aif(?:-[a-z0-9-]+)?)/g;
 
 export function rewriteInvocationPrefix(
   content: string,
@@ -78,16 +83,79 @@ export function rewriteInvocationPrefix(
   );
 }
 
-const registry: Record<string, () => AgentTransformer> = {
-  codex: () => new CodexTransformer(),
-  kilocode: () => new KiloCodeTransformer(),
-  qwen: () => new QwenTransformer(),
-  antigravity: () => new AntigravityTransformer(),
+interface TransformerRegistration {
+  create: () => AgentTransformer;
+  identity: string;
+}
+
+const DEFAULT_TRANSFORMER_IDENTITY = 'default';
+
+const registry: Record<string, TransformerRegistration> = {
+  codex: {
+    create: () => new CodexTransformer(),
+    identity: 'codex',
+  },
+  'codex-app': {
+    create: () => new CodexTransformer('Codex app'),
+    identity: 'codex',
+  },
+  kilocode: {
+    create: () => new KiloCodeTransformer(),
+    identity: 'kilocode',
+  },
+  qwen: {
+    create: () => new QwenTransformer(),
+    identity: 'qwen',
+  },
+  antigravity: {
+    create: () => new AntigravityTransformer(),
+    identity: 'antigravity',
+  },
 };
 
 export function getTransformer(agentId: string): AgentTransformer {
-  const factory = registry[agentId];
-  return factory ? factory() : new DefaultTransformer();
+  const registration = registry[agentId];
+  return registration ? registration.create() : new DefaultTransformer();
+}
+
+export function getTransformerIdentity(agentId: string): string {
+  return registry[agentId]?.identity ?? DEFAULT_TRANSFORMER_IDENTITY;
+}
+
+function normalizeSkillsDir(skillsDir: string): string {
+  return skillsDir.replaceAll('\\', '/').replace(/\/+$/, '');
+}
+
+export function assertCompatibleSkillTargets(targets: SkillTargetRuntime[]): void {
+  const targetsByDir = new Map<string, SkillTargetRuntime[]>();
+
+  for (const target of targets) {
+    const normalizedDir = normalizeSkillsDir(target.skillsDir);
+    targetsByDir.set(normalizedDir, [...(targetsByDir.get(normalizedDir) ?? []), target]);
+  }
+
+  for (const [skillsDir, groupedTargets] of targetsByDir) {
+    const identities = new Map<string, string[]>();
+    for (const target of groupedTargets) {
+      const identity = getTransformerIdentity(target.id);
+      identities.set(identity, [...(identities.get(identity) ?? []), target.id]);
+    }
+
+    if (identities.size <= 1) {
+      continue;
+    }
+
+    const runtimeIds = groupedTargets.map(target => target.id).join(', ');
+    const transformerSummary = [...identities.entries()]
+      .map(([identity, ids]) => `${identity}: ${ids.join(', ')}`)
+      .join('; ');
+
+    throw new Error(
+      `Incompatible agent skill targets: ${runtimeIds} all write to "${skillsDir}" ` +
+      `but use different skill transformers (${transformerSummary}). ` +
+      'Select only one of these agents for this project or configure separate skills directories.',
+    );
+  }
 }
 
 export function getAgentOnboarding(agentId: string): AgentOnboarding {

--- a/src/core/transformers/codex.ts
+++ b/src/core/transformers/codex.ts
@@ -6,6 +6,8 @@ function toCodexInvocation(content: string): string {
 }
 
 export class CodexTransformer implements AgentTransformer {
+  constructor(private readonly runtimeName: string = 'Codex CLI') {}
+
   transform(skillName: string, content: string): TransformResult {
     return {
       targetDir: skillName,
@@ -17,12 +19,12 @@ export class CodexTransformer implements AgentTransformer {
 
   getWelcomeMessage(): string[] {
     return [
-      '1. Open Codex CLI in this directory',
+      `1. Open ${this.runtimeName} in this directory`,
       '2. Run $aif to analyze project and generate project-relevant skills',
     ];
   }
 
   getInvocationHint(): string {
-    return 'Codex CLI: $aif-plan, $aif-commit';
+    return `${this.runtimeName}: $aif-plan, $aif-commit`;
   }
 }


### PR DESCRIPTION
Summary
- Add built-in codex-app runtime using .agents/skills with Codex-style  invocations.
- Add Codex app MCP support in .codex/config.toml with scoped TOML add/remove behavior.
- Add compatibility guard for incompatible runtimes sharing the same skills directory and update docs/tests.

Tests
- npm run build
- node scripts/run-bash-test.mjs scripts/test-init.sh
- NPM_CONFIG_CACHE=/private/tmp/aif-npm-cache npm test

Manual smoke
- Installed github:eljump/ai-factory-fork#feature/codex-app-connector into a fresh project.
- Ran ai-factory init for Codex app, verified .agents/skills, .codex/config.toml, Codex app discovery, and  execution.