### PR TITLE
Add Dockerize references for Angie ACME and Compose hooks

### DIFF
--- a/skills/aif-dockerize/SKILL.md
+++ b/skills/aif-dockerize/SKILL.md
@@ -311,6 +311,11 @@ Read skills/dockerize/references/BEST-PRACTICES.md
 Read skills/dockerize/references/SECURITY-CHECKLIST.md
 ```
 
+Additional focused references are available for production reverse-proxy and Compose permission edge cases:
+
+- `references/ANGIE-ACME.md` — read when generating or auditing Angie HTTPS/ACME configuration. Use it for built-in ACME setup, persistent certificate volumes, `acme_client_path`, resolver requirements, and avoiding unnecessary Certbot containers.
+- `references/COMPOSE-LIFECYCLE-HOOKS.md` — read when a production Compose service runs non-root but needs named-volume ownership fixes or best-effort stop hooks. Use it for `post_start`/`pre_stop` syntax, Docker Compose 2.30.0+ requirements, and hook timing caveats.
+
 Select the Dockerfile template matching the language:
 
 | Language | Template |

--- a/skills/aif-dockerize/references/ANGIE-ACME.md
+++ b/skills/aif-dockerize/references/ANGIE-ACME.md
@@ -1,0 +1,193 @@
+# Angie Docker ACME Reference
+
+> Sources:
+> - https://en.angie.software/angie/docs/configuration/
+> - https://en.angie.software/angie/docs/configuration/acme/
+> - https://en.angie.software/angie/docs/configuration/modules/http/http_acme/
+> - https://en.angie.software/angie/docs/configuration/modules/http/http_ssl/
+> - https://en.angie.software/angie/docs/configuration/modules/stream/stream_acme/
+> - https://en.angie.software/angie/docs/installation/docker/
+> Created: 2026-05-11
+> Updated: 2026-05-11
+
+## Overview
+
+Angie has built-in ACME support for automatic certificate issuance and renewal. Official Angie packages and Docker images include the ACME module. When building Angie from source, the HTTP ACME module must be enabled explicitly with `--with-http_acme_module`.
+
+For Docker-based projects, the key operational point is that a separate Certbot container is usually unnecessary for a basic HTTP-01 flow. Configure `acme_client`, use `$acme_cert_<name>` and `$acme_cert_key_<name>` in the TLS server block, and persist the certificate/key storage directory with a Docker volume. Set `acme_client_path` explicitly so the mounted path is obvious and does not depend on build-time defaults.
+
+## Core Concepts
+
+`acme_client`: HTTP-level ACME client definition. It is configured in the `http` context and has a name plus an ACME directory URI.
+
+`acme`: server-level directive. It binds the `server_name` values from a server block to a named ACME client. All `server_name` values using the same client name are included in one certificate.
+
+`$acme_cert_<name>`: the latest certificate obtained by the named ACME client.
+
+`$acme_cert_key_<name>`: the key for the named ACME client certificate. The key is available immediately after startup, while the certificate is available only after successful issuance.
+
+`acme_client_path`: certificate and key storage directory. In Docker, set it explicitly and mount the same path as a persistent volume.
+
+`resolver`: required in the same context as `acme_client`; otherwise Angie cannot resolve the ACME directory host.
+
+## Configuration
+
+| Directive / option | Context | Default / values | Notes |
+|---|---|---|---|
+| `acme name;` | `server` | none | Enables ACME for the domains in this server block's `server_name`. |
+| `acme_client name uri ...;` | `http` | none | Defines a named ACME client used by `acme` and the `$acme_cert_*` variables. |
+| `enabled=` | `acme_client` | `on` | Enables or disables renewal without removing the client from config. |
+| `key_type=` | `acme_client` | `ecdsa`; valid: `rsa`, `ecdsa` | Certificate key algorithm. |
+| `key_bits=` | `acme_client` | `256` for `ecdsa`, `2048` for `rsa` | Certificate key size. |
+| `email=` | `acme_client` | none | Email for the CA account. |
+| `renew_before_expiry=` | `acme_client` | `30d` | How early renewal starts before expiration. |
+| `renew_on_load` | `acme_client` | off unless present | Forces renewal on config load; use carefully because of CA rate limits. |
+| `retry_after_error=` | `acme_client` | `2h`; can be `off` | Delay before retry after an issuance or renewal error. |
+| `challenge=` | `acme_client` | `http`; valid: `dns`, `http`, `alpn` | Wildcard domains require `challenge=dns`. |
+| `account_key=` | `acme_client` | generated when omitted | Full path to the PEM account key. If missing, Angie attempts to create it. |
+| `acme_client_path path;` | `http` | build-time path | Overrides the certificate/key storage directory. Set this explicitly in Docker. |
+| `acme_http_port` | `http` | `80` | HTTP challenge port. If nothing listens on the address/port, the module creates a dedicated listener. |
+| `acme_dns_port` | `http` | `53` | UDP port for DNS challenge. Ports `<=1024` require superuser privileges. |
+| `acme_max_response_size` | `http` | `32k` | Increase if Angie logs a too-large ACME subrequest response. |
+
+## Docker Pattern
+
+Use a named volume for ACME state and mount it at the exact path configured by `acme_client_path`.
+
+```yaml
+services:
+  angie:
+    image: docker.angie.software/angie:1.11.4
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./docker/angie/default.conf:/etc/angie/http.d/default.conf:ro
+      - angie_acme:/var/lib/angie/acme
+      - angie_logs:/var/log/angie
+
+volumes:
+  angie_acme:
+  angie_logs:
+```
+
+`/var/lib/angie/acme` is a project-chosen path in this example, not a required official default. The portable Docker pattern is to set `acme_client_path` and mount that same path.
+
+## Minimal HTTP-01 Example
+
+```nginx
+resolver 1.1.1.1 8.8.8.8 valid=300s;
+
+acme_client_path /var/lib/angie/acme;
+
+acme_client letsencrypt https://acme-v02.api.letsencrypt.org/directory
+    email=admin@example.com
+    challenge=http
+    renew_before_expiry=30d
+    retry_after_error=2h;
+
+server {
+    listen 80;
+    server_name example.com www.example.com;
+
+    acme letsencrypt;
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name example.com www.example.com;
+
+    acme letsencrypt;
+
+    ssl_certificate     $acme_cert_letsencrypt;
+    ssl_certificate_key $acme_cert_key_letsencrypt;
+
+    location / {
+        proxy_pass http://app:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+```
+
+For initial infrastructure validation, use the Let's Encrypt staging directory to avoid production rate limits:
+
+```nginx
+acme_client letsencrypt https://acme-staging-v02.api.letsencrypt.org/directory
+    email=admin@example.com
+    challenge=http;
+```
+
+## Stream Module Notes
+
+Stream ACME supports automatic certificates for `stream` servers. Official Angie packages and images include it. When building from source, `--with-stream_acme_module` is required and it also requires `--with-http_acme_module`.
+
+The `stream` block must be placed after the `http` block because stream ACME uses client definitions created while parsing HTTP configuration.
+
+```nginx
+http {
+    resolver 1.1.1.1;
+    acme_client_path /var/lib/angie/acme;
+    acme_client letsencrypt https://acme-v02.api.letsencrypt.org/directory;
+}
+
+stream {
+    server {
+        listen 12345 ssl;
+        server_name example.com;
+
+        acme letsencrypt;
+
+        ssl_certificate     $acme_cert_letsencrypt;
+        ssl_certificate_key $acme_cert_key_letsencrypt;
+    }
+}
+```
+
+## Best Practices
+
+1. Always mount the `acme_client_path` directory as a persistent Docker volume.
+2. Set `acme_client_path` explicitly in Angie config so storage, backups, permissions, and migrations are obvious.
+3. Expose port `80` for `challenge=http` and port `443` for HTTPS. If public HTTP is impossible, use DNS challenge instead.
+4. Configure `resolver` in the same context as `acme_client`.
+5. Use the Let's Encrypt staging directory while validating new infrastructure.
+6. Keep `server_name` exact. Regex server names are skipped by ACME, and wildcard domains require `challenge=dns`.
+7. Do not enable `renew_on_load` casually in production because reloads/restarts can force renewals.
+8. Treat `$acme_cert_<name>` as unavailable until first successful issuance; Angie logs are the source of truth during bootstrap.
+9. Pin Angie image versions for production instead of using `latest`.
+
+## Common Pitfalls
+
+Missing Docker volume: certificates and account keys disappear when the container is replaced. Fix by mounting the directory used by `acme_client_path`.
+
+Missing `resolver`: `acme_client` requires DNS resolver configuration in the same context. Fix by adding project-approved DNS resolvers.
+
+Port 80 blocked: HTTP-01 cannot validate. Fix by publishing `80:80`, checking firewall/DNS routing, or switching to DNS challenge.
+
+Unnecessary Certbot container: Angie can issue and renew certificates itself through built-in ACME in official images/packages.
+
+Wildcard with HTTP challenge: wildcard domains require DNS challenge.
+
+Stream block before HTTP block: stream ACME needs HTTP ACME client definitions, so put `stream` after `http`.
+
+Regex server names: domains specified with regular expressions are not supported and will be skipped.
+
+Unclear storage path: choose a project path, set it in `acme_client_path`, and mount that exact path.
+
+## Source Facts To Preserve
+
+- ACME HTTP module provides automatic certificate retrieval using ACME.
+- Official Angie packages and images include HTTP ACME and SSL modules.
+- `acme_client` requires a `resolver` in the same context.
+- The Let's Encrypt production directory is `https://acme-v02.api.letsencrypt.org/directory`.
+- The Let's Encrypt staging directory is `https://acme-staging-v02.api.letsencrypt.org/directory`.
+- `challenge` defaults to `http`; valid values are `dns`, `http`, and `alpn`.
+- `renew_before_expiry` defaults to `30d`.
+- `retry_after_error` defaults to `2h`.
+- `acme_http_port` defaults to `80`.
+- `acme_client_path` overrides the certificate/key storage directory set at build time.
+- Official Docker images use config under `/etc/angie` and logs under `/var/log/angie`.

--- a/skills/aif-dockerize/references/COMPOSE-LIFECYCLE-HOOKS.md
+++ b/skills/aif-dockerize/references/COMPOSE-LIFECYCLE-HOOKS.md
@@ -1,0 +1,165 @@
+# Docker Compose Lifecycle Hooks Reference
+
+> Sources:
+> - https://docs.docker.com/compose/how-tos/lifecycle/
+> - https://docs.docker.com/reference/compose-file/services/#post_start
+> - https://docs.docker.com/reference/compose-file/services/#pre_stop
+> Created: 2026-05-11
+> Updated: 2026-05-11
+
+## Overview
+
+Docker Compose lifecycle hooks let a service run commands just after container start or just before container stop. They are useful when the main container should run as a non-root user, but a narrow setup or cleanup task needs elevated privileges.
+
+For Docker generation, the main use case is fixing permissions on named volumes or generated data directories without running the whole service as root. Docker's own lifecycle hook example uses `post_start` to run `chown` on a volume because Docker volumes are created with root ownership by default.
+
+Lifecycle hooks require Docker Compose 2.30.0 or later.
+
+## Core Concepts
+
+`post_start`: sequence of commands run after a container has started. The exact timing is not guaranteed, and Docker explicitly notes that hook timing is not assured during execution of the container entrypoint.
+
+`pre_stop`: sequence of commands run before a container is stopped by a Compose or user stop action. It does not run if the container stops by itself or is killed suddenly.
+
+Hook-level `user`: runs the hook command as a different user than the main service command. This is the key setting for permission fixes: the service can run as UID/GID `1001`, while a short `chown` hook runs as `root`.
+
+Hook-level `privileged`: runs the hook command with privileged access. Use only when `user: root` is not enough.
+
+Hook-level `working_dir`: sets the working directory for the hook command. If omitted, Compose uses the main service command working directory.
+
+Hook-level `environment`: adds or overrides environment variables for the hook command. Hook commands inherit the service command environment.
+
+## Interface
+
+```yaml
+services:
+  app:
+    post_start:
+      - command: <string-or-exec-form-command>
+        user: <user>
+        privileged: <true|false>
+        working_dir: <path>
+        environment:
+          - KEY=VALUE
+
+    pre_stop:
+      - command: <string-or-exec-form-command>
+        user: <user>
+        privileged: <true|false>
+        working_dir: <path>
+        environment:
+          KEY: VALUE
+```
+
+`command` is required for each hook. The command can use shell form or exec form.
+
+`pre_stop` uses configuration equivalent to `post_start`.
+
+## Permission Fix Pattern
+
+Use this pattern when a service can tolerate the permission fix running shortly after startup:
+
+```yaml
+services:
+  app:
+    image: example/app:latest
+    user: "${APP_UID:-1001}:${APP_GID:-1001}"
+    volumes:
+      - app_data:/var/lib/app
+      - app_cache:/var/cache/app
+    post_start:
+      - command: >
+          sh -lc 'chown -R "${APP_UID:-1001}:${APP_GID:-1001}" /var/lib/app /var/cache/app'
+        user: root
+        environment:
+          APP_UID: "${APP_UID:-1001}"
+          APP_GID: "${APP_GID:-1001}"
+
+volumes:
+  app_data:
+  app_cache:
+```
+
+If the application needs permissions before entrypoint work starts reading or writing those paths, do the permission setup in the image entrypoint or a separate init/migration step instead.
+
+## Angie ACME Volume Pattern
+
+For Angie ACME, use hooks only if the Angie worker process needs access to a persisted ACME directory and image defaults do not already set ownership correctly.
+
+```yaml
+services:
+  angie:
+    image: docker.angie.software/angie:1.11.4
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./docker/angie/default.conf:/etc/angie/http.d/default.conf:ro
+      - angie_acme:/var/lib/angie/acme
+      - angie_logs:/var/log/angie
+    post_start:
+      - command: chown -R angie:angie /var/lib/angie/acme /var/log/angie
+        user: root
+
+volumes:
+  angie_acme:
+  angie_logs:
+```
+
+Only use user/group names that exist in the image. If unsure, check the image and prefer numeric UID/GID when portability matters.
+
+## Pre-stop Pattern
+
+Use `pre_stop` for best-effort cleanup or flushing when the container is intentionally stopped by Compose or the user:
+
+```yaml
+services:
+  app:
+    image: example/app:latest
+    pre_stop:
+      - command: ./data_flush.sh
+```
+
+Do not rely on `pre_stop` for critical durability. It will not run if the container stops by itself or is terminated suddenly.
+
+## Best Practices
+
+1. Use hooks to keep the main service non-root while allowing a narrow setup command to run as root.
+2. Prefer hook-level `user: root` over `privileged: true`. Use `privileged` only when normal root permissions are insufficient.
+3. Make permission hooks idempotent. `chown -R` and `mkdir -p` are acceptable; destructive cleanup is risky.
+4. Keep hook commands short and observable. If the command grows, put it in a script inside the image and call the script from the hook.
+5. Avoid `post_start` for work that must finish before the application starts.
+6. For named volumes, hooks are useful because Docker volumes are created with root ownership by default.
+7. For bind mounts from the host, remember that container `chown` can change host filesystem ownership on Linux.
+8. Add explicit `working_dir` when the hook command uses relative paths.
+9. Use hook-level `environment` for hook-specific values like UID/GID overrides.
+10. Require Docker Compose 2.30.0+ in generated documentation if the project uses `post_start` or `pre_stop`.
+
+## Common Pitfalls
+
+Assuming `post_start` runs before app startup: it runs after the container starts, and exact timing is not guaranteed. If permissions are required before entrypoint work, use entrypoint or init logic.
+
+Using `privileged: true` by default: for volume ownership fixes, `user: root` is usually the intended narrow elevation.
+
+Relying on `pre_stop` for guaranteed cleanup: it does not run on sudden termination, kill, or self-exit.
+
+Using user names that do not exist in the image: `chown app:app` fails if the image has no `app` user/group.
+
+Running recursive `chown` on large volumes every start: this can slow startup. Prefer a marker file or narrower paths if the volume is large.
+
+Changing ownership of host bind mounts unexpectedly: this can alter host filesystem ownership on Linux. Avoid recursive ownership changes on project source directories.
+
+Forgetting Compose version requirements: older Docker Compose versions do not support lifecycle hooks.
+
+## Source Facts To Preserve
+
+- Lifecycle hooks require Docker Compose 2.30.0 or later.
+- `post_start` runs after a container has started.
+- Exact `post_start` timing is not guaranteed.
+- Docker docs use `post_start` to `chown` a Docker volume because volumes are created with root ownership by default.
+- Hook command `user` defaults to the same user as the main service command when unset.
+- Hook command `privileged` can run the hook with privileged access.
+- Hook command `working_dir` defaults to the main service command working directory when unset.
+- Hook command `environment` inherits service environment and can add or override variables for the hook.
+- `pre_stop` runs before an intentional stop, such as `docker compose down` or manual stop.
+- `pre_stop` does not run if the container stops by itself or is terminated suddenly.


### PR DESCRIPTION
## Summary
- Add an Angie ACME reference for Docker-based HTTPS setup, persistent certificate storage, resolver requirements, and Certbot avoidance.
- Add a Docker Compose lifecycle hooks reference for non-root services, named-volume ownership fixes, and post_start/pre_stop caveats.
- Point the aif-dockerize skill at these focused references so agents know when to read them.

## Testing
- Not run; documentation/reference-only change.