### PR TITLE
feat: add artifact audit command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,6 +82,9 @@ ai-factory update --force
 # Migrate existing skills from v1 naming to v2 naming
 ai-factory upgrade
 
+# Audit artifact metadata links (frontmatter id/depends_on/affects/etc.)
+ai-factory audit-artifacts
+
 # Install an extension (local path, git URL, or npm package)
 ai-factory extension add ./my-extension
 
@@ -98,6 +101,8 @@ ai-factory extension update my-extension --force
 ai-factory extension remove my-extension
 ```
 
+See [Plan Files](plan-files.md) for the artifact frontmatter schema, default scan paths, `--json` output, `--strict` exit behavior, and path boundary rules.
+
 ### `ai-factory init` Flags
 
 - `--agents` - Comma-separated target agents (for example `claude,codex`)
@@ -110,6 +115,7 @@ ai-factory extension remove my-extension
 Run `ai-factory upgrade` to migrate old bare-named skills (`commit`, `feature`, etc.) to `aif-*` names. Custom skills are preserved.
 
 `ai-factory update` now:
+- Checks whether a newer `ai-factory` package is available and prints the exact global install command when package-level CLI features require an npm package update
 - Checks for extension updates from their sources (npm, GitHub, etc.) before updating base skills
 - Prints per-agent status buckets for base skills (`changed`, `unchanged`, `skipped`, `removed`)
 - For runtimes with managed agent files, also refreshes bundled package-managed agent files (Claude today) and prints a separate `Agent files` status block

--- a/docs/plan-files.md
+++ b/docs/plan-files.md
@@ -89,7 +89,7 @@ ai-factory audit-artifacts --strict
 ai-factory audit-artifacts --json
 ```
 
-Default discovery scans `.ai-factory`, `docs`, `README.md`, and `AGENTS.md` when those paths exist. This default is intentionally default-layout first; projects that relocate artifact directories through `config.yaml` should pass those paths explicitly until the command becomes config-aware.
+Default discovery scans `.ai-factory`, `docs`, `README.md`, and `AGENTS.md` when those paths exist. Recursive default discovery skips noisy or generated subdirectories such as `qa`, `evolution`, and `evolutions`; pass those paths explicitly when you want to audit them. This default is intentionally default-layout first; projects that relocate artifact directories through `config.yaml` should pass those paths explicitly until the command becomes config-aware.
 
 Positional paths are explicit audit targets. Missing or outside-project explicit targets are failures so CI cannot pass after a typo or file rename. Missing default targets are skipped because many projects do not have every default file. Symlinked targets are canonicalized with `realpath`; a symlink that resolves outside the project is not scanned. For default targets this is a warning, and for explicit targets it is a failure.
 

--- a/docs/plan-files.md
+++ b/docs/plan-files.md
@@ -44,12 +44,6 @@ depends_on:
 affects:
   - plan-auth-login
   - docs-auth
-implements:
-  - spec-auth-login
-verifies:
-  - spec-auth-login
-documents:
-  - spec-auth-login
 supersedes:
   - adr-auth-jwt
 ---

--- a/docs/plan-files.md
+++ b/docs/plan-files.md
@@ -29,6 +29,133 @@ To avoid ownership conflicts, artifact writers are command-scoped:
 
 Quality commands (`/aif-commit`, `/aif-review`, `/aif-verify`) treat these files as read-only context by default.
 
+## Artifact Metadata
+
+`ai-factory audit-artifacts` reads lightweight YAML frontmatter from markdown artifacts. The schema is intentionally small: it gives teams enough traceability to catch broken links and stale downstream artifacts without requiring a full artifact-management system.
+
+```markdown
+---
+id: spec-auth-login
+type: spec
+status: accepted
+owners: [platform]
+depends_on:
+  - adr-auth-session
+affects:
+  - plan-auth-login
+  - docs-auth
+implements:
+  - spec-auth-login
+verifies:
+  - spec-auth-login
+documents:
+  - spec-auth-login
+supersedes:
+  - adr-auth-jwt
+---
+```
+
+Supported fields:
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `id` | Yes | Stable unique identifier. Prefer lowercase kebab-case with a type prefix, for example `spec-auth-login`, `adr-auth-session`, `plan-password-reset`, `docs-api-auth`, or `tests-checkout-flow`. Keep it stable when files move. |
+| `type` | Recommended | Artifact kind. Recommended values: `spec`, `requirement`, `plan`, `adr`, `architecture`, `roadmap`, `docs`, `tests`, `qa`, `code`, `rules`, `research`, `patch`. |
+| `status` | Recommended | Lifecycle state. Recommended values: `draft`, `proposed`, `accepted`, `active`, `in_progress`, `done`, `deprecated`, `obsolete`, `superseded`. |
+| `owners` / `owner` | Recommended | Team, role, or person responsible for review when the artifact is affected. Prefer team owners such as `platform`, `frontend`, `backend`, `security`, `infra`, `qa`, `docs`, or `product`. |
+| `depends_on` | Optional | Upstream artifacts this artifact relies on. Use it when the current artifact cannot be safely changed without checking another artifact. `audit-artifacts` checks for unknown references and dependency cycles. |
+| `affects` | Optional | Downstream artifacts that should be reviewed when this artifact changes. Use it to make PR impact review explicit. |
+| `implements` | Optional | Requirements, specs, or decisions implemented by this artifact. Common for `code` and `plan` artifacts. |
+| `verifies` | Optional | Requirements, specs, or decisions verified by this artifact. Common for `tests` and `qa` artifacts. |
+| `documents` | Optional | Requirements, specs, or decisions described by this artifact. Common for `docs` artifacts. |
+| `supersedes` | Optional | Older artifacts replaced by this artifact. Common for ADRs and specs. Mark the older artifact `status: superseded` when possible. |
+
+Relationship guidance:
+
+- `depends_on` points upstream: a plan may depend on a spec, an ADR, and architecture guidance.
+- `affects` points downstream: a changed ADR may affect architecture, plans, tests, and docs that need review.
+- `implements`, `verifies`, and `documents` provide reverse traceability for implementation, test, and documentation coverage.
+- `supersedes` keeps history while making the newer source of truth explicit.
+
+The command accepts scalar values, inline arrays, or YAML-style lists:
+
+```markdown
+depends_on: adr-auth-session
+affects: [plan-auth-login, docs-auth]
+verifies:
+  - spec-auth-login
+```
+
+Run the audit locally before opening a PR:
+
+```bash
+ai-factory audit-artifacts
+ai-factory audit-artifacts .ai-factory docs/requirements.md
+ai-factory audit-artifacts --strict
+ai-factory audit-artifacts --json
+```
+
+Default discovery scans `.ai-factory`, `docs`, `README.md`, and `AGENTS.md` when those paths exist. This default is intentionally default-layout first; projects that relocate artifact directories through `config.yaml` should pass those paths explicitly until the command becomes config-aware.
+
+Positional paths are explicit audit targets. Missing or outside-project explicit targets are failures so CI cannot pass after a typo or file rename. Missing default targets are skipped because many projects do not have every default file. Symlinked targets are canonicalized with `realpath`; a symlink that resolves outside the project is not scanned. For default targets this is a warning, and for explicit targets it is a failure.
+
+Finding severity and exit behavior:
+
+| Finding | Severity |
+|---------|----------|
+| Explicit missing or outside-project target | Fail |
+| Duplicate `id` | Fail |
+| Unknown relation target | Fail |
+| Self-reference | Fail |
+| `depends_on` cycle | Fail |
+| Missing `type`, `status`, or `owner` / `owners` | Warn |
+| Spec with no dependency/impact links | Warn |
+| Spec without incoming `implements`, `verifies`, or `documents` coverage | Warn |
+| Accepted ADR without `affects` links | Warn |
+| Default symlink target resolving outside the project | Warn |
+
+Exit codes:
+
+- `pass` exits `0`.
+- `warn` exits `0` by default.
+- `fail` exits non-zero.
+- `--strict` treats warnings as failures and exits non-zero.
+
+`--json` is intended for CI or future PR automation. Its output shape is:
+
+```json
+{
+  "status": "pass|warn|fail",
+  "artifacts": 2,
+  "markdown_without_metadata": 0,
+  "findings": [
+    {
+      "level": "fail|warn",
+      "file": ".ai-factory/spec.md",
+      "id": "spec-auth-login",
+      "message": "depends_on references unknown artifact \"adr-missing\"."
+    }
+  ]
+}
+```
+
+When a PR changes an artifact with downstream links, include an impact note that records the decision for each affected artifact:
+
+```markdown
+## Artifact Impact
+
+Changed:
+- adr-auth-session
+
+Reviewed:
+- architecture-auth: updated
+- spec-auth-login: reviewed-ok
+- tests-auth-session: deferred, follow-up #123
+
+Audit:
+- ai-factory audit-artifacts: pass
+```
+
 ## Research File (Optional)
 
 `.ai-factory/RESEARCH.md` is a persisted exploration artifact. Use it to capture constraints, decisions, and open questions during `/aif-explore` so you can `/clear` and still feed the same context into `/aif-plan`.

--- a/scripts/test-audit-artifacts.sh
+++ b/scripts/test-audit-artifacts.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+# Smoke tests for ai-factory audit-artifacts command behavior.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() {
+    PASSED=$((PASSED + 1))
+    echo -e "  ${GREEN}OK${NC} $1"
+}
+
+fail() {
+    FAILED=$((FAILED + 1))
+    echo -e "  ${RED}FAIL${NC} $1"
+}
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+(cd "$ROOT_DIR" && npm run build > /dev/null)
+
+run_audit() {
+    local project_dir="$1"
+    local output_file="$2"
+    shift 2
+
+    set +e
+    (cd "$project_dir" && node "$ROOT_DIR/dist/cli/index.js" audit-artifacts --json "$@" > "$output_file" 2>&1)
+    local exit_code=$?
+    set -e
+    return "$exit_code"
+}
+
+assert_json() {
+    local output_file="$1"
+    local expression="$2"
+    local message="$3"
+
+    if AUDIT_JSON_FILE="$output_file" AUDIT_JSON_EXPR="$expression" node <<'JS'
+const fs = require('fs');
+const result = JSON.parse(fs.readFileSync(process.env.AUDIT_JSON_FILE, 'utf8'));
+const ok = Function('result', `return (${process.env.AUDIT_JSON_EXPR});`)(result);
+process.exit(ok ? 0 : 1);
+JS
+    then
+        pass "$message"
+    else
+        fail "$message"
+        sed 's/^/      /' "$output_file"
+    fi
+}
+
+write_artifact() {
+    local file="$1"
+    local body="$2"
+    mkdir -p "$(dirname "$file")"
+    printf '%s\n' "$body" > "$file"
+}
+
+echo -e "\n${BOLD}=== audit-artifacts command smoke ===${NC}\n"
+
+# Valid graph -> pass, exit 0.
+VALID_PROJECT="$TMPDIR/valid"
+mkdir -p "$VALID_PROJECT/.ai-factory"
+write_artifact "$VALID_PROJECT/.ai-factory/spec.md" '---
+id: spec-auth
+type: spec
+status: accepted
+owners: [platform]
+affects: [tests-auth]
+---
+# Spec'
+write_artifact "$VALID_PROJECT/.ai-factory/tests.md" '---
+id: tests-auth
+type: tests
+status: active
+owners: [qa]
+verifies: [spec-auth]
+---
+# Tests'
+VALID_OUTPUT="$TMPDIR/valid.json"
+if run_audit "$VALID_PROJECT" "$VALID_OUTPUT" .ai-factory; then
+    pass "valid artifact graph exits 0"
+else
+    fail "valid artifact graph should exit 0"
+fi
+assert_json "$VALID_OUTPUT" 'result.status === "pass" && result.artifacts === 2 && result.findings.length === 0' "valid artifact graph reports pass"
+
+# Unknown relation -> fail, non-zero.
+UNKNOWN_PROJECT="$TMPDIR/unknown"
+mkdir -p "$UNKNOWN_PROJECT/.ai-factory"
+write_artifact "$UNKNOWN_PROJECT/.ai-factory/spec.md" '---
+id: spec-auth
+type: spec
+status: accepted
+owners: [platform]
+depends_on: [adr-missing]
+---
+# Spec'
+UNKNOWN_OUTPUT="$TMPDIR/unknown.json"
+if run_audit "$UNKNOWN_PROJECT" "$UNKNOWN_OUTPUT" .ai-factory; then
+    fail "unknown relation should exit non-zero"
+else
+    pass "unknown relation exits non-zero"
+fi
+assert_json "$UNKNOWN_OUTPUT" 'result.status === "fail" && result.findings.some(f => f.level === "fail" && f.message.includes("adr-missing"))' "unknown relation reports fail finding"
+
+# Duplicate id -> fail, non-zero.
+DUP_PROJECT="$TMPDIR/duplicate"
+mkdir -p "$DUP_PROJECT/.ai-factory"
+write_artifact "$DUP_PROJECT/.ai-factory/a.md" '---
+id: spec-auth
+type: spec
+status: accepted
+owners: [platform]
+---
+# A'
+write_artifact "$DUP_PROJECT/.ai-factory/b.md" '---
+id: spec-auth
+type: spec
+status: accepted
+owners: [platform]
+---
+# B'
+DUP_OUTPUT="$TMPDIR/duplicate.json"
+if run_audit "$DUP_PROJECT" "$DUP_OUTPUT" .ai-factory; then
+    fail "duplicate id should exit non-zero"
+else
+    pass "duplicate id exits non-zero"
+fi
+assert_json "$DUP_OUTPUT" 'result.status === "fail" && result.findings.some(f => f.message.includes("Duplicate artifact id"))' "duplicate id reports fail finding"
+
+# Missing recommended fields -> warn by default, fail under strict.
+WARN_PROJECT="$TMPDIR/warn"
+mkdir -p "$WARN_PROJECT/.ai-factory"
+write_artifact "$WARN_PROJECT/.ai-factory/minimal.md" '---
+id: spec-minimal
+---
+# Minimal'
+WARN_OUTPUT="$TMPDIR/warn.json"
+if run_audit "$WARN_PROJECT" "$WARN_OUTPUT" .ai-factory; then
+    pass "warnings exit 0 by default"
+else
+    fail "warnings should exit 0 by default"
+fi
+assert_json "$WARN_OUTPUT" 'result.status === "warn" && result.findings.some(f => f.level === "warn" && f.message.includes("Missing owner"))' "missing recommended fields report warn"
+STRICT_OUTPUT="$TMPDIR/strict.json"
+if run_audit "$WARN_PROJECT" "$STRICT_OUTPUT" .ai-factory --strict; then
+    fail "strict warnings should exit non-zero"
+else
+    pass "strict warnings exit non-zero"
+fi
+assert_json "$STRICT_OUTPUT" 'result.status === "fail" && result.findings.every(f => f.level === "warn")' "strict warnings report fail status"
+
+# Dependency cycle -> fail, non-zero.
+CYCLE_PROJECT="$TMPDIR/cycle"
+mkdir -p "$CYCLE_PROJECT/.ai-factory"
+write_artifact "$CYCLE_PROJECT/.ai-factory/a.md" '---
+id: artifact-a
+type: spec
+status: active
+owners: [platform]
+depends_on: [artifact-b]
+---
+# A'
+write_artifact "$CYCLE_PROJECT/.ai-factory/b.md" '---
+id: artifact-b
+type: spec
+status: active
+owners: [platform]
+depends_on: [artifact-a]
+---
+# B'
+CYCLE_OUTPUT="$TMPDIR/cycle.json"
+if run_audit "$CYCLE_PROJECT" "$CYCLE_OUTPUT" .ai-factory; then
+    fail "dependency cycle should exit non-zero"
+else
+    pass "dependency cycle exits non-zero"
+fi
+assert_json "$CYCLE_OUTPUT" 'result.status === "fail" && result.findings.some(f => f.message.includes("Dependency cycle"))' "dependency cycle reports fail finding"
+
+# Explicit missing path -> fail, non-zero; mixed valid + missing also fails.
+MISSING_OUTPUT="$TMPDIR/missing.json"
+if run_audit "$VALID_PROJECT" "$MISSING_OUTPUT" missing.md; then
+    fail "explicit missing path should exit non-zero"
+else
+    pass "explicit missing path exits non-zero"
+fi
+assert_json "$MISSING_OUTPUT" 'result.status === "fail" && result.findings.some(f => f.file === "missing.md" && f.message.includes("does not exist"))' "explicit missing path reports target finding"
+
+MIXED_OUTPUT="$TMPDIR/mixed.json"
+if run_audit "$VALID_PROJECT" "$MIXED_OUTPUT" .ai-factory missing.md; then
+    fail "mixed valid and missing explicit targets should exit non-zero"
+else
+    pass "mixed valid and missing explicit targets exit non-zero"
+fi
+assert_json "$MIXED_OUTPUT" 'result.status === "fail" && result.artifacts === 2 && result.findings.some(f => f.file === "missing.md")' "mixed explicit targets keep valid artifacts and missing-path finding"
+
+# Symlinked default target outside project -> do not index outside artifact; warn by default.
+OUTSIDE_DIR="$TMPDIR/outside-docs"
+SYMLINK_PROJECT="$TMPDIR/symlink"
+mkdir -p "$OUTSIDE_DIR" "$SYMLINK_PROJECT"
+write_artifact "$OUTSIDE_DIR/outside.md" '---
+id: outside-artifact
+type: docs
+status: active
+owners: [docs]
+---
+# Outside'
+ln -s "$OUTSIDE_DIR" "$SYMLINK_PROJECT/docs"
+SYMLINK_OUTPUT="$TMPDIR/symlink.json"
+if run_audit "$SYMLINK_PROJECT" "$SYMLINK_OUTPUT"; then
+    pass "default outside symlink warning exits 0"
+else
+    fail "default outside symlink warning should exit 0"
+fi
+assert_json "$SYMLINK_OUTPUT" 'result.status === "warn" && result.artifacts === 0 && result.findings.some(f => f.file === "docs" && f.message.includes("outside the project boundary"))' "default outside symlink is not indexed and reports warning"
+
+EXPLICIT_SYMLINK_OUTPUT="$TMPDIR/explicit-symlink.json"
+if run_audit "$SYMLINK_PROJECT" "$EXPLICIT_SYMLINK_OUTPUT" docs; then
+    fail "explicit outside symlink should exit non-zero"
+else
+    pass "explicit outside symlink exits non-zero"
+fi
+assert_json "$EXPLICIT_SYMLINK_OUTPUT" 'result.status === "fail" && result.artifacts === 0 && result.findings.some(f => f.file === "docs" && f.level === "fail")' "explicit outside symlink reports fail finding"
+
+echo -e "\n${BOLD}Total:${NC} $((PASSED + FAILED)), ${GREEN}Passed:${NC} $PASSED, ${RED}Failed:${NC} $FAILED"
+
+if [[ "$FAILED" -gt 0 ]]; then
+    exit 1
+fi

--- a/scripts/test-audit-artifacts.sh
+++ b/scripts/test-audit-artifacts.sh
@@ -234,6 +234,41 @@ else
 fi
 assert_json "$EXPLICIT_SYMLINK_OUTPUT" 'result.status === "fail" && result.artifacts === 0 && result.findings.some(f => f.file === "docs" && f.level === "fail")' "explicit outside symlink reports fail finding"
 
+# Explicit directory targets whose basename is skipped by default are still scanned as requested.
+EXPLICIT_SKIP_PROJECT="$TMPDIR/explicit-skip-root"
+mkdir -p "$EXPLICIT_SKIP_PROJECT/.ai-factory/qa/branch" "$EXPLICIT_SKIP_PROJECT/qa/branch"
+write_artifact "$EXPLICIT_SKIP_PROJECT/.ai-factory/qa/branch/case.md" '---
+id: qa-auth-login
+type: qa
+status: active
+owners: [qa]
+depends_on: [spec-missing]
+---
+# QA'
+write_artifact "$EXPLICIT_SKIP_PROJECT/qa/branch/case.md" '---
+id: qa-root-auth-login
+type: qa
+status: active
+owners: [qa]
+depends_on: [spec-missing]
+---
+# QA'
+EXPLICIT_AIF_QA_OUTPUT="$TMPDIR/explicit-aif-qa.json"
+if run_audit "$EXPLICIT_SKIP_PROJECT" "$EXPLICIT_AIF_QA_OUTPUT" .ai-factory/qa; then
+    fail "explicit .ai-factory/qa target with bad artifact should exit non-zero"
+else
+    pass "explicit .ai-factory/qa target with bad artifact exits non-zero"
+fi
+assert_json "$EXPLICIT_AIF_QA_OUTPUT" 'result.status === "fail" && result.artifacts === 1 && result.findings.some(f => f.file === ".ai-factory/qa/branch/case.md" && f.message.includes("spec-missing"))' "explicit .ai-factory/qa target is scanned"
+
+EXPLICIT_ROOT_QA_OUTPUT="$TMPDIR/explicit-root-qa.json"
+if run_audit "$EXPLICIT_SKIP_PROJECT" "$EXPLICIT_ROOT_QA_OUTPUT" qa; then
+    fail "explicit qa target with bad artifact should exit non-zero"
+else
+    pass "explicit qa target with bad artifact exits non-zero"
+fi
+assert_json "$EXPLICIT_ROOT_QA_OUTPUT" 'result.status === "fail" && result.artifacts === 1 && result.findings.some(f => f.file === "qa/branch/case.md" && f.message.includes("spec-missing"))' "explicit qa target is scanned"
+
 echo -e "\n${BOLD}Total:${NC} $((PASSED + FAILED)), ${GREEN}Passed:${NC} $PASSED, ${RED}Failed:${NC} $FAILED"
 
 if [[ "$FAILED" -gt 0 ]]; then

--- a/scripts/test-gate-result-contract.sh
+++ b/scripts/test-gate-result-contract.sh
@@ -180,15 +180,14 @@ assert_contains "$CONTRACT_REF" '/aif-commit' "contract documents commit as clea
 
 echo -e "\n${BOLD}=== Gate skill output contracts ===${NC}\n"
 
-declare -A GATE_SKILLS=(
-  [verify]="$ROOT_DIR/skills/aif-verify/SKILL.md"
-  [review]="$ROOT_DIR/skills/aif-review/SKILL.md"
-  [security]="$ROOT_DIR/skills/aif-security-checklist/SKILL.md"
-  [rules]="$ROOT_DIR/skills/aif-rules-check/SKILL.md"
-)
-
 for gate in verify review security rules; do
-    file="${GATE_SKILLS[$gate]}"
+    case "$gate" in
+        verify) file="$ROOT_DIR/skills/aif-verify/SKILL.md" ;;
+        review) file="$ROOT_DIR/skills/aif-review/SKILL.md" ;;
+        security) file="$ROOT_DIR/skills/aif-security-checklist/SKILL.md" ;;
+        rules) file="$ROOT_DIR/skills/aif-rules-check/SKILL.md" ;;
+    esac
+
     assert_contains "$file" '```aif-gate-result' "$gate skill includes aif-gate-result fence"
     assert_contains "$file" '"gate": "' "$gate skill includes gate field in JSON example"
     assert_contains "$file" '"status": "pass|warn|fail"' "$gate skill documents pass/warn/fail status"

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -877,6 +877,20 @@ else
     echo "$GATE_RESULT_SMOKE_OUTPUT" | sed 's/^/      /'
 fi
 
+echo -e "\n${BOLD}=== audit-artifacts command smoke tests ===${NC}\n"
+
+set +e
+AUDIT_ARTIFACTS_SMOKE_OUTPUT=$(bash "$ROOT_DIR/scripts/test-audit-artifacts.sh" 2>&1)
+AUDIT_ARTIFACTS_SMOKE_EXIT=$?
+set -e
+
+if [[ $AUDIT_ARTIFACTS_SMOKE_EXIT -eq 0 ]]; then
+    pass "audit-artifacts smoke tests"
+else
+    fail "audit-artifacts smoke tests"
+    echo "$AUDIT_ARTIFACTS_SMOKE_OUTPUT" | sed 's/^/      /'
+fi
+
 echo -e "\n${BOLD}=== Results ===${NC}"
 echo -e "  Total:    $TOTAL"
 echo -e "  Passed:   ${GREEN}$PASSED${NC}"

--- a/src/cli/commands/audit-artifacts.ts
+++ b/src/cli/commands/audit-artifacts.ts
@@ -1,0 +1,499 @@
+import path from 'path';
+import fs from 'fs-extra';
+import chalk from 'chalk';
+import { readTextFile } from '../../utils/fs.js';
+
+type RelationField = 'depends_on' | 'affects' | 'implements' | 'verifies' | 'documents' | 'supersedes';
+
+interface ArtifactRecord {
+  id: string;
+  file: string;
+  type?: string;
+  status?: string;
+  owners: string[];
+  relations: Record<RelationField, string[]>;
+}
+
+interface Finding {
+  level: 'fail' | 'warn';
+  file?: string;
+  id?: string;
+  message: string;
+}
+
+interface AuditOptions {
+  json?: boolean;
+  strict?: boolean;
+}
+
+interface CollectResult {
+  files: string[];
+  findings: Finding[];
+}
+
+const RELATION_FIELDS: RelationField[] = [
+  'depends_on',
+  'affects',
+  'implements',
+  'verifies',
+  'documents',
+  'supersedes',
+];
+
+const DEFAULT_TARGETS = ['.ai-factory', 'docs', 'README.md', 'AGENTS.md'];
+const DEFAULT_SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'coverage',
+  'docs-html',
+  'evolution',
+  'evolutions',
+  'qa',
+]);
+
+function emptyRelations(): Record<RelationField, string[]> {
+  return {
+    depends_on: [],
+    affects: [],
+    implements: [],
+    verifies: [],
+    documents: [],
+    supersedes: [],
+  };
+}
+
+function normalizeRelPath(projectDir: string, filePath: string): string {
+  return path.relative(projectDir, filePath).replaceAll('\\', '/');
+}
+
+function isInsideProject(canonicalProjectDir: string, candidate: string): boolean {
+  const relative = path.relative(canonicalProjectDir, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function stripInlineComment(value: string): string {
+  const hashIndex = value.indexOf(' #');
+  return hashIndex >= 0 ? value.slice(0, hashIndex).trim() : value.trim();
+}
+
+function stripQuotes(value: string): string {
+  const trimmed = stripInlineComment(value).trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function parseArrayValue(value: string): string[] {
+  const trimmed = stripInlineComment(value).trim();
+  if (!trimmed) return [];
+
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    return trimmed
+      .slice(1, -1)
+      .split(',')
+      .map(item => stripQuotes(item))
+      .filter(Boolean);
+  }
+
+  return [stripQuotes(trimmed)].filter(Boolean);
+}
+
+function parseFrontmatter(content: string): Record<string, string[]> | null {
+  if (!content.startsWith('---\n') && !content.startsWith('---\r\n')) {
+    return null;
+  }
+
+  const endMatch = content.match(/\r?\n---\r?\n/);
+  if (!endMatch || typeof endMatch.index !== 'number') {
+    return null;
+  }
+
+  const block = content.slice(content.indexOf('\n') + 1, endMatch.index);
+  const fields: Record<string, string[]> = {};
+  let currentListKey: string | null = null;
+
+  for (const rawLine of block.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    if (!line.trim() || line.trimStart().startsWith('#')) {
+      continue;
+    }
+
+    const listMatch = line.match(/^\s*-\s+(.+)$/);
+    if (listMatch && currentListKey) {
+      fields[currentListKey] = [...(fields[currentListKey] ?? []), ...parseArrayValue(listMatch[1])];
+      continue;
+    }
+
+    const fieldMatch = line.match(/^([A-Za-z0-9_.-]+):(?:\s*(.*))?$/);
+    if (!fieldMatch) {
+      currentListKey = null;
+      continue;
+    }
+
+    const key = fieldMatch[1];
+    const value = fieldMatch[2] ?? '';
+    currentListKey = value.trim() === '' ? key : null;
+    fields[key] = parseArrayValue(value);
+  }
+
+  return fields;
+}
+
+function first(fields: Record<string, string[]>, key: string): string | undefined {
+  return fields[key]?.[0];
+}
+
+function getOwners(fields: Record<string, string[]>): string[] {
+  return [...(fields.owners ?? []), ...(fields.owner ?? [])].filter(Boolean);
+}
+
+function toArtifact(projectDir: string, absPath: string, fields: Record<string, string[]>): ArtifactRecord | null {
+  const id = first(fields, 'id');
+  if (!id) return null;
+
+  const relations = emptyRelations();
+  for (const field of RELATION_FIELDS) {
+    relations[field] = fields[field] ?? [];
+  }
+
+  return {
+    id,
+    file: normalizeRelPath(projectDir, absPath),
+    type: first(fields, 'type'),
+    status: first(fields, 'status'),
+    owners: getOwners(fields),
+    relations,
+  };
+}
+
+function targetFindingLevel(isExplicit: boolean): 'fail' | 'warn' {
+  return isExplicit ? 'fail' : 'warn';
+}
+
+async function realpathOrNull(filePath: string): Promise<string | null> {
+  try {
+    return await fs.realpath(filePath);
+  } catch {
+    return null;
+  }
+}
+
+async function collectMarkdownFiles(projectDir: string, targets: string[], isExplicit: boolean): Promise<CollectResult> {
+  const canonicalProjectDir = await fs.realpath(projectDir);
+  const files = new Set<string>();
+  const findings: Finding[] = [];
+  const visitedDirectories = new Set<string>();
+
+  async function walk(currentPath: string, requestedPath: string): Promise<void> {
+    const canonicalPath = await realpathOrNull(currentPath);
+    if (!canonicalPath) {
+      findings.push({
+        level: targetFindingLevel(isExplicit),
+        file: requestedPath,
+        message: `Requested audit target does not exist: ${requestedPath}`,
+      });
+      return;
+    }
+
+    if (!isInsideProject(canonicalProjectDir, canonicalPath)) {
+      findings.push({
+        level: targetFindingLevel(isExplicit),
+        file: requestedPath,
+        message: `Requested audit target is outside the project boundary: ${requestedPath}`,
+      });
+      return;
+    }
+
+    const stats = await fs.lstat(currentPath);
+    const statTarget = stats.isSymbolicLink() ? canonicalPath : currentPath;
+    const targetStats = stats.isSymbolicLink() ? await fs.stat(canonicalPath) : stats;
+
+    if (targetStats.isFile()) {
+      if (statTarget.endsWith('.md')) {
+        files.add(statTarget);
+      }
+      return;
+    }
+
+    if (!targetStats.isDirectory()) {
+      return;
+    }
+
+    if (visitedDirectories.has(canonicalPath)) {
+      return;
+    }
+    visitedDirectories.add(canonicalPath);
+
+    const directoryName = path.basename(currentPath);
+    if (DEFAULT_SKIP_DIRS.has(directoryName)) {
+      return;
+    }
+
+    const entries = await fs.readdir(canonicalPath, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      const entryPath = path.join(canonicalPath, entry.name);
+      const entryRequestedPath = path.join(requestedPath, entry.name).replaceAll('\\', '/');
+      await walk(entryPath, entryRequestedPath);
+    }
+  }
+
+  for (const target of targets) {
+    const absTarget = path.resolve(projectDir, target);
+    if (!isInsideProject(canonicalProjectDir, absTarget)) {
+      findings.push({
+        level: targetFindingLevel(isExplicit),
+        file: target,
+        message: `Requested audit target is outside the project boundary: ${target}`,
+      });
+      continue;
+    }
+
+    if (!await fs.pathExists(absTarget)) {
+      if (isExplicit) {
+        findings.push({
+          level: 'fail',
+          file: target,
+          message: `Requested audit target does not exist: ${target}`,
+        });
+      }
+      continue;
+    }
+
+    await walk(absTarget, target);
+  }
+
+  return {
+    files: [...files].sort((a, b) => a.localeCompare(b)),
+    findings,
+  };
+}
+
+function relationTargets(artifact: ArtifactRecord): string[] {
+  return RELATION_FIELDS.flatMap(field => artifact.relations[field]);
+}
+
+function hasIncomingRelation(artifactId: string, artifacts: ArtifactRecord[], fields: RelationField[]): boolean {
+  return artifacts.some(artifact =>
+    fields.some(field => artifact.relations[field].includes(artifactId)),
+  );
+}
+
+function detectDependencyCycles(artifacts: ArtifactRecord[]): string[][] {
+  const byId = new Map(artifacts.map(artifact => [artifact.id, artifact]));
+  const cycles: string[][] = [];
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const stack: string[] = [];
+
+  function visit(id: string): void {
+    if (visiting.has(id)) {
+      const start = stack.indexOf(id);
+      if (start >= 0) {
+        cycles.push([...stack.slice(start), id]);
+      }
+      return;
+    }
+
+    if (visited.has(id)) return;
+
+    const artifact = byId.get(id);
+    if (!artifact) return;
+
+    visiting.add(id);
+    stack.push(id);
+    for (const targetId of artifact.relations.depends_on) {
+      visit(targetId);
+    }
+    stack.pop();
+    visiting.delete(id);
+    visited.add(id);
+  }
+
+  for (const artifact of artifacts) {
+    visit(artifact.id);
+  }
+
+  return cycles;
+}
+
+function auditRecords(artifacts: ArtifactRecord[], markdownWithoutMetadata: number): Finding[] {
+  const findings: Finding[] = [];
+  const ids = new Map<string, ArtifactRecord[]>();
+
+  for (const artifact of artifacts) {
+    ids.set(artifact.id, [...(ids.get(artifact.id) ?? []), artifact]);
+  }
+
+  for (const [id, matches] of ids) {
+    if (matches.length > 1) {
+      findings.push({
+        level: 'fail',
+        id,
+        message: `Duplicate artifact id is used by ${matches.map(match => match.file).join(', ')}`,
+      });
+    }
+  }
+
+  const knownIds = new Set(ids.keys());
+  for (const artifact of artifacts) {
+    if (!artifact.type) {
+      findings.push({ level: 'warn', file: artifact.file, id: artifact.id, message: 'Missing type.' });
+    }
+    if (!artifact.status) {
+      findings.push({ level: 'warn', file: artifact.file, id: artifact.id, message: 'Missing status.' });
+    }
+    if (artifact.owners.length === 0) {
+      findings.push({ level: 'warn', file: artifact.file, id: artifact.id, message: 'Missing owner/owners.' });
+    }
+
+    for (const field of RELATION_FIELDS) {
+      for (const targetId of artifact.relations[field]) {
+        if (targetId === artifact.id) {
+          findings.push({
+            level: 'fail',
+            file: artifact.file,
+            id: artifact.id,
+            message: `Self-reference in ${field}.`,
+          });
+        } else if (!knownIds.has(targetId)) {
+          findings.push({
+            level: 'fail',
+            file: artifact.file,
+            id: artifact.id,
+            message: `${field} references unknown artifact "${targetId}".`,
+          });
+        }
+      }
+    }
+
+    const type = artifact.type?.toLowerCase();
+    const status = artifact.status?.toLowerCase();
+    if ((type === 'spec' || type === 'requirement' || type === 'requirements') && relationTargets(artifact).length === 0) {
+      findings.push({
+        level: 'warn',
+        file: artifact.file,
+        id: artifact.id,
+        message: 'Spec has no explicit dependency/impact links.',
+      });
+    }
+    if (
+      (type === 'spec' || type === 'requirement' || type === 'requirements') &&
+      !hasIncomingRelation(artifact.id, artifacts, ['implements', 'verifies', 'documents'])
+    ) {
+      findings.push({
+        level: 'warn',
+        file: artifact.file,
+        id: artifact.id,
+        message: 'Spec is not referenced by code/tests/docs metadata.',
+      });
+    }
+    if (type === 'adr' && status === 'accepted' && artifact.relations.affects.length === 0) {
+      findings.push({
+        level: 'warn',
+        file: artifact.file,
+        id: artifact.id,
+        message: 'Accepted ADR has no affects links.',
+      });
+    }
+  }
+
+  for (const cycle of detectDependencyCycles(artifacts)) {
+    findings.push({
+      level: 'fail',
+      message: `Dependency cycle: ${cycle.join(' -> ')}`,
+    });
+  }
+
+  if (markdownWithoutMetadata > 0 && artifacts.length === 0) {
+    findings.push({
+      level: 'warn',
+      message: `${markdownWithoutMetadata} markdown file(s) were found, but none had artifact frontmatter with an id.`,
+    });
+  }
+
+  return findings;
+}
+
+function printHumanReport(artifacts: ArtifactRecord[], findings: Finding[], markdownWithoutMetadata: number, strict: boolean): void {
+  const failCount = findings.filter(finding => finding.level === 'fail').length;
+  const warnCount = findings.filter(finding => finding.level === 'warn').length;
+  const effectiveFailCount = strict ? failCount + warnCount : failCount;
+
+  console.log(chalk.bold('Artifact Audit'));
+  console.log(`Artifacts indexed: ${artifacts.length}`);
+  console.log(`Markdown without artifact metadata: ${markdownWithoutMetadata}`);
+  console.log(`Findings: ${failCount} fail, ${warnCount} warn${strict ? ' (strict treats warnings as failures)' : ''}`);
+  console.log('');
+
+  if (findings.length === 0) {
+    console.log(chalk.green('PASS No artifact graph issues found.'));
+    return;
+  }
+
+  for (const finding of findings) {
+    const label = finding.level === 'fail' ? chalk.red('FAIL') : chalk.yellow('WARN');
+    const location = [finding.file, finding.id].filter(Boolean).join(' ');
+    console.log(`${label} ${location ? `${location}: ` : ''}${finding.message}`);
+  }
+
+  console.log('');
+  if (effectiveFailCount > 0) {
+    console.log(chalk.red('Result: FAIL'));
+  } else {
+    console.log(chalk.yellow('Result: WARN'));
+  }
+}
+
+export async function auditArtifactsCommand(paths: string[] = [], options: AuditOptions = {}): Promise<void> {
+  const projectDir = process.cwd();
+  const targets = paths.length > 0 ? paths : DEFAULT_TARGETS;
+  const explicitTargets = paths.length > 0;
+  const { files: markdownFiles, findings: collectionFindings } = await collectMarkdownFiles(projectDir, targets, explicitTargets);
+  const artifacts: ArtifactRecord[] = [];
+  let markdownWithoutMetadata = 0;
+
+  for (const file of markdownFiles) {
+    const content = await readTextFile(file);
+    if (!content) continue;
+
+    const fields = parseFrontmatter(content);
+    if (!fields) {
+      markdownWithoutMetadata += 1;
+      continue;
+    }
+
+    const artifact = toArtifact(projectDir, file, fields);
+    if (artifact) {
+      artifacts.push(artifact);
+    } else {
+      markdownWithoutMetadata += 1;
+    }
+  }
+
+  const findings = [...collectionFindings, ...auditRecords(artifacts, markdownWithoutMetadata)];
+  const failCount = findings.filter(finding => finding.level === 'fail').length;
+  const warnCount = findings.filter(finding => finding.level === 'warn').length;
+  const shouldFail = options.strict ? failCount + warnCount > 0 : failCount > 0;
+
+  if (options.json) {
+    console.log(JSON.stringify({
+      status: shouldFail ? 'fail' : warnCount > 0 ? 'warn' : 'pass',
+      artifacts: artifacts.length,
+      markdown_without_metadata: markdownWithoutMetadata,
+      findings,
+    }, null, 2));
+  } else {
+    printHumanReport(artifacts, findings, markdownWithoutMetadata, options.strict ?? false);
+  }
+
+  if (shouldFail) {
+    process.exitCode = 1;
+  }
+}

--- a/src/cli/commands/audit-artifacts.ts
+++ b/src/cli/commands/audit-artifacts.ts
@@ -189,7 +189,7 @@ async function collectMarkdownFiles(projectDir: string, targets: string[], isExp
   const findings: Finding[] = [];
   const visitedDirectories = new Set<string>();
 
-  async function walk(currentPath: string, requestedPath: string): Promise<void> {
+  async function walk(currentPath: string, requestedPath: string, isRootTarget = false): Promise<void> {
     const canonicalPath = await realpathOrNull(currentPath);
     if (!canonicalPath) {
       findings.push({
@@ -230,7 +230,7 @@ async function collectMarkdownFiles(projectDir: string, targets: string[], isExp
     visitedDirectories.add(canonicalPath);
 
     const directoryName = path.basename(currentPath);
-    if (DEFAULT_SKIP_DIRS.has(directoryName)) {
+    if (!isRootTarget && DEFAULT_SKIP_DIRS.has(directoryName)) {
       return;
     }
 
@@ -266,7 +266,7 @@ async function collectMarkdownFiles(projectDir: string, targets: string[], isExp
       continue;
     }
 
-    await walk(absTarget, target);
+    await walk(absTarget, target, true);
   }
 
   return {

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -107,6 +107,13 @@ function getInstallCommand(version: string): string {
   return `npm install -g ai-factory@${version}`;
 }
 
+function printPackageUpdateHint(latestVersion: string): void {
+  const installCmd = getInstallCommand(latestVersion);
+  console.log(chalk.cyan(`Run: ${installCmd}`));
+  console.log(chalk.dim('New CLI commands and package-level features are available only after updating the ai-factory package.'));
+  console.log(chalk.dim('After updating, re-run `ai-factory update` in the project to refresh skills and agent assets.\n'));
+}
+
 async function selfUpdate(currentVersion: string): Promise<boolean> {
   const latestVersion = await getLatestVersion();
   if (!latestVersion) {
@@ -122,7 +129,8 @@ async function selfUpdate(currentVersion: string): Promise<boolean> {
   console.log(chalk.cyan(`📦 New version available: ${currentVersion} → ${latestVersion}`));
 
   if (!process.stdin.isTTY) {
-    console.log(chalk.dim('Non-interactive mode — skipping self-update\n'));
+    console.log(chalk.dim('Non-interactive mode — skipping self-update.'));
+    printPackageUpdateHint(latestVersion);
     return false;
   }
 
@@ -134,7 +142,8 @@ async function selfUpdate(currentVersion: string): Promise<boolean> {
   }]);
 
   if (!shouldUpdate) {
-    console.log(chalk.dim('Skipping package update\n'));
+    console.log(chalk.dim('Skipping package update.'));
+    printPackageUpdateHint(latestVersion);
     return false;
   }
 
@@ -148,6 +157,7 @@ async function selfUpdate(currentVersion: string): Promise<boolean> {
     return true;
   } catch (error) {
     console.log(chalk.yellow(`⚠ Self-update failed: ${(error as Error).message}`));
+    printPackageUpdateHint(latestVersion);
     return false;
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { initCommand } from './commands/init.js';
 import { updateCommand } from './commands/update.js';
 import { upgradeCommand } from './commands/upgrade.js';
+import { auditArtifactsCommand } from './commands/audit-artifacts.js';
 import { extensionAddCommand, extensionRemoveCommand, extensionListCommand, extensionUpdateCommand } from './commands/extension.js';
 import { getCurrentVersion, loadConfig } from '../core/config.js';
 import { loadAllExtensions } from '../core/extensions.js';
@@ -33,6 +34,13 @@ program
   .command('upgrade')
   .description('Upgrade from v1 to v2 (removes old-format skills, installs new)')
   .action(upgradeCommand);
+
+program
+  .command('audit-artifacts [paths...]')
+  .description('Audit artifact frontmatter links and traceability metadata')
+  .option('--json', 'Print machine-readable JSON')
+  .option('--strict', 'Treat warnings as failures')
+  .action(auditArtifactsCommand);
 
 const ext = program
   .command('extension')


### PR DESCRIPTION
## Summary
- add `ai-factory audit-artifacts` for lightweight artifact frontmatter and traceability checks
- show explicit package update instructions when `ai-factory update` sees newer CLI package features but cannot self-update
- document the new command and fix gate-result smoke portability on macOS bash

## Tests
- `npm run build`
- `npm test`
- `node dist/cli/index.js --help`
- `node dist/cli/index.js audit-artifacts --json`
- manual negative smoke with an unknown `depends_on` artifact