### PR TITLE
feat(aif-commit): use active plan Commit Plan for multi-commit grouping

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -66,8 +66,8 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | `paths.roadmap` | `.ai-factory/ROADMAP.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-loop` | Strategic roadmap artifact |
 | `paths.research` | `.ai-factory/RESEARCH.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-improve`, `/aif-loop` | Persisted exploration context |
 | `paths.rules_file` | `.ai-factory/RULES.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-rules`, `/aif-reference`, `/aif-loop` | Top-level rules artifact |
-| `paths.plan` | `.ai-factory/PLAN.md` | `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-loop` | Fast-plan path |
-| `paths.plans` | `.ai-factory/plans/` | `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-loop` | Full-plan directory |
+| `paths.plan` | `.ai-factory/PLAN.md` | `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-loop` | Fast-plan path |
+| `paths.plans` | `.ai-factory/plans/` | `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-loop` | Full-plan directory |
 | `paths.fix_plan` | `.ai-factory/FIX_PLAN.md` | `/aif-fix`, `/aif-improve`, `/aif-implement`, `/aif-verify` | Fix-plan path |
 | `paths.security` | `.ai-factory/SECURITY.md` | `/aif-security-checklist` | Security ignore-state artifact |
 | `paths.references` | `.ai-factory/references/` | `/aif-reference` | Knowledge reference storage |
@@ -83,7 +83,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
 | `workflow.auto_create_dirs` | `true` | No dedicated built-in reader yet | Present in schema/template; reserved for directory-management behavior |
-| `workflow.plan_id_format` | `slug` | `/aif-plan`, `/aif-implement`, `/aif-improve`, `/aif-explore`, `/aif-verify`, `/aif-rules-check` | Active values: `slug` (default), `sequential`. Reserved values (currently fall back to `slug` with an `INFO` log): `timestamp`, `uuid`. `sequential` writes `paths.plans/<NNNN>_<stem>.md` where `stem` is the canonical Handoff/branch/slug stem from `/aif-plan` Step 1.2.a. `NNNN` is derived from existing numbered plans in the directory (next = max(existing) + 1; empty dir starts at `0001`), zero-padded to 4 digits, bounded at `9999` (the producer errors before writing `10000_…`). Deleting or moving a numbered plan out of the directory can free that number for reuse on the next run. Force-disabled when `HANDOFF_BRANCH_PREPARED=1`. |
+| `workflow.plan_id_format` | `slug` | `/aif-plan`, `/aif-implement`, `/aif-improve`, `/aif-explore`, `/aif-verify`, `/aif-rules-check`, `/aif-commit` | Active values: `slug` (default), `sequential`. Reserved values (currently fall back to `slug` with an `INFO` log): `timestamp`, `uuid`. `sequential` writes `paths.plans/<NNNN>_<stem>.md` where `stem` is the canonical Handoff/branch/slug stem from `/aif-plan` Step 1.2.a. `NNNN` is derived from existing numbered plans in the directory (next = max(existing) + 1; empty dir starts at `0001`), zero-padded to 4 digits, bounded at `9999` (the producer errors before writing `10000_…`). Deleting or moving a numbered plan out of the directory can free that number for reuse on the next run. Force-disabled when `HANDOFF_BRANCH_PREPARED=1`. |
 | `workflow.analyze_updates_architecture` | `true` | No dedicated built-in reader yet | Present in schema/template; reserved for setup/update workflow control |
 | `workflow.architecture_updates_roadmap` | `true` | No dedicated built-in reader yet | Present in schema/template; reserved for architecture-to-roadmap automation |
 | `workflow.verify_mode` | `normal` | `/aif-verify` | Default strictness for verification runs |
@@ -92,9 +92,9 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
-| `git.enabled` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-qa` | Disables branch/worktree assumptions when false; `/aif-qa` switches to manual change context instead of git diffing |
+| `git.enabled` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-qa` | Disables branch/worktree assumptions when false; `/aif-qa` switches to manual change context instead of git diffing |
 | `git.base_branch` | `main` with auto-detect fallback | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-qa` | Target branch for diff, merge, and verification guidance |
-| `git.create_branches` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify` | Full plans may still exist when false; they just skip auto branch creation |
+| `git.create_branches` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-commit` | Full plans may still exist when false; they just skip auto branch creation |
 | `git.branch_prefix` | `feature/` | `/aif`, `/aif-plan` | Prefix for auto-created full-plan branches |
 | `git.skip_push_after_commit` | `false` | `/aif-commit` | When true, `/aif-commit` skips push prompt and ends after local commit |
 
@@ -126,7 +126,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | `/aif-implement` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.research`, `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.patches`, `paths.rules`, `language.ui`, `language.artifacts`, `git.enabled`, `git.base_branch`, `git.create_branches`, `rules.base`, `rules.<area>` |
 | `/aif-verify` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.specs`, `paths.rules`, `workflow.verify_mode`, `git.enabled`, `git.base_branch`, `git.create_branches`, `rules.base`, `rules.<area>` |
 | `/aif-rules-check` | Yes | No | `paths.rules_file`, `paths.rules`, `paths.plan`, `paths.plans`, `language.ui`, `git.enabled`, `git.base_branch`, `rules.base`, `rules.<area>` |
-| `/aif-commit` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.rules`, `language.ui`, `git.skip_push_after_commit`, `rules.base`, `rules.<area>` |
+| `/aif-commit` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.rules`, `paths.plan`, `paths.plans`, `workflow.plan_id_format`, `language.ui`, `git.enabled`, `git.create_branches`, `git.skip_push_after_commit`, `rules.base`, `rules.<area>` |
 | `/aif-review` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.rules`, `language.ui`, `git.base_branch` |
 | `/aif-loop` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.research`, `paths.plan`, `paths.plans`, `paths.evolution`, `language.ui`, `language.artifacts` |
 | `/aif-docs` | Yes | No | `paths.description`, `paths.architecture`, `paths.docs`, `language.ui`, `language.artifacts` |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -421,6 +421,7 @@ Creates conventional commits:
 - Analyzes staged changes
 - Uses active plan `## Commit Plan` groups when available and asks whether to `Follow Commit Plan`, commit everything together, or adjust grouping
 - Stops for user input when staged files or hunks cannot be mapped to planned commit groups
+- Uses hunk-level staging for planned groups that share a file, or stops before changing staging when hunks cannot be applied confidently
 - Keeps current staged-diff behavior unchanged when no active plan or no `## Commit Plan` exists
 - Generates meaningful commit message
 - Follows conventional commits format

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -422,6 +422,7 @@ Creates conventional commits:
 - Uses active plan `## Commit Plan` groups when available and asks whether to `Follow Commit Plan`, commit everything together, or adjust grouping
 - Stops for user input when staged files or hunks cannot be mapped to planned commit groups
 - Uses hunk-level staging for planned groups that share a file, or stops before changing staging when hunks cannot be applied confidently
+- Avoids whole-file staging when there is unstaged worktree overlap with grouped files
 - Keeps current staged-diff behavior unchanged when no active plan or no `## Commit Plan` exists
 - Generates meaningful commit message
 - Follows conventional commits format

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -419,6 +419,9 @@ Adds project-specific rules and conventions:
 ### `/aif-commit`
 Creates conventional commits:
 - Analyzes staged changes
+- Uses active plan `## Commit Plan` groups when available and asks whether to `Follow Commit Plan`, commit everything together, or adjust grouping
+- Stops for user input when staged files or hunks cannot be mapped to planned commit groups
+- Keeps current staged-diff behavior unchanged when no active plan or no `## Commit Plan` exists
 - Generates meaningful commit message
 - Follows conventional commits format
 - Runs read-only architecture/roadmap/rules gate checks before commit proposal

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -312,7 +312,7 @@ Reviews staged changes or PR diff and reports correctness/security/performance f
 
 ### `/aif-commit` — conventional commit with read-only context gates
 
-Creates conventional commits from staged changes and runs read-only architecture/roadmap/rules checks before finalizing the message. When an active plan contains `## Commit Plan`, it can use the planned commit groups first; unmapped staged files trigger a question before staging or committing, and no commit plan leaves staged-diff behavior unchanged. By default this remains warning-first (no implicit strict mode). For `feat`/`fix`/`perf` commits, missing roadmap milestone linkage is reported as warning.
+Creates conventional commits from staged changes and runs read-only architecture/roadmap/rules checks before finalizing the message. When an active plan contains `## Commit Plan`, it can use the planned commit groups first; unmapped staged files trigger a question before staging or committing, and no commit plan leaves staged-diff behavior unchanged. If the same file spans multiple groups, `/aif-commit` must use hunk-level staging or stop before changing staging. By default this remains warning-first (no implicit strict mode). For `feat`/`fix`/`perf` commits, missing roadmap milestone linkage is reported as warning.
 
 ### `/aif-fix [bug description]` — fix and learn
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -312,7 +312,7 @@ Reviews staged changes or PR diff and reports correctness/security/performance f
 
 ### `/aif-commit` — conventional commit with read-only context gates
 
-Creates conventional commits from staged changes and runs read-only architecture/roadmap/rules checks before finalizing the message. By default this remains warning-first (no implicit strict mode). For `feat`/`fix`/`perf` commits, missing roadmap milestone linkage is reported as warning.
+Creates conventional commits from staged changes and runs read-only architecture/roadmap/rules checks before finalizing the message. When an active plan contains `## Commit Plan`, it can use the planned commit groups first; unmapped staged files trigger a question before staging or committing, and no commit plan leaves staged-diff behavior unchanged. By default this remains warning-first (no implicit strict mode). For `feat`/`fix`/`perf` commits, missing roadmap milestone linkage is reported as warning.
 
 ### `/aif-fix [bug description]` — fix and learn
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -312,7 +312,7 @@ Reviews staged changes or PR diff and reports correctness/security/performance f
 
 ### `/aif-commit` — conventional commit with read-only context gates
 
-Creates conventional commits from staged changes and runs read-only architecture/roadmap/rules checks before finalizing the message. When an active plan contains `## Commit Plan`, it can use the planned commit groups first; unmapped staged files trigger a question before staging or committing, and no commit plan leaves staged-diff behavior unchanged. If the same file spans multiple groups, `/aif-commit` must use hunk-level staging or stop before changing staging. By default this remains warning-first (no implicit strict mode). For `feat`/`fix`/`perf` commits, missing roadmap milestone linkage is reported as warning.
+Creates conventional commits from staged changes and runs read-only architecture/roadmap/rules checks before finalizing the message. When an active plan contains `## Commit Plan`, it can use the planned commit groups first; unmapped staged files trigger a question before staging or committing, and no commit plan leaves staged-diff behavior unchanged. If the same file spans multiple groups, `/aif-commit` must use hunk-level staging or stop before changing staging. Whole-file staging is allowed only when grouped files do not overlap unstaged worktree paths. By default this remains warning-first (no implicit strict mode). For `feat`/`fix`/`perf` commits, missing roadmap milestone linkage is reported as warning.
 
 ### `/aif-fix [bug description]` — fix and learn
 

--- a/scripts/test-audit-artifacts.sh
+++ b/scripts/test-audit-artifacts.sh
@@ -217,7 +217,15 @@ status: active
 owners: [docs]
 ---
 # Outside'
-ln -s "$OUTSIDE_DIR" "$SYMLINK_PROJECT/docs"
+node - "$OUTSIDE_DIR" "$SYMLINK_PROJECT/docs" <<'EOF'
+const fs = require('fs');
+
+fs.symlinkSync(
+  process.argv[2],
+  process.argv[3],
+  process.platform === 'win32' ? 'junction' : 'dir',
+);
+EOF
 SYMLINK_OUTPUT="$TMPDIR/symlink.json"
 if run_audit "$SYMLINK_PROJECT" "$SYMLINK_OUTPUT"; then
     pass "default outside symlink warning exits 0"

--- a/scripts/test-init.sh
+++ b/scripts/test-init.sh
@@ -884,10 +884,12 @@ for (const relPath of ['../config.toml', 'nested/../../config.toml', 'C:/config.
 }
 
 const resolved = resolveManagedConfigFilePaths(projectDir, 'codex', 'config.toml');
-if (!resolved.targetFile.endsWith('/.codex/config.toml')) {
+const normalizedTarget = resolved.targetFile.replaceAll('\\', '/');
+const normalizedSource = resolved.sourceFile.replaceAll('\\', '/');
+if (!normalizedTarget.endsWith('/.codex/config.toml')) {
   throw new Error(`Unexpected target path: ${resolved.targetFile}`);
 }
-if (!resolved.sourceFile.endsWith('/subagents/codex/config.toml')) {
+if (!normalizedSource.endsWith('/subagents/codex/config.toml')) {
   throw new Error(`Unexpected source path: ${resolved.sourceFile}`);
 }
 EOF

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -213,7 +213,11 @@ fi
 
 # /aif localization contract regression checks
 AIF_SKILL="$ROOT_DIR/skills/aif/SKILL.md"
+AIF_COMMIT_SKILL="$ROOT_DIR/skills/aif-commit/SKILL.md"
 AIF_ARCH_SKILL="$ROOT_DIR/skills/aif-architecture/SKILL.md"
+CONFIG_REFERENCE_DOC="$ROOT_DIR/docs/config-reference.md"
+WORKFLOW_DOC="$ROOT_DIR/docs/workflow.md"
+SKILLS_DOC="$ROOT_DIR/docs/skills.md"
 MODE1_SECTION="$(awk '
     /^### Mode 1: Analyze Existing Project$/ { capture=1 }
     capture { print }
@@ -475,6 +479,76 @@ if printf '%s\n' "$AIF_ARCH_OWNERSHIP_SECTION" | grep -Fq '.ai-factory/DESCRIPTI
     fail "default DESCRIPTION path leaked into /aif-architecture Artifact Ownership"
 else
     pass "no default DESCRIPTION path leak in /aif-architecture Artifact Ownership"
+fi
+
+# /aif-commit active Commit Plan grouping contract
+if grep -Fq '`paths.plan`' "$AIF_COMMIT_SKILL" \
+   && grep -Fq '`paths.plans`' "$AIF_COMMIT_SKILL" \
+   && grep -Fq '`workflow.plan_id_format`' "$AIF_COMMIT_SKILL" \
+   && grep -Fq '`git.enabled`' "$AIF_COMMIT_SKILL" \
+   && grep -Fq '`git.create_branches`' "$AIF_COMMIT_SKILL"; then
+    pass "/aif-commit reads config keys for active plan discovery"
+else
+    fail "/aif-commit active-plan config keys missing"
+fi
+
+if grep -Fq 'Resolve active plan using this read-only priority' "$AIF_COMMIT_SKILL" \
+   && grep -Fq '`@<plan-file>`' "$AIF_COMMIT_SKILL" \
+   && grep -Fq 'branch-based full plan' "$AIF_COMMIT_SKILL" \
+   && grep -Fq 'single full plan in `paths.plans`' "$AIF_COMMIT_SKILL" \
+   && grep -Fq 'fast plan at `paths.plan`' "$AIF_COMMIT_SKILL"; then
+    pass "/aif-commit documents active plan discovery priority"
+else
+    fail "/aif-commit active plan discovery priority missing"
+fi
+
+if grep -Fq 'If active plan contains `## Commit Plan`' "$AIF_COMMIT_SKILL" \
+   && grep -Fq 'Compare staged files/hunks with planned groups' "$AIF_COMMIT_SKILL" \
+   && grep -Fq 'Follow Commit Plan' "$AIF_COMMIT_SKILL" \
+   && grep -Fq 'Commit everything together' "$AIF_COMMIT_SKILL" \
+   && grep -Fq 'Adjust grouping' "$AIF_COMMIT_SKILL" \
+   && grep -Fq 'If files cannot be mapped to groups, stop and ask the user to adjust grouping.' "$AIF_COMMIT_SKILL"; then
+    pass "/aif-commit documents Commit Plan grouping prompt and unmapped-file behavior"
+else
+    fail "/aif-commit Commit Plan grouping contract missing"
+fi
+
+if grep -Fq 'If no active plan resolves or the active plan has no `## Commit Plan`, keep current staged-diff behavior unchanged.' "$AIF_COMMIT_SKILL"; then
+    pass "/aif-commit preserves fallback without Commit Plan"
+else
+    fail "/aif-commit fallback without Commit Plan missing"
+fi
+
+CONFIG_COMMIT_ROW="$(grep -F '| `/aif-commit` |' "$CONFIG_REFERENCE_DOC" || true)"
+if printf '%s\n' "$CONFIG_COMMIT_ROW" | grep -Fq '`paths.plan`' \
+   && printf '%s\n' "$CONFIG_COMMIT_ROW" | grep -Fq '`paths.plans`' \
+   && printf '%s\n' "$CONFIG_COMMIT_ROW" | grep -Fq '`workflow.plan_id_format`' \
+   && printf '%s\n' "$CONFIG_COMMIT_ROW" | grep -Fq '`git.enabled`' \
+   && printf '%s\n' "$CONFIG_COMMIT_ROW" | grep -Fq '`git.create_branches`' \
+   && printf '%s\n' "$CONFIG_COMMIT_ROW" | grep -Fq '`git.skip_push_after_commit`'; then
+    pass "config reference lists /aif-commit active-plan config usage"
+else
+    fail "config reference missing /aif-commit active-plan config usage"
+fi
+
+if grep -F '| `paths.plan` |' "$CONFIG_REFERENCE_DOC" | grep -Fq '/aif-commit' \
+   && grep -F '| `paths.plans` |' "$CONFIG_REFERENCE_DOC" | grep -Fq '/aif-commit' \
+   && grep -F '| `workflow.plan_id_format` |' "$CONFIG_REFERENCE_DOC" | grep -Fq '/aif-commit' \
+   && grep -F '| `git.enabled` |' "$CONFIG_REFERENCE_DOC" | grep -Fq '/aif-commit' \
+   && grep -F '| `git.create_branches` |' "$CONFIG_REFERENCE_DOC" | grep -Fq '/aif-commit'; then
+    pass "config reference key rows include /aif-commit where applicable"
+else
+    fail "config reference key rows missing /aif-commit"
+fi
+
+if grep -Fq 'active plan contains `## Commit Plan`' "$WORKFLOW_DOC" \
+   && grep -Fq 'unmapped staged files' "$WORKFLOW_DOC" \
+   && grep -Fq 'staged-diff behavior unchanged' "$WORKFLOW_DOC" \
+   && grep -Fq 'active plan `## Commit Plan`' "$SKILLS_DOC" \
+   && grep -Fq 'Follow Commit Plan' "$SKILLS_DOC"; then
+    pass "/aif-commit docs describe plan-aware grouping and fallback"
+else
+    fail "/aif-commit docs missing plan-aware grouping and fallback"
 fi
 
 # No hardcoded agent-specific values (must use {{template_vars}})

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -513,6 +513,16 @@ else
     fail "/aif-commit Commit Plan grouping contract missing"
 fi
 
+if grep -Fq 'Only use `git add <files>` when each planned group has a disjoint file set.' "$AIF_COMMIT_SKILL" \
+   && grep -Fq 'When one file spans multiple planned groups, use hunk-level staging (`git add -p` or `git apply --cached`) for each group.' "$AIF_COMMIT_SKILL" \
+   && grep -Fq 'If hunk-level staging cannot be applied confidently, stop before changing staging and ask the user to adjust grouping or commit everything together.' "$AIF_COMMIT_SKILL" \
+   && grep -Fq 'same file spans multiple groups' "$WORKFLOW_DOC" \
+   && grep -Fq 'hunk-level staging' "$SKILLS_DOC"; then
+    pass "/aif-commit prevents whole-file staging leakage across planned groups"
+else
+    fail "/aif-commit missing hunk-level staging guard for same-file planned groups"
+fi
+
 if grep -Fq 'If no active plan resolves or the active plan has no `## Commit Plan`, keep current staged-diff behavior unchanged.' "$AIF_COMMIT_SKILL"; then
     pass "/aif-commit preserves fallback without Commit Plan"
 else

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -513,7 +513,7 @@ else
     fail "/aif-commit Commit Plan grouping contract missing"
 fi
 
-if grep -Fq 'Only use `git add <files>` when each planned group has a disjoint file set.' "$AIF_COMMIT_SKILL" \
+if grep -Fq 'disjoint file set' "$AIF_COMMIT_SKILL" \
    && grep -Fq 'When one file spans multiple planned groups, use hunk-level staging (`git add -p` or `git apply --cached`) for each group.' "$AIF_COMMIT_SKILL" \
    && grep -Fq 'If hunk-level staging cannot be applied confidently, stop before changing staging and ask the user to adjust grouping or commit everything together.' "$AIF_COMMIT_SKILL" \
    && grep -Fq 'same file spans multiple groups' "$WORKFLOW_DOC" \
@@ -521,6 +521,16 @@ if grep -Fq 'Only use `git add <files>` when each planned group has a disjoint f
     pass "/aif-commit prevents whole-file staging leakage across planned groups"
 else
     fail "/aif-commit missing hunk-level staging guard for same-file planned groups"
+fi
+
+if grep -Fq 'Before using whole-file staging, compare grouped files with unstaged worktree paths from `git diff --name-only`.' "$AIF_COMMIT_SKILL" \
+   && grep -Fq 'Only use `git add <files>` when each planned group has a disjoint file set and no grouped file appears in `git diff --name-only`.' "$AIF_COMMIT_SKILL" \
+   && grep -Fq 'If grouped files overlap unstaged worktree paths, preserve and apply the original cached patch per group (`git diff --cached` + `git apply --cached`), use hunk-level staging, or stop before changing staging.' "$AIF_COMMIT_SKILL" \
+   && grep -Fq 'unstaged worktree paths' "$WORKFLOW_DOC" \
+   && grep -Fq 'unstaged worktree overlap' "$SKILLS_DOC"; then
+    pass "/aif-commit prevents whole-file staging from pulling unstaged WIP"
+else
+    fail "/aif-commit missing guard against staging unstaged WIP in grouped files"
 fi
 
 if grep -Fq 'If no active plan resolves or the active plan has no `## Commit Plan`, keep current staged-diff behavior unchanged.' "$AIF_COMMIT_SKILL"; then

--- a/skills/aif-commit/SKILL.md
+++ b/skills/aif-commit/SKILL.md
@@ -79,8 +79,10 @@ If any rule is violated — fix the output before presenting it to the user.
      - use staged hunk evidence from `git diff --cached` when a file may span multiple groups
      - task ranges and `Files:` hints are guidance, not executable instructions
    - If files cannot be mapped to groups, stop and ask the user to adjust grouping.
-   - Only use `git add <files>` when each planned group has a disjoint file set.
+   - Before using whole-file staging, compare grouped files with unstaged worktree paths from `git diff --name-only`.
+   - Only use `git add <files>` when each planned group has a disjoint file set and no grouped file appears in `git diff --name-only`.
    - When one file spans multiple planned groups, use hunk-level staging (`git add -p` or `git apply --cached`) for each group.
+   - If grouped files overlap unstaged worktree paths, preserve and apply the original cached patch per group (`git diff --cached` + `git apply --cached`), use hunk-level staging, or stop before changing staging.
    - If hunk-level staging cannot be applied confidently, stop before changing staging and ask the user to adjust grouping or commit everything together.
    - When a usable grouping exists, ask:
 
@@ -241,9 +243,10 @@ If argument provided (e.g., `/aif-commit auth`):
      - **Yes, split as suggested** → proceed to step 4
      - **No, commit everything together** → proceed to step 5 (propose single commit message)
      - **Let me adjust the grouping** → ask the user for the adjusted grouping via `AskUserQuestion`, then return to step 2 with the new plan
-  4. Before changing staging, confirm whether each planned group has a disjoint file set or whether any file spans multiple groups.
-  5. If every group has a disjoint file set, unstage all with `git reset HEAD`, then stage and commit each group separately using `git add <files>` + `git commit`.
-  6. If one file spans multiple groups, use hunk-level staging for each group: stage only that group's hunks with `git add -p` or `git apply --cached`, commit, then repeat for the next group.
-  7. If hunk-level staging cannot be applied confidently, stop before changing staging and ask the user to adjust grouping or commit everything together.
-  8. Offer to push only after all commits are done
+  4. Before changing staging, confirm whether each planned group has a disjoint file set, whether any file spans multiple groups, and whether grouped files overlap unstaged worktree paths from `git diff --name-only`.
+  5. If every group has a disjoint file set and no grouped file appears in `git diff --name-only`, unstage all with `git reset HEAD`, then stage and commit each group separately using `git add <files>` + `git commit`.
+  6. If grouped files overlap unstaged worktree paths, preserve each group's original cached patch before unstaging and re-apply only that patch with `git apply --cached`; otherwise use hunk-level staging or stop before changing staging.
+  7. If one file spans multiple groups, use hunk-level staging for each group: stage only that group's hunks with `git add -p` or `git apply --cached`, commit, then repeat for the next group.
+  8. If hunk-level staging or cached-patch application cannot be applied confidently, stop before changing staging and ask the user to adjust grouping or commit everything together.
+  9. Offer to push only after all commits are done
 - NEVER add `Co-Authored-By` or any other trailer attributing authorship to the AI. Commits must not contain AI co-author lines

--- a/skills/aif-commit/SKILL.md
+++ b/skills/aif-commit/SKILL.md
@@ -2,7 +2,7 @@
 name: aif-commit
 description: Create conventional commit messages by analyzing staged changes. Generates semantic commit messages following the Conventional Commits specification. Use when user says "commit", "save changes", or "create commit".
 argument-hint: "[scope or context]"
-allowed-tools: Read Bash(git *) AskUserQuestion Questions
+allowed-tools: Read Glob Bash(git *) AskUserQuestion Questions
 disable-model-invocation: false
 ---
 
@@ -13,14 +13,17 @@ Generate commit messages following the [Conventional Commits](https://www.conven
 ## Workflow
 
 **FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
-- **Paths:** `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, and `paths.rules`
+- **Paths:** `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.rules`, `paths.plan`, and `paths.plans`
 - **Language:** `language.ui` for prompts and commit message conventions
-- **Git preference:** `git.skip_push_after_commit` for post-commit push behavior
+- **Workflow:** `workflow.plan_id_format` for read-only active plan discovery (`slug` default; `sequential` uses numbered full-plan lookup)
+- **Git preference:** `git.enabled`, `git.create_branches`, and `git.skip_push_after_commit` for active plan discovery and post-commit push behavior
 - **Rules hierarchy:** `rules.base` plus any named `rules.<area>` entries
 
 If config.yaml doesn't exist, use defaults:
-- Paths: `.ai-factory/` for all artifacts
+- Paths: `.ai-factory/` for context artifacts, `.ai-factory/PLAN.md` for `paths.plan`, `.ai-factory/plans/` for `paths.plans`
 - Language: `en` (English)
+- Workflow: `workflow.plan_id_format: slug`
+- Git: `git.enabled: true`, `git.create_branches: true`
 - Git preference: `skip_push_after_commit: false`
 
 **Read `.ai-factory/skill-context/aif-commit/SKILL.md`** — MANDATORY if the file exists.
@@ -48,7 +51,50 @@ If any rule is violated — fix the output before presenting it to the user.
    - Run `git diff --cached` to see staged changes
    - If nothing staged, show warning and suggest staging
 
-2. **Run Context Gates (Read-Only)**
+2. **Resolve Active Plan Context (Read-Only, Optional)**
+   - Resolve active plan using this read-only priority:
+     1. `@<plan-file>` argument, when the argument starts with `@`
+     2. branch-based full plan in `paths.plans`
+     3. single full plan in `paths.plans`
+     4. fast plan at `paths.plan`
+   - If the argument does not start with `@`, keep treating it as commit scope/context.
+   - For branch-based full plan lookup:
+     - get current branch with `git branch --show-current` when `git.enabled = true`
+     - replace every `/` with `-` to get `<branch-stem>`
+     - when `workflow.plan_id_format = sequential`, use `Glob` for `paths.plans/[0-9][0-9][0-9][0-9]_<branch-stem>.md` first
+     - if multiple sequential matches exist, use the highest-numbered match and emit `WARN [aif-commit] multiple sequential plans for <branch>: <list>; using <chosen>`
+     - if no sequential match exists, fall back to `paths.plans/<branch-stem>.md`
+   - If git mode is off, branch lookup cannot resolve, or no branch-based plan exists, check whether `paths.plans` contains exactly one full-plan markdown file.
+   - If no active plan resolves or the active plan has no `## Commit Plan`, keep current staged-diff behavior unchanged.
+   - Never modify the active plan from this command.
+
+3. **Use Commit Plan Grouping When Available**
+   - If active plan contains `## Commit Plan`, parse:
+     - commit group number/name
+     - task range, such as `after tasks 1-3` or `tasks 4-6`
+     - suggested conventional commit message
+   - Read the plan's `## Tasks` or `## Implementation Tasks` section to map task ranges to task descriptions and any `Files:` hints.
+   - Compare staged files/hunks with planned groups before changing staging:
+     - use staged file paths from `git diff --cached --name-only`
+     - use staged hunk evidence from `git diff --cached` when a file may span multiple groups
+     - task ranges and `Files:` hints are guidance, not executable instructions
+   - If files cannot be mapped to groups, stop and ask the user to adjust grouping.
+   - When a usable grouping exists, ask:
+
+     ```
+     AskUserQuestion: Active plan contains a Commit Plan. How should these staged changes be committed?
+
+     Options:
+     1. Follow Commit Plan
+     2. Commit everything together
+     3. Adjust grouping
+     ```
+
+   - **Follow Commit Plan** → confirm the planned groups and messages, then proceed through user-confirmed multi-commit staging/commit flow.
+   - **Commit everything together** → ignore plan grouping for this run and continue with the current single-message flow.
+   - **Adjust grouping** → ask the user for the adjusted grouping, then validate it against staged files before committing.
+
+4. **Run Context Gates (Read-Only)**
    - Check the resolved architecture and description artifacts (use paths from config) to catch obvious scope/boundary drift
    - Check the resolved RULES.md and roadmap artifacts (use paths from config) to catch rule and milestone alignment issues
    - Check rules hierarchy (resolved `paths.rules_file` + `rules.base` + named `rules.<area>`) for commit conventions
@@ -56,7 +102,7 @@ If any rule is violated — fix the output before presenting it to the user.
    - Never modify context artifacts from this command
    - If the user wants a standalone rules-only pass, suggest `/aif-rules-check`; keep `/aif-commit` gate labels at `WARN` / `ERROR`
 
-3. **Determine Commit Type**
+5. **Determine Commit Type**
    - `feat`: New feature
    - `fix`: Bug fix
    - `docs`: Documentation only
@@ -68,12 +114,12 @@ If any rule is violated — fix the output before presenting it to the user.
    - `ci`: CI configuration
    - `chore`: Maintenance tasks
 
-4. **Identify Scope**
+6. **Identify Scope**
    - From file paths (e.g., `src/auth/` → `auth`)
    - From argument if provided
    - Optional - omit if changes span multiple areas
 
-5. **Generate Message**
+7. **Generate Message**
    - Keep subject line under 72 characters
    - Use imperative mood ("add" not "added")
    - Don't capitalize first letter after type
@@ -119,10 +165,11 @@ When invoked:
 
 1. Check for staged changes
 2. Analyze the diff content
-3. Run read-only context gates and summarize findings as `WARN`/`ERROR`
-4. If commit type is `feat`/`fix`/`perf` and roadmap exists, check milestone linkage; if missing, warn and suggest adding linkage in commit body/footer
-5. Propose a commit message
-6. Confirm with the user before committing:
+3. Resolve optional active plan context and use `## Commit Plan` grouping when available
+4. Run read-only context gates and summarize findings as `WARN`/`ERROR`
+5. If commit type is `feat`/`fix`/`perf` and roadmap exists, check milestone linkage; if missing, warn and suggest adding linkage in commit body/footer
+6. Propose a commit message
+7. Confirm with the user before committing:
 
    ```
    AskUserQuestion: Proposed commit message:
@@ -135,13 +182,13 @@ When invoked:
    3. Cancel
    ```
 
-7. Handle user response:
-   - **Commit as is** → proceed to step 8
-   - **Edit message** → ask the user for the corrected message via `AskUserQuestion`, then return to step 6 with the new message
+8. Handle user response:
+   - **Commit as is** → proceed to step 9
+   - **Edit message** → ask the user for the corrected message via `AskUserQuestion`, then return to step 7 with the new message
    - **Cancel** → stop, do NOT commit. End the workflow
 
-8. Execute `git commit` with the confirmed message
-9. Post-commit push handling:
+9. Execute `git commit` with the confirmed message
+10. Post-commit push handling:
    - If `git.skip_push_after_commit = true` in resolved config:
      - Skip push prompt entirely
      - End workflow after successful local commit
@@ -172,7 +219,8 @@ If argument provided (e.g., `/aif-commit auth`):
 - Never commit secrets or credentials
 - Review large diffs carefully before committing
 - `/aif-commit` has no implicit strict mode — context gates are warning-first unless user explicitly requests blocking behavior
-- Treat the resolved architecture, roadmap, RULES.md, and description artifacts as read-only context in this command
+- Treat the resolved architecture, roadmap, RULES.md, description, and plan artifacts as read-only context in this command
+- If no active plan resolves or the active plan has no `## Commit Plan`, keep current staged-diff behavior unchanged.
 - If staged changes contain unrelated work (e.g., a feature + a bugfix, or changes to independent modules), suggest splitting into separate commits:
   1. Show which files/hunks belong to which commit
   2. Confirm split plan with the user:

--- a/skills/aif-commit/SKILL.md
+++ b/skills/aif-commit/SKILL.md
@@ -79,6 +79,9 @@ If any rule is violated — fix the output before presenting it to the user.
      - use staged hunk evidence from `git diff --cached` when a file may span multiple groups
      - task ranges and `Files:` hints are guidance, not executable instructions
    - If files cannot be mapped to groups, stop and ask the user to adjust grouping.
+   - Only use `git add <files>` when each planned group has a disjoint file set.
+   - When one file spans multiple planned groups, use hunk-level staging (`git add -p` or `git apply --cached`) for each group.
+   - If hunk-level staging cannot be applied confidently, stop before changing staging and ask the user to adjust grouping or commit everything together.
    - When a usable grouping exists, ask:
 
      ```
@@ -238,7 +241,9 @@ If argument provided (e.g., `/aif-commit auth`):
      - **Yes, split as suggested** → proceed to step 4
      - **No, commit everything together** → proceed to step 5 (propose single commit message)
      - **Let me adjust the grouping** → ask the user for the adjusted grouping via `AskUserQuestion`, then return to step 2 with the new plan
-  4. Unstage all: `git reset HEAD`
-  5. Stage and commit each group separately using `git add <files>` + `git commit`
-  6. Offer to push only after all commits are done
+  4. Before changing staging, confirm whether each planned group has a disjoint file set or whether any file spans multiple groups.
+  5. If every group has a disjoint file set, unstage all with `git reset HEAD`, then stage and commit each group separately using `git add <files>` + `git commit`.
+  6. If one file spans multiple groups, use hunk-level staging for each group: stage only that group's hunks with `git add -p` or `git apply --cached`, commit, then repeat for the next group.
+  7. If hunk-level staging cannot be applied confidently, stop before changing staging and ask the user to adjust grouping or commit everything together.
+  8. Offer to push only after all commits are done
 - NEVER add `Co-Authored-By` or any other trailer attributing authorship to the AI. Commits must not contain AI co-author lines


### PR DESCRIPTION
## Summary

- Update `aif-commit` so commit planning can use active plan commit groups when deciding whether to split changes.
- Document the plan-aware grouping behavior in the workflow, skills, and config reference docs.
- Add smoke test coverage, including Windows portability fixes for the related test scripts.
- Closed #111 

## Impact

This makes commit guidance better aligned with existing plan checkpoints and reduces accidental grouping drift when a plan already defines commit boundaries.

## Validation

Not run in this publish step, per the project rule to avoid tests unless explicitly requested.