### PR TITLE
Add aif-distillation skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 **AI Factory** (v2) is an npm package + skill system that automates AI agent context setup for projects. It provides:
 
 1. **CLI tool** (`ai-factory init/update/upgrade`) — installs skills and configures MCP
-2. **Built-in skills** (25 skills, all `aif-*` prefixed) — workflow commands for spec-driven development
+2. **Built-in skills** (26 skills, all `aif-*` prefixed) — workflow commands for spec-driven development
 3. **Spec-driven workflow** — structured approach: plan → implement → commit
 4. **Multi-agent support** — 16 agents (Claude Code, Cursor, Windsurf, Roo Code, Kilo Code, Antigravity, OpenCode, Warp,
    Zencoder, Codex CLI, Codex app, GitHub Copilot, Gemini CLI, Junie, Qwen Code, Universal)
@@ -30,6 +30,7 @@ ai-factory/
 │   ├── aif-build-automation/   # Makefile/Taskfile/Justfile/Mage; unified stack detection (incl. JVM)
 │   ├── aif-ci/                 # GitHub Actions / GitLab CI generator
 │   ├── aif-commit/             # Conventional commits
+│   ├── aif-distillation/       # Distill books/docs/files into skills
 │   ├── aif-dockerize/          # Docker/compose generator
 │   ├── aif-docs/               # Documentation generation & maintenance
 │   ├── aif-evolve/             # Self-improve skills based on context
@@ -129,6 +130,7 @@ Context gate policy for quality commands:
 - Core workflow and quality: `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`,
   `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`
 - Additional utility: `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`,
+  `/aif-distillation`,
   `/aif-security-checklist`, `/aif-qa`
 
 Current config-agnostic built-ins:
@@ -450,10 +452,17 @@ docs/
 
 ### Adding a new skill
 
-1. Create `skills/aif-new-skill/SKILL.md` (must use `aif-` prefix)
-2. Add to `getAvailableSkills()` if needed
-3. Rebuild: `npm run build`
-4. Validate: `npm test`
+1. Create `skills/aif-new-skill/SKILL.md` (must use the `aif-` prefix). Built-in skills are discovered from `skills/`; no TypeScript registry change is needed unless adding UI hints or agent-specific behavior.
+2. Keep `SKILL.md` as the router: purpose, triggers, Step 0 context/config loading, workflow, and ownership. Put dense knowledge in `references/`; put reusable examples in `examples/`; add `scripts/` only for repeatable processing. If source material includes code examples, generated skills must include adapted code snippets in `examples/` and cover the major code-facing source areas, not only a few samples.
+3. Decide config policy explicitly:
+   - Config-aware skills must read `.ai-factory/config.yaml` first and document exact keys used.
+   - Config-agnostic skills must say why they do not read config.
+   - Use `language.ui` for prompts/summaries and `language.artifacts` for generated artifacts when applicable.
+4. Add an Artifact Ownership section. Owner commands write only their owned artifacts; non-owner context artifacts stay read-only. Quality gates must follow the shared `aif-gate-result` contract only when they are machine-readable gates.
+5. Never hardcode installed skill directories in built-in skills. Use template variables such as `{{skills_dir}}` or `{{home_skills_dir}}`; the installer resolves them per agent.
+6. If the skill creates user skills, save them in the current agent skills directory (`{{skills_dir}}/<skill-name>/`) with concise lowercase-hyphen names.
+7. Update docs when user-facing behavior changes: `docs/skills.md`, `docs/workflow.md` if workflow-relevant, `docs/configuration.md` / `docs/config-reference.md` if config-aware, and `AGENTS.md` if project rules change.
+8. Validate with `npm run build` and `npm test`.
 
 ### Modifying workflow
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -52,9 +52,9 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
-| `language.ui` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-reference`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa` | UI language for prompts, questions, and summaries; `/aif` resolves it before downstream setup questions |
-| `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-roadmap`, `/aif-implement`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-qa` | Language for generated artifacts; `/aif` locks it before the first setup artifact so DESCRIPTION/rules base/AGENTS/ARCHITECTURE stay aligned in one run; `/aif-qa` uses it for QA markdown artifacts with fallback to `language.ui` |
-| `language.technical_terms` | `keep` | `/aif-qa` | Present in schema and template; `/aif` preserves an existing value when present and otherwise writes the default `keep`; `/aif-qa` uses it to decide whether human-readable QA terminology should stay in English, be translated, or use mixed style |
+| `language.ui` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-reference`, `/aif-distillation`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa` | UI language for prompts, questions, and summaries; `/aif` resolves it before downstream setup questions |
+| `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-roadmap`, `/aif-implement`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-distillation`, `/aif-qa` | Language for generated artifacts; `/aif` locks it before the first setup artifact so DESCRIPTION/rules base/AGENTS/ARCHITECTURE stay aligned in one run; `/aif-distillation` uses it for generated skill package content; `/aif-qa` uses it for QA markdown artifacts with fallback to `language.ui` |
+| `language.technical_terms` | `keep` | `/aif-distillation`, `/aif-qa` | Present in schema and template; `/aif` preserves an existing value when present and otherwise writes the default `keep`; `/aif-distillation` and `/aif-qa` use it to decide whether human-readable terminology should stay in English, be translated, or use mixed style |
 
 ### `paths`
 
@@ -133,6 +133,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | `/aif-fix` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.rules`, `paths.fix_plan`, `paths.patches`, `language.ui`, `rules.base`, `rules.<area>` |
 | `/aif-evolve` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.rules`, `paths.patches`, `paths.evolutions`, `language.ui`, `language.artifacts`, `rules.base`, `rules.<area>` |
 | `/aif-reference` | Yes | No | `paths.references`, `paths.rules_file`, `language.ui` |
+| `/aif-distillation` | Yes | No | `language.ui`, `language.artifacts`, `language.technical_terms` |
 | `/aif-security-checklist` | Yes | No | `paths.security`, `language.ui` |
 | `/aif-qa` | Yes | No | `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, `language.artifacts`, `language.technical_terms`, `git.enabled`, `git.base_branch` |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,7 +189,7 @@ rules:
 
 **Current config-aware skills** read `config.yaml` at Step 0. This currently includes:
 - Core workflow and quality commands: `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`
-- Additional utility commands: `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-security-checklist`, `/aif-qa`
+- Additional utility commands: `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-distillation`, `/aif-security-checklist`, `/aif-qa`
 
 Other skills are config-agnostic for now and rely on repository context, explicit arguments, or fixed non-configurable paths such as `skill-context`.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,7 +2,7 @@
 
 # Core Skills
 
-**Config-aware skills read `.ai-factory/config.yaml` at startup** to resolve paths, language settings, workflow preferences, and rules hierarchy. The current config-aware set is `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`, `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-security-checklist`, and `/aif-qa`.
+**Config-aware skills read `.ai-factory/config.yaml` at startup** to resolve paths, language settings, workflow preferences, and rules hierarchy. The current config-aware set is `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`, `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-distillation`, `/aif-security-checklist`, and `/aif-qa`.
 
 `/aif` is also the primary writer for `config.yaml`: the initial file comes from the commented template, and setup reruns update only managed keys while preserving comments, unrelated manual edits, and `rules.<area>` entries owned by `/aif-rules`.
 
@@ -474,6 +474,26 @@ Creates knowledge references from external sources for AI agents:
 - Best when AI needs knowledge it wasn't trained on: new libraries, internal APIs, project-specific specs, or rapidly changing documentation
 
 - Config policy: config-aware; reference storage uses `paths.references`
+
+### `/aif-distillation <path|url> [path|url...] [--name <skill-name>] [--update]`
+Distills books, documents, folders, or URLs into reusable Agent Skills:
+```
+/aif-distillation ./books/software-craft.pdf --name construction-practices
+/aif-distillation ./docs/internal-platform ./examples --name platform-operator
+/aif-distillation https://example.com/guide --name example-api
+/aif-distillation ./new-material --name platform-operator --update
+```
+- Accepts local files, directories, and URLs, including large PDFs through a chunking helper
+- Saves the distilled package in the current agent's skills directory, for example `.codex/skills/<skill-name>/` for Codex CLI
+- Produces a compact `SKILL.md` plus detailed `references/` and practical `examples/`
+- Converts source material into workflows, heuristics, checklists, pitfalls, and examples rather than a long summary
+- For programming material, creates adapted code examples such as before/after snippets or code patterns and maps major code-facing source areas to concrete examples
+- Checks existing references/examples before writing and updates matching files instead of creating duplicates
+- Uses temporary extraction artifacts for large material and removes them after generation
+- Reads `.ai-factory/config.yaml` for `language.ui`, `language.artifacts`, and `language.technical_terms`
+- Best when you want a durable skill from a book, internal documentation set, research notes, or external guide
+
+- Config policy: config-aware for language only; generated skill package content uses `language.artifacts`, while prompts and summaries use `language.ui`
 
 ### `/aif-skill-generator`
 Generates new skills:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -175,6 +175,7 @@ Optional conventions step: use `/aif-rules` to append or refine project-wide axi
 | `/aif-improve` | Refine plan before implementation | No | No (improves existing) |
 | `/aif-loop` | Iterative generation with quality gates and phase-based cycles | No | No (uses `paths.evolution`, default `.ai-factory/evolution/`) |
 | `/aif-reference` | Create knowledge refs from URLs/docs for AI agents | No | No (`paths.references`, default `.ai-factory/references/`) |
+| `/aif-distillation` | Turn books, docs, folders, or URLs into reusable Agent Skills | No | No |
 | `/aif-fix` | Bug fixes, errors, hotfixes | No | Optional (`paths.fix_plan`, default `.ai-factory/FIX_PLAN.md`) |
 | `/aif-rules-check` | Standalone read-only rules compliance gate for staged work, working tree, or a git ref | No | No (reads existing rules and optional plan context) |
 | `/aif-verify` | Post-implementation quality check | No | No (reads existing) |
@@ -195,6 +196,7 @@ Ownership is command-scoped to avoid conflicting writers:
 | `/aif-plan`                               | `paths.plan`, `paths.plans/<branch-or-slug>.md`                                               | `/aif-improve` refines existing plans                     |
 | `/aif-explore`                            | `paths.research` (default: `.ai-factory/RESEARCH.md`)                                         | all other artifacts are read-only in explore mode         |
 | `/aif-reference`                          | `paths.references/*`, `paths.references/INDEX.md`                                             | knowledge references from external sources                |
+| `/aif-distillation`                       | current agent skills directory (`<skills-dir>/<skill-name>/`)                                 | distilled skills from explicit source material            |
 | `/aif-fix`                                | `paths.fix_plan`, `paths.patches/*.md`                                                        | bug-fix learning loop artifacts                           |
 | `/aif-evolve`                             | `paths.evolutions/*.md`, `paths.evolutions/patch-cursor.json`, `.ai-factory/skill-context/*`  | skill-context overrides + evolution logs + cursor state   |
 | `/aif-qa`                                 | `paths.qa/<branch-slug>/change-summary.md`, `test-plan.md`, `test-cases.md`                   | derived branch slug as subdirectory (see aif-qa SKILL.md) |
@@ -342,7 +344,7 @@ Reads patches incrementally using an evolve cursor, analyzes project patterns, a
 
 ---
 
-For full details on all skills including utility commands (`/aif-docs`, `/aif-dockerize`, `/aif-build-automation`, `/aif-ci`, `/aif-commit`, `/aif-rules-check`, `/aif-skill-generator`, `/aif-reference`, `/aif-security-checklist`, `/aif-qa`), see [Core Skills](skills.md).
+For full details on all skills including utility commands (`/aif-docs`, `/aif-dockerize`, `/aif-build-automation`, `/aif-ci`, `/aif-commit`, `/aif-rules-check`, `/aif-skill-generator`, `/aif-distillation`, `/aif-reference`, `/aif-security-checklist`, `/aif-qa`), see [Core Skills](skills.md).
 
 ## Why Spec-Driven?
 

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -214,14 +214,26 @@ fi
 # aif-distillation helper safety regression checks
 DISTILL_HELPER="$ROOT_DIR/skills/aif-distillation/scripts/material-prep.py"
 DISTILL_SRC="$TMPDIR/distillation-source"
-mkdir -p "$DISTILL_SRC/docs/.hidden-dir" "$DISTILL_SRC/docs/secrets" "$DISTILL_SRC/docs/.ai-factory"
+mkdir -p "$DISTILL_SRC/docs/.hidden-dir" "$DISTILL_SRC/docs/secrets" "$DISTILL_SRC/docs/.ai-factory" "$DISTILL_SRC/.ssh"
 cat > "$DISTILL_SRC/docs/guide.md" << 'EOF'
 # Guide
 
 This is normal distillation source material.
 EOF
+cat > "$DISTILL_SRC/.env" << 'EOF'
+SYMLINK_ENV_SECRET=should-not-be-read
+EOF
+cat > "$DISTILL_SRC/.ssh/id_rsa" << 'EOF'
+SYMLINK_SSH_SECRET=should-not-be-read
+EOF
+cat > "$DISTILL_SRC/outside.md" << 'EOF'
+SYMLINK_OUTSIDE_ROOT=should-not-be-read
+EOF
 cat > "$DISTILL_SRC/docs/.hidden.md" << 'EOF'
 hidden markdown source
+EOF
+cat > "$DISTILL_SRC/docs/.env.md" << 'EOF'
+IN_ROOT_HIDDEN_SENSITIVE_SYMLINK_TARGET=can-only-be-read-with-all-opt-ins
 EOF
 cat > "$DISTILL_SRC/docs/.hidden-dir/notes.md" << 'EOF'
 hidden directory source
@@ -236,15 +248,22 @@ cat > "$DISTILL_SRC/docs/.ai-factory/config.yaml" << 'EOF'
 language:
   ui: en
 EOF
+ln -s ../.env "$DISTILL_SRC/docs/symlink-env.md"
+ln -s ../.ssh/id_rsa "$DISTILL_SRC/docs/symlink-ssh.md"
+ln -s ../outside.md "$DISTILL_SRC/docs/symlink-outside.md"
+ln -s ../.ssh "$DISTILL_SRC/docs/symlink-ssh-dir"
+ln -s .env.md "$DISTILL_SRC/docs/symlink-hidden-sensitive.md"
 
 DISTILL_OUT="$TMPDIR/distillation-out"
 if python3 "$DISTILL_HELPER" "$DISTILL_SRC/docs" --out "$DISTILL_OUT" --chunk-chars 200 > "$TMPDIR/distillation-helper.log" 2>&1; then
     if grep -q "guide.md" "$DISTILL_OUT/source-index.md" \
         && ! grep -q ".hidden.md" "$DISTILL_OUT/source-index.md" \
         && ! grep -q ".hidden-dir" "$DISTILL_OUT/source-index.md" \
+        && ! grep -q ".env.md" "$DISTILL_OUT/source-index.md" \
         && ! grep -q "private.key.md" "$DISTILL_OUT/source-index.md" \
         && ! grep -q "secrets" "$DISTILL_OUT/source-index.md" \
-        && ! grep -q ".ai-factory" "$DISTILL_OUT/source-index.md"; then
+        && ! grep -q ".ai-factory" "$DISTILL_OUT/source-index.md" \
+        && ! grep -q "symlink-" "$DISTILL_OUT/source-index.md"; then
         pass "aif-distillation helper filters hidden and sensitive folder sources"
     else
         fail "aif-distillation helper should skip hidden and sensitive folder sources"
@@ -253,6 +272,37 @@ if python3 "$DISTILL_HELPER" "$DISTILL_SRC/docs" --out "$DISTILL_OUT" --chunk-ch
 else
     fail "aif-distillation helper should process normal docs folder"
     cat "$TMPDIR/distillation-helper.log"
+fi
+
+DISTILL_SENSITIVE_ONLY_OUT="$TMPDIR/distillation-sensitive-only-out"
+if python3 "$DISTILL_HELPER" "$DISTILL_SRC/docs" --out "$DISTILL_SENSITIVE_ONLY_OUT" --include-sensitive --chunk-chars 200 > "$TMPDIR/distillation-sensitive-only.log" 2>&1; then
+    if ! grep -q ".env.md" "$DISTILL_SENSITIVE_ONLY_OUT/source-index.md" \
+        && ! grep -q "symlink-hidden-sensitive.md" "$DISTILL_SENSITIVE_ONLY_OUT/source-index.md"; then
+        pass "aif-distillation helper requires --include-hidden for hidden sensitive paths"
+    else
+        fail "aif-distillation helper should require both hidden and sensitive opt-ins for hidden sensitive paths"
+        cat "$DISTILL_SENSITIVE_ONLY_OUT/source-index.md"
+    fi
+else
+    fail "aif-distillation helper should process folder with --include-sensitive"
+    cat "$TMPDIR/distillation-sensitive-only.log"
+fi
+
+DISTILL_SYMLINK_OUT="$TMPDIR/distillation-symlink-out"
+if python3 "$DISTILL_HELPER" "$DISTILL_SRC/docs" --out "$DISTILL_SYMLINK_OUT" --include-symlinks --include-hidden --include-sensitive --chunk-chars 200 > "$TMPDIR/distillation-symlink.log" 2>&1; then
+    if grep -q "symlink-hidden-sensitive.md" "$DISTILL_SYMLINK_OUT/source-index.md" \
+        && ! grep -q "symlink-env.md" "$DISTILL_SYMLINK_OUT/source-index.md" \
+        && ! grep -q "symlink-ssh.md" "$DISTILL_SYMLINK_OUT/source-index.md" \
+        && ! grep -q "symlink-outside.md" "$DISTILL_SYMLINK_OUT/source-index.md" \
+        && ! grep -q "symlink-ssh-dir" "$DISTILL_SYMLINK_OUT/source-index.md"; then
+        pass "aif-distillation helper allows only in-root symlink files with all required opt-ins"
+    else
+        fail "aif-distillation helper symlink opt-in should keep source-root and hidden/sensitive boundaries"
+        cat "$DISTILL_SYMLINK_OUT/source-index.md"
+    fi
+else
+    fail "aif-distillation helper should process folder with explicit symlink opt-ins"
+    cat "$TMPDIR/distillation-symlink.log"
 fi
 
 DISTILL_EXISTING_OUT="$TMPDIR/distillation-existing-out"

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -211,6 +211,133 @@ else
     fail "found $DOTTED_REFS dotted invocations in docs"
 fi
 
+# aif-distillation helper safety regression checks
+DISTILL_HELPER="$ROOT_DIR/skills/aif-distillation/scripts/material-prep.py"
+DISTILL_SRC="$TMPDIR/distillation-source"
+mkdir -p "$DISTILL_SRC/docs/.hidden-dir" "$DISTILL_SRC/docs/secrets" "$DISTILL_SRC/docs/.ai-factory"
+cat > "$DISTILL_SRC/docs/guide.md" << 'EOF'
+# Guide
+
+This is normal distillation source material.
+EOF
+cat > "$DISTILL_SRC/docs/.hidden.md" << 'EOF'
+hidden markdown source
+EOF
+cat > "$DISTILL_SRC/docs/.hidden-dir/notes.md" << 'EOF'
+hidden directory source
+EOF
+cat > "$DISTILL_SRC/docs/private.key.md" << 'EOF'
+private key shaped source
+EOF
+cat > "$DISTILL_SRC/docs/secrets/plan.yaml" << 'EOF'
+token: should-not-be-read
+EOF
+cat > "$DISTILL_SRC/docs/.ai-factory/config.yaml" << 'EOF'
+language:
+  ui: en
+EOF
+
+DISTILL_OUT="$TMPDIR/distillation-out"
+if python3 "$DISTILL_HELPER" "$DISTILL_SRC/docs" --out "$DISTILL_OUT" --chunk-chars 200 > "$TMPDIR/distillation-helper.log" 2>&1; then
+    if grep -q "guide.md" "$DISTILL_OUT/source-index.md" \
+        && ! grep -q ".hidden.md" "$DISTILL_OUT/source-index.md" \
+        && ! grep -q ".hidden-dir" "$DISTILL_OUT/source-index.md" \
+        && ! grep -q "private.key.md" "$DISTILL_OUT/source-index.md" \
+        && ! grep -q "secrets" "$DISTILL_OUT/source-index.md" \
+        && ! grep -q ".ai-factory" "$DISTILL_OUT/source-index.md"; then
+        pass "aif-distillation helper filters hidden and sensitive folder sources"
+    else
+        fail "aif-distillation helper should skip hidden and sensitive folder sources"
+        cat "$DISTILL_OUT/source-index.md"
+    fi
+else
+    fail "aif-distillation helper should process normal docs folder"
+    cat "$TMPDIR/distillation-helper.log"
+fi
+
+DISTILL_EXISTING_OUT="$TMPDIR/distillation-existing-out"
+mkdir -p "$DISTILL_EXISTING_OUT"
+cat > "$DISTILL_EXISTING_OUT/user-notes.md" << 'EOF'
+user-owned file
+EOF
+if python3 "$DISTILL_HELPER" "$DISTILL_SRC/docs/guide.md" --out "$DISTILL_EXISTING_OUT" > "$TMPDIR/distillation-existing-out.log" 2>&1; then
+    fail "aif-distillation helper should refuse non-empty user-owned --out"
+else
+    if [[ -f "$DISTILL_EXISTING_OUT/user-notes.md" ]]; then
+        pass "aif-distillation helper refuses non-empty user-owned --out"
+    else
+        fail "aif-distillation helper must not remove files from refused --out"
+    fi
+fi
+
+DISTILL_TEMP_LOG="$TMPDIR/distillation-temp.log"
+if python3 "$DISTILL_HELPER" "$DISTILL_SRC/docs/guide.md" --chunk-chars 200 > "$DISTILL_TEMP_LOG" 2>&1; then
+    DISTILL_TEMP_OUT=$(sed -n 's/^Output: //p' "$DISTILL_TEMP_LOG" | tail -n 1)
+    if [[ -n "$DISTILL_TEMP_OUT" && -d "$DISTILL_TEMP_OUT" ]]; then
+        if python3 "$DISTILL_HELPER" --cleanup "$DISTILL_TEMP_OUT" > "$TMPDIR/distillation-cleanup.log" 2>&1 && [[ ! -e "$DISTILL_TEMP_OUT" ]]; then
+            pass "aif-distillation helper cleans generated temp output"
+        else
+            fail "aif-distillation helper should clean generated temp output"
+            cat "$TMPDIR/distillation-cleanup.log"
+        fi
+    else
+        fail "aif-distillation helper should print generated temp output path"
+        cat "$DISTILL_TEMP_LOG"
+    fi
+else
+    fail "aif-distillation helper should create temp output"
+    cat "$DISTILL_TEMP_LOG"
+fi
+
+DISTILL_USER_DIR="$TMPDIR/user-aif-distillation"
+mkdir -p "$DISTILL_USER_DIR"
+cat > "$DISTILL_USER_DIR/manifest.json" << 'EOF'
+{}
+EOF
+cat > "$DISTILL_USER_DIR/source-index.md" << 'EOF'
+# Source Index
+EOF
+if python3 "$DISTILL_HELPER" --cleanup "$DISTILL_USER_DIR" > "$TMPDIR/distillation-user-cleanup.log" 2>&1; then
+    fail "aif-distillation helper cleanup should refuse user-owned directory with generic marker names"
+else
+    if [[ -f "$DISTILL_USER_DIR/manifest.json" && -f "$DISTILL_USER_DIR/source-index.md" ]]; then
+        pass "aif-distillation helper cleanup requires dedicated ownership marker"
+    else
+        fail "aif-distillation helper cleanup must not remove user-owned directory"
+    fi
+fi
+
+if [[ -f "$ROOT_DIR/dist/core/installer.js" ]]; then
+    DISTILL_INSTALL_PROJECT="$TMPDIR/distillation-install-smoke"
+    mkdir -p "$DISTILL_INSTALL_PROJECT"
+    AIF_TEST_ROOT_DIR="$ROOT_DIR" AIF_TEST_PROJECT_DIR="$DISTILL_INSTALL_PROJECT" node --input-type=module > "$TMPDIR/distillation-install.log" 2>&1 <<'EOF'
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+const rootDir = process.env.AIF_TEST_ROOT_DIR;
+const projectDir = process.env.AIF_TEST_PROJECT_DIR;
+const moduleUrl = pathToFileURL(path.join(rootDir, 'dist/core/installer.js')).href;
+const { installSkills } = await import(moduleUrl);
+
+await installSkills({ projectDir, skillsDir: '.codex/skills', skills: ['aif-distillation'], agentId: 'codex' });
+await installSkills({ projectDir, skillsDir: '.claude/skills', skills: ['aif-distillation'], agentId: 'claude' });
+EOF
+    if [[ -f "$DISTILL_INSTALL_PROJECT/.codex/skills/aif-distillation/scripts/material-prep.py" ]] \
+        && [[ -f "$DISTILL_INSTALL_PROJECT/.claude/skills/aif-distillation/scripts/material-prep.py" ]] \
+        && grep -q "python3 .codex/skills/aif-distillation/scripts/material-prep.py" "$DISTILL_INSTALL_PROJECT/.codex/skills/aif-distillation/references/LARGE-MATERIALS.md" \
+        && grep -q "python3 .claude/skills/aif-distillation/scripts/material-prep.py" "$DISTILL_INSTALL_PROJECT/.claude/skills/aif-distillation/references/LARGE-MATERIALS.md" \
+        && ! grep -q "~/.codex/skills/aif-distillation/scripts/material-prep.py" "$DISTILL_INSTALL_PROJECT/.codex/skills/aif-distillation/references/LARGE-MATERIALS.md" \
+        && python3 "$DISTILL_INSTALL_PROJECT/.codex/skills/aif-distillation/scripts/material-prep.py" --help > /dev/null \
+        && python3 "$DISTILL_INSTALL_PROJECT/.claude/skills/aif-distillation/scripts/material-prep.py" --help > /dev/null; then
+        pass "aif-distillation installed helper path works for Codex and Claude"
+    else
+        fail "aif-distillation installed helper path should be project-local for Codex and Claude"
+        cat "$TMPDIR/distillation-install.log"
+    fi
+else
+    fail "dist/core/installer.js missing; run npm run build before skill tests"
+fi
+
 # /aif localization contract regression checks
 AIF_SKILL="$ROOT_DIR/skills/aif/SKILL.md"
 AIF_ARCH_SKILL="$ROOT_DIR/skills/aif-architecture/SKILL.md"

--- a/skills/aif-distillation/SKILL.md
+++ b/skills/aif-distillation/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: aif-distillation
+description: >-
+  Distill books, documents, folders, or URLs into compact, practical Agent Skills.
+  Use when source material should become a reusable skill package with a concise
+  SKILL.md plus detailed references and examples.
+argument-hint: "<path|url> [path|url...] [--name <skill-name>] [--update]"
+allowed-tools: Read Write Edit Glob Grep Bash(mkdir *) Bash(ls *) Bash(find *) Bash(wc *) Bash(python3 *) WebFetch WebSearch AskUserQuestion
+disable-model-invocation: false
+metadata:
+  author: ai-factory
+  version: "1.0"
+  category: knowledge-management
+---
+
+# Distillation
+
+Turn source material into a useful skill. The output is not a summary dump: it is an operational skill that captures the best practices, decision rules, workflows, checks, and examples from the material.
+
+## Step 0: Load Config and Skill Context
+
+**FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
+- `language.ui` for prompts, questions, progress updates, and final summaries
+- `language.artifacts` for generated skill package content (`SKILL.md`, `references/`, `examples/`)
+- `language.technical_terms` for translated artifacts; default to `keep` when absent
+
+If config.yaml doesn't exist, use defaults:
+- `language.ui`: `en`
+- `language.artifacts`: same as `language.ui`
+- `language.technical_terms`: `keep`
+
+**Read `.ai-factory/skill-context/aif-distillation/SKILL.md`** - MANDATORY if the file exists.
+
+Treat skill-context rules as project-level overrides for this skill. They apply to all generated skill files, references, examples, source maps, and final reports.
+
+## Inputs
+
+Accept `$ARGUMENTS` as one or more:
+- local files
+- local directories
+- URLs
+- optional `--name <skill-name>`
+- optional `--update` to improve an existing skill instead of creating a duplicate
+
+If the target skill name is missing, derive a concise, general, lowercase-hyphenated name from the material topic, such as `clean-code-style`, `api-design-rules`, or `ddd-modeling`.
+
+Default destination: `{{skills_dir}}/<skill-name>/` for the current agent. Do not save distilled skills into the package `skills/` directory unless the user is explicitly developing AI Factory itself.
+
+## Workflow
+
+1. Prepare sources.
+   - For normal text, markdown, JSON, YAML, HTML, or code files, read directly.
+   - For large folders or PDFs, use `scripts/material-prep.py` to extract and chunk material, then clean temporary extraction artifacts with the helper after the skill is generated.
+   - For URLs, fetch the source and any critical linked pages needed to understand the topic.
+
+2. Distill, do not copy.
+   - Extract transferable principles, workflows, heuristics, checklists, terminology, and failure modes.
+   - Inventory examples from the source, especially code snippets, before deciding the output structure.
+   - Group source examples by topic so coverage can be checked later.
+   - Preserve only short source excerpts when essential. Prefer paraphrase and cite sources.
+   - Convert narrative advice into agent-operable instructions and source examples into original, reusable examples.
+
+3. Design the target skill package.
+   - Keep target `SKILL.md` focused on purpose, triggers, and workflow.
+   - Put detailed knowledge in `references/`.
+   - Put reusable prompts, cases, and transformed examples in `examples/`.
+   - If the material teaches programming with code examples, create or update an examples file with original before/after snippets or compact code patterns. Do not omit code examples only because verbatim copying is inappropriate.
+   - For book-scale or broad code material, cover every major code-facing topic with an adapted example, or state why a topic does not need one. Split examples into multiple files when one file would become a shallow sampler.
+   - Add scripts only when the workflow needs repeatable processing.
+   - Save the package under `{{skills_dir}}/<skill-name>/` using the chosen concise name.
+   - Use resolved `language.artifacts` for generated skill content unless the source material or user explicitly requires another language.
+
+4. Check existing content before writing.
+   - If the target skill already has matching references or examples, update them in place.
+   - Do not create near-duplicate files with different names.
+   - Preserve useful existing material and add only missing or better distilled content.
+
+5. Validate usefulness.
+   - The skill must tell an agent what to do, when to do it, what good output looks like, and what mistakes to avoid.
+   - References must be dense and navigable.
+   - Examples must demonstrate decisions or transformations, not decorative filler.
+   - If source material contained meaningful code snippets or worked examples, the generated skill must include adapted examples. Missing adapted examples is a failure to fix before finishing.
+   - Example coverage must match the source map: major code-facing source areas should point to concrete examples, not just prose references.
+   - Generated skills must include an artifact ownership/config policy section when they write or read project artifacts.
+   - Generated quality-gate skills must follow the `aif-gate-result` contract from `/aif-verify` references.
+
+## Required Supporting Guidance
+
+Read these before generating or updating a distilled skill:
+- `references/DISTILLATION-PROTOCOL.md`
+- `references/OUTPUT-STRUCTURE.md`
+- `references/LARGE-MATERIALS.md`
+
+Use `examples/REQUESTS.md` for invocation patterns.
+
+## Artifact Ownership
+
+- Primary ownership: generated or updated skill packages under `{{skills_dir}}/<skill-name>/`.
+- Read-only context: `.ai-factory/config.yaml`, existing AI Factory context artifacts, and existing skill files except the selected target skill in update mode.
+- Config policy: config-aware for `language.ui`, `language.artifacts`, and `language.technical_terms` only. Do not write `config.yaml`.

--- a/skills/aif-distillation/SKILL.md
+++ b/skills/aif-distillation/SKILL.md
@@ -44,13 +44,19 @@ Accept `$ARGUMENTS` as one or more:
 
 If the target skill name is missing, derive a concise, general, lowercase-hyphenated name from the material topic, such as `clean-code-style`, `api-design-rules`, or `ddd-modeling`.
 
+Before any write, validate the final target skill name:
+- It must match `^[a-z0-9]+(?:-[a-z0-9]+)*$`.
+- Reject empty names, overlong names, `.`, `..`, dots, path separators (`/` or `\`), absolute paths, Windows drive paths, and hidden names.
+- Reject reserved `aif-*` names unless the user explicitly says they are developing AI Factory itself.
+- Resolve the final destination path and confirm it is inside `{{skills_dir}}` before creating or updating files.
+
 Default destination: `{{skills_dir}}/<skill-name>/` for the current agent. Do not save distilled skills into the package `skills/` directory unless the user is explicitly developing AI Factory itself.
 
 ## Workflow
 
 1. Prepare sources.
    - For normal text, markdown, JSON, YAML, HTML, or code files, read directly.
-   - For large folders or PDFs, use `scripts/material-prep.py` to extract and chunk material, then clean temporary extraction artifacts with the helper after the skill is generated.
+   - For large folders or PDFs, use `{{skills_dir}}/aif-distillation/scripts/material-prep.py` to extract and chunk material, then clean temporary extraction artifacts with the helper after the skill is generated.
    - For URLs, fetch the source and any critical linked pages needed to understand the topic.
 
 2. Distill, do not copy.

--- a/skills/aif-distillation/examples/REQUESTS.md
+++ b/skills/aif-distillation/examples/REQUESTS.md
@@ -1,0 +1,69 @@
+# Request Examples
+
+## Create a Skill from One Book
+
+```text
+/aif-distillation ./books/domain-driven-design.pdf --name ddd-practices
+```
+
+Expected output:
+
+- `{{skills_dir}}/ddd-practices/SKILL.md`
+- `{{skills_dir}}/ddd-practices/references/SOURCE-MAP.md`
+- dense references for tactical patterns, modeling workflow, and pitfalls
+- examples for aggregate boundaries and ubiquitous language checks
+
+## Create a Skill from Programming Material
+
+```text
+/aif-distillation ./books/code-quality.pdf --name code-quality-practices
+```
+
+Expected behavior:
+
+- inventory the source's code snippets and worked examples
+- create or update `examples/code-patterns.md` with original, compact code examples
+- add more focused example files when the material spans testing, debugging, refactoring, optimization, review, or integration patterns
+- map major code-facing source areas to concrete examples
+- include before/after snippets when the source teaches transformations
+- link the code examples from the target `SKILL.md`
+- avoid verbatim copying while preserving the programming lesson
+
+## Create a Skill from a Docs Folder
+
+```text
+/aif-distillation ./docs/internal-platform --name platform-operator
+```
+
+Expected behavior:
+
+- read current docs structure
+- save to `{{skills_dir}}/platform-operator/`
+- avoid duplicating existing examples
+- turn operational docs into agent instructions and checks
+
+## Update an Existing Skill
+
+```text
+/aif-distillation ./new-material ./examples --name platform-operator --update
+```
+
+Expected behavior:
+
+- compare existing references and examples
+- update matching files in place
+- add only missing topics
+- report changed files
+
+## Create a Skill from URLs
+
+```text
+/aif-distillation https://example.com/guide https://example.com/reference --name example-api
+```
+
+Expected behavior:
+
+- fetch the pages
+- follow only critical sub-pages
+- source-map all URLs used
+- summarize rules and examples without long quoted passages

--- a/skills/aif-distillation/examples/REQUESTS.md
+++ b/skills/aif-distillation/examples/REQUESTS.md
@@ -41,6 +41,24 @@ Expected behavior:
 - save to `{{skills_dir}}/platform-operator/`
 - avoid duplicating existing examples
 - turn operational docs into agent instructions and checks
+- ignore hidden/config/sensitive files in the source folder unless the user explicitly opts in
+
+## Reject Unsafe Skill Names
+
+```text
+/aif-distillation ./docs --name ../foo
+/aif-distillation ./docs --name aif-review
+/aif-distillation ./docs --name .hidden
+/aif-distillation ./docs --name C:\temp\skill
+/aif-distillation ./docs --name clean/code
+```
+
+Expected behavior:
+
+- reject the request before writing files
+- explain that skill names must match `^[a-z0-9]+(?:-[a-z0-9]+)*$`
+- reserve `aif-*` names unless the user explicitly says they are developing AI Factory itself
+- confirm the resolved target path would stay under `{{skills_dir}}`
 
 ## Update an Existing Skill
 

--- a/skills/aif-distillation/references/DISTILLATION-PROTOCOL.md
+++ b/skills/aif-distillation/references/DISTILLATION-PROTOCOL.md
@@ -1,0 +1,135 @@
+# Distillation Protocol
+
+Use this protocol to convert source material into a reusable Agent Skill.
+
+## 1. Source Intake
+
+Create a source inventory:
+
+| Field | Meaning |
+|-------|---------|
+| Source | URL or local path |
+| Type | book, docs, code, policy, tutorial, paper, notes |
+| Scope | what the material covers |
+| Signal | why it matters for the target skill |
+| Gaps | missing context that may require another source |
+
+For folders, group files by topic before reading deeply. For books, read the table of contents first, then sample each major part before deep extraction.
+
+## 2. Extraction
+
+Extract only material that can drive agent behavior:
+
+- concepts that change decisions
+- named techniques, workflows, and checklists
+- constraints and preconditions
+- quality bars and failure modes
+- examples that teach a reusable pattern
+- code snippets, command examples, and worked examples that demonstrate a reusable decision or transformation
+- terminology that prevents misunderstanding
+
+For code-heavy sources, also build an example inventory:
+
+| Source topic | Example type | Distilled example target |
+|--------------|--------------|--------------------------|
+| <topic> | snippet, before/after, test, debug trace, decision table | <examples file or "skip: reason"> |
+
+This inventory is a planning tool. It does not need to be shipped verbatim, but
+the final examples must visibly cover the major code-facing topics from it.
+
+Skip:
+
+- praise, marketing, introductions, and repetition
+- historical context unless it changes practice
+- examples that do not generalize
+- long verbatim passages
+
+## 3. Synthesis
+
+Transform extracted material into:
+
+- **Rules:** direct instructions an agent can follow
+- **Heuristics:** judgment calls with conditions
+- **Workflow:** ordered steps with inputs and outputs
+- **Checklists:** gates for quality and completeness
+- **Examples:** compact input/output or before/after cases
+- **Pitfalls:** common mistakes and how to detect them
+
+For programming material, do not stop at prose rules. If the source uses code
+examples to teach a practice, create original snippets that preserve the lesson
+without copying the source. Prefer small before/after examples, named code
+patterns, decision tables, and test/refactoring examples that can be applied in
+the target ecosystem. If the source examples are language-specific and the user
+does not request a different language, keep the examples in that ecosystem.
+
+For broad programming books or documentation sets, do not compress example
+coverage into a handful of generic snippets. Cover the major example families:
+abstraction/type design, routine/function shape, data/naming, control flow,
+defensive boundaries, tests, debugging, refactoring, performance, comments, and
+integration when the source covers them. A topic can be skipped only with a
+specific reason, such as "covered by checklist only; no reusable code pattern."
+
+When source material conflicts, keep both positions only if the context differs. Otherwise choose the stronger rule and note the reason in a reference.
+
+## 4. Skill Design
+
+Before writing, answer:
+
+1. What task should trigger this skill?
+2. Who benefits from it?
+3. What should the agent produce?
+4. What source-derived checks define success?
+5. Which details belong in references instead of `SKILL.md`?
+
+The target `SKILL.md` should fit in one screen when possible. It is the router and operating loop, not the knowledge base.
+
+## 5. Existing-File Merge
+
+Before creating any new reference or example:
+
+1. List existing `references/`, `examples/`, `scripts/`, and `templates/`.
+2. Compare intended topic names with existing file names and headings.
+3. Update matching files when the new material fills gaps.
+4. For code-heavy material, look for an existing code examples file such as
+   `code-patterns.md`, `before-after.md`, or a topic-specific examples file and
+   update it before creating a new one.
+5. Create a new file only for a genuinely new topic.
+6. Keep stable filenames so future updates do not fragment the skill.
+
+For book-scale programming material, prefer multiple focused example files over
+one shallow sampler, for example:
+
+- `code-patterns.md` for local construction patterns
+- `testing-debugging.md` for test and debugging examples
+- `refactoring-optimization.md` for safe change and measurement examples
+- `review-examples.md` for review findings and corrections
+
+## 6. Traceability
+
+Every distilled skill should include a source map in a reference:
+
+```markdown
+## Source Map
+
+| Source | Used for |
+|--------|----------|
+| <path-or-url> | <principles, workflow, examples, checks> |
+```
+
+Do not imply that every rule is a direct quote. Distillation is synthesis; source maps explain provenance.
+
+## 7. Quality Gate
+
+Before finishing, check:
+
+- `SKILL.md` explains what and when in frontmatter.
+- `SKILL.md` stays concise and points to references/examples.
+- References contain the dense knowledge.
+- Examples are actionable and source-derived.
+- Code-heavy sources have adapted code snippets in `examples/`; missing snippets
+  are a blocking quality failure.
+- Example coverage maps to the source areas. If references mention many
+  code-facing topics but examples cover only a few, the skill is incomplete.
+- Existing references/examples were updated instead of duplicated.
+- Temporary extraction files were removed.
+- No long copyrighted passages were copied.

--- a/skills/aif-distillation/references/LARGE-MATERIALS.md
+++ b/skills/aif-distillation/references/LARGE-MATERIALS.md
@@ -23,7 +23,8 @@ Optional flags:
 
 - `--out <dir>` writes to a specific output directory. Use only an empty directory or a directory previously created by this helper.
 - `--include-hidden` includes hidden files and folders during directory extraction.
-- `--include-sensitive` includes credential-like paths such as `.env*`, `*token*`, `*credential*`, `.ssh`, `.codex`, `.claude`, `secrets`, and `private`. Treat this as unsafe unless the user explicitly asks for those sources.
+- `--include-sensitive` includes credential-like paths such as `.env*`, `*token*`, `*credential*`, `.ssh`, `.codex`, `.claude`, `secrets`, and `private`. Hidden sensitive paths still require both `--include-hidden` and `--include-sensitive`. Treat this as unsafe unless the user explicitly asks for those sources.
+- `--include-symlinks` includes symlinked files only when the resolved target stays inside the selected folder and passes the same hidden/sensitive checks. Symlinks to hidden sensitive targets require `--include-symlinks --include-hidden --include-sensitive`.
 
 Read `source-index.md` first. Then read only the chunks needed for each section of the target skill.
 

--- a/skills/aif-distillation/references/LARGE-MATERIALS.md
+++ b/skills/aif-distillation/references/LARGE-MATERIALS.md
@@ -7,7 +7,7 @@ Large books, PDFs, and source folders need staged processing. The goal is to fit
 Use:
 
 ```bash
-python3 ~/{{skills_dir}}/aif-distillation/scripts/material-prep.py <source...> --out <temp-dir>
+python3 {{skills_dir}}/aif-distillation/scripts/material-prep.py <source...>
 ```
 
 The script:
@@ -15,8 +15,15 @@ The script:
 - accepts local files, local folders, and URLs
 - converts GitHub `blob` URLs to raw downloads when possible
 - extracts text from PDFs with Python libraries when present, then falls back to `pdftotext`
-- walks directories while skipping common generated/vendor folders
+- walks directories while skipping common generated/vendor folders, hidden paths, and credential-like paths by default
 - writes a `manifest.json`, `source-index.md`, and chunk files
+- writes output to a fresh temporary directory by default
+
+Optional flags:
+
+- `--out <dir>` writes to a specific output directory. Use only an empty directory or a directory previously created by this helper.
+- `--include-hidden` includes hidden files and folders during directory extraction.
+- `--include-sensitive` includes credential-like paths such as `.env*`, `*token*`, `*credential*`, `.ssh`, `.codex`, `.claude`, `secrets`, and `private`. Treat this as unsafe unless the user explicitly asks for those sources.
 
 Read `source-index.md` first. Then read only the chunks needed for each section of the target skill.
 
@@ -45,10 +52,10 @@ Required cleanup:
 Preferred cleanup command:
 
 ```bash
-python3 ~/{{skills_dir}}/aif-distillation/scripts/material-prep.py --cleanup <temp-dir>
+python3 {{skills_dir}}/aif-distillation/scripts/material-prep.py --cleanup <temp-dir>
 ```
 
-The cleanup guard accepts only directories that look like `aif-distillation` extraction output.
+The cleanup guard removes only directories with this helper's dedicated marker file.
 
 If cleanup cannot be completed, report the exact temporary path to the user.
 

--- a/skills/aif-distillation/references/LARGE-MATERIALS.md
+++ b/skills/aif-distillation/references/LARGE-MATERIALS.md
@@ -1,0 +1,63 @@
+# Large Materials
+
+Large books, PDFs, and source folders need staged processing. The goal is to fit the agent context without losing structure.
+
+## Helper Script
+
+Use:
+
+```bash
+python3 ~/{{skills_dir}}/aif-distillation/scripts/material-prep.py <source...> --out <temp-dir>
+```
+
+The script:
+
+- accepts local files, local folders, and URLs
+- converts GitHub `blob` URLs to raw downloads when possible
+- extracts text from PDFs with Python libraries when present, then falls back to `pdftotext`
+- walks directories while skipping common generated/vendor folders
+- writes a `manifest.json`, `source-index.md`, and chunk files
+
+Read `source-index.md` first. Then read only the chunks needed for each section of the target skill.
+
+## Chunking Strategy
+
+Use this order:
+
+1. Table of contents or headings
+2. Introductions to each major part
+3. Checklists, summaries, and examples
+4. Sections that explain core techniques
+5. Edge-case sections and warnings
+
+Do not read chunks linearly if the source is a book. Build a topic map first, then sample intentionally.
+
+## Temporary Artifacts
+
+Extraction artifacts are working files, not project artifacts.
+
+Required cleanup:
+
+- keep only the final generated or updated skill package
+- remove downloaded PDFs and chunk directories after validation
+- do not commit extracted full text
+
+Preferred cleanup command:
+
+```bash
+python3 ~/{{skills_dir}}/aif-distillation/scripts/material-prep.py --cleanup <temp-dir>
+```
+
+The cleanup guard accepts only directories that look like `aif-distillation` extraction output.
+
+If cleanup cannot be completed, report the exact temporary path to the user.
+
+## PDF Fallbacks
+
+If PDF text extraction fails:
+
+1. Try a different extractor if available.
+2. Ask the user for a text/markdown export.
+3. Distill only accessible metadata or pages if the user accepts partial coverage.
+
+Never pretend a full book was processed when only a small sample was readable.

--- a/skills/aif-distillation/references/OUTPUT-STRUCTURE.md
+++ b/skills/aif-distillation/references/OUTPUT-STRUCTURE.md
@@ -39,9 +39,17 @@ Save the distilled skill in the configured skills directory of the currently act
 
 Do not write distilled output into AI Factory's package `skills/` directory unless the task is explicitly to add a built-in AI Factory skill.
 
+Before writing, resolve and canonicalize the final destination path. It must stay inside the resolved `{{skills_dir}}` directory.
+
 ## Naming
 
 Choose a concise, general name that matches the distilled practice, not just the exact source title.
+
+Required validation before any write:
+
+- Accept only names matching `^[a-z0-9]+(?:-[a-z0-9]+)*$`.
+- Reject empty names, overlong names, `.`, `..`, dots, path separators (`/` or `\`), absolute paths, Windows drive paths, and hidden names.
+- Reject reserved `aif-*` names unless the user explicitly says they are developing AI Factory itself.
 
 Good:
 
@@ -56,6 +64,7 @@ Avoid:
 - full book titles
 - version/date suffixes unless required for compatibility
 - vague names like `notes`, `reference`, or `book-summary`
+- reserved or unsafe names like `aif-review`, `../foo`, `.hidden`, `C:\temp\skill`, or `clean/code`
 
 ## SKILL.md Rules
 

--- a/skills/aif-distillation/references/OUTPUT-STRUCTURE.md
+++ b/skills/aif-distillation/references/OUTPUT-STRUCTURE.md
@@ -1,0 +1,140 @@
+# Output Structure
+
+Use this structure for skills created by `aif-distillation`.
+
+## Target Package
+
+```text
+{{skills_dir}}/<skill-name>/
+├── SKILL.md
+├── references/
+│   ├── SOURCE-MAP.md
+│   ├── CORE-PRINCIPLES.md
+│   ├── WORKFLOW.md
+│   └── CHECKLISTS.md
+├── examples/
+│   ├── REQUESTS.md
+│   ├── code-patterns.md   # when source material teaches programming with snippets
+│   ├── testing-debugging.md
+│   ├── refactoring-optimization.md
+│   └── <topic>.md
+└── scripts/
+    └── <helper>    # only when repeatable processing is needed
+```
+
+Use fewer files when the material is small. Do not create empty directories.
+For broad programming material, use enough example files to cover the major
+source topics. Do not create a single `code-patterns.md` that only samples a few
+topics while the references claim broad code coverage.
+
+## Destination
+
+Save the distilled skill in the configured skills directory of the currently active agent:
+
+```text
+{{skills_dir}}/<skill-name>/
+```
+
+`{{skills_dir}}` is resolved by AI Factory for the active agent installation.
+
+Do not write distilled output into AI Factory's package `skills/` directory unless the task is explicitly to add a built-in AI Factory skill.
+
+## Naming
+
+Choose a concise, general name that matches the distilled practice, not just the exact source title.
+
+Good:
+
+- `clean-code-style`
+- `domain-modeling`
+- `api-design-rules`
+- `incident-review`
+
+Avoid:
+
+- author names unless the method is known by that name
+- full book titles
+- version/date suffixes unless required for compatibility
+- vague names like `notes`, `reference`, or `book-summary`
+
+## SKILL.md Rules
+
+`SKILL.md` should contain:
+
+- frontmatter with name, description, and argument hint
+- one-sentence purpose
+- trigger/input detection
+- workflow steps
+- links to the most important references/examples
+- artifact ownership and config policy if relevant
+
+For AI Factory-style skills, also include:
+
+- a Step 0 section that reads `.ai-factory/config.yaml` when the skill uses any config-managed path or language setting
+- a project skill-context read (`.ai-factory/skill-context/<skill-name>/SKILL.md`) when the skill should learn from `/aif-evolve`
+- clear read/write boundaries matching the artifact ownership contract
+- `aif-gate-result` output only for quality-gate skills that need machine-readable orchestration
+
+`SKILL.md` should not contain:
+
+- a book-length summary
+- long source excerpts
+- all examples from the material
+- exhaustive background theory
+
+## Reference File Roles
+
+| File | Purpose |
+|------|---------|
+| `SOURCE-MAP.md` | Sources, coverage, and attribution |
+| `CORE-PRINCIPLES.md` | Dense distilled concepts and rules |
+| `WORKFLOW.md` | Step-by-step operating procedure |
+| `CHECKLISTS.md` | Review gates and quality criteria |
+| `PITFALLS.md` | Common mistakes and detection signals |
+| `GLOSSARY.md` | Terms that affect interpretation |
+
+Prefer stable, obvious filenames over clever names.
+
+## Example File Roles
+
+Examples should show how to apply the distilled knowledge:
+
+- before/after transformations
+- decision tables
+- prompt examples
+- review examples
+- compact case studies
+- source-derived code patterns when licensing allows reuse
+
+Do not copy examples blindly. If a source example is long, convert it into a shorter original example that teaches the same rule.
+
+For programming sources:
+
+- create or update a code examples file when the source uses code to teach practices
+- prefer original before/after snippets, tests, refactoring steps, or table-driven examples
+- keep snippets compact enough to review in one screen
+- label the construction rule or decision each snippet demonstrates
+- adapt examples to the source language unless the user or project context calls for a different target language
+- do not finish with prose-only examples when the source contained meaningful code examples
+- include a short coverage note or table when the source spans many code topics, mapping source areas to example files
+- split examples by topic when a single file would hide gaps
+
+## Update Mode
+
+When `--update` is present:
+
+1. Locate the target skill by `--name` or inferred topic.
+2. Read its existing `SKILL.md`, references, and examples.
+3. Build a gap list from the new material.
+4. Patch matching files.
+5. Add new files only for new topics.
+6. Report what changed and what was intentionally left untouched.
+
+## Ownership and Context-Gate Alignment
+
+When distilling material into an AI Factory workflow or quality skill:
+
+- Owner commands write only their owned artifacts.
+- Non-owner commands treat `.ai-factory/DESCRIPTION.md`, architecture, roadmap, rules, research, plan, patch, QA, security, and evolution artifacts as read-only unless the user explicitly asks otherwise.
+- Commit/review/verify style skills should keep context gates read-only.
+- Use human `WARN` / `ERROR` labels for context findings and reserve final fenced `aif-gate-result` JSON blocks for supported quality gates.

--- a/skills/aif-distillation/scripts/material-prep.py
+++ b/skills/aif-distillation/scripts/material-prep.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Prepare large material for aif-distillation.
+
+The script extracts text from local files, folders, and URLs, then writes
+chunked markdown files plus a manifest. It intentionally leaves the output
+directory for the caller to read and remove after distillation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+TEXT_EXTENSIONS = {
+    ".adoc",
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cs",
+    ".css",
+    ".csv",
+    ".go",
+    ".h",
+    ".hpp",
+    ".html",
+    ".htm",
+    ".java",
+    ".js",
+    ".json",
+    ".jsx",
+    ".kt",
+    ".md",
+    ".php",
+    ".py",
+    ".rb",
+    ".rs",
+    ".rst",
+    ".scss",
+    ".sh",
+    ".sql",
+    ".svelte",
+    ".swift",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".vue",
+    ".xml",
+    ".yaml",
+    ".yml",
+}
+
+PDF_EXTENSIONS = {".pdf"}
+
+SKIP_DIRS = {
+    ".cache",
+    ".git",
+    ".hg",
+    ".next",
+    ".nuxt",
+    ".svn",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "target",
+    "vendor",
+    "__pycache__",
+}
+
+
+@dataclass
+class ExtractedDocument:
+    source: str
+    title: str
+    kind: str
+    text: str
+
+
+def slugify(value: str, fallback: str = "source") -> str:
+    value = value.lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = value.strip("-")
+    return value[:80] or fallback
+
+
+def normalize_text(text: str) -> str:
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = text.replace("\x00", "")
+    text = re.sub(r"[ \t]+\n", "\n", text)
+    text = re.sub(r"\n{4,}", "\n\n\n", text)
+    return text.strip()
+
+
+def read_text_file(path: Path) -> str:
+    data = path.read_bytes()
+    for encoding in ("utf-8", "utf-8-sig", "cp1251", "latin-1"):
+        try:
+            return data.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return data.decode("utf-8", errors="replace")
+
+
+def html_to_text(raw: str) -> str:
+    raw = re.sub(r"(?is)<(script|style).*?>.*?</\1>", " ", raw)
+    raw = re.sub(r"(?s)<[^>]+>", " ", raw)
+    raw = html.unescape(raw)
+    return re.sub(r"[ \t]{2,}", " ", raw)
+
+
+def extract_pdf_with_python(path: Path) -> str | None:
+    try:
+        from pypdf import PdfReader  # type: ignore
+
+        reader = PdfReader(str(path))
+        return "\n\n".join(page.extract_text() or "" for page in reader.pages)
+    except Exception:
+        pass
+
+    try:
+        from PyPDF2 import PdfReader  # type: ignore
+
+        reader = PdfReader(str(path))
+        return "\n\n".join(page.extract_text() or "" for page in reader.pages)
+    except Exception:
+        pass
+
+    try:
+        from pdfminer.high_level import extract_text  # type: ignore
+
+        return extract_text(str(path))
+    except Exception:
+        return None
+
+
+def extract_pdf(path: Path) -> str:
+    text = extract_pdf_with_python(path)
+    if text and text.strip():
+        return text
+
+    pdftotext = shutil.which("pdftotext")
+    if pdftotext:
+        result = subprocess.run(
+            [pdftotext, "-layout", str(path), "-"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout
+
+    raise RuntimeError(
+        f"Could not extract PDF text from {path}. Install pypdf, PyPDF2, pdfminer.six, or pdftotext."
+    )
+
+
+def convert_github_blob_url(url: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.netloc != "github.com":
+        return url
+
+    parts = parsed.path.strip("/").split("/")
+    if len(parts) >= 5 and parts[2] == "blob":
+        owner, repo, _, branch = parts[:4]
+        rest = "/".join(parts[4:])
+        raw_path = "/".join([owner, repo, branch, rest])
+        return urllib.parse.urlunparse(("https", "raw.githubusercontent.com", raw_path, "", "", ""))
+
+    return url
+
+
+def download_url(url: str, work_dir: Path) -> Path:
+    download_url_value = convert_github_blob_url(url)
+    parsed = urllib.parse.urlparse(download_url_value)
+    basename = Path(urllib.parse.unquote(parsed.path)).name or "downloaded-source"
+    if "." not in basename:
+        basename += ".html"
+    target = work_dir / basename
+
+    request = urllib.request.Request(
+        download_url_value,
+        headers={"User-Agent": "ai-factory-aif-distillation/1.0"},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        target.write_bytes(response.read())
+    return target
+
+
+def iter_folder_files(root: Path) -> Iterable[Path]:
+    for current_root, dirs, files in os.walk(root):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        for filename in sorted(files):
+            path = Path(current_root) / filename
+            if path.suffix.lower() in TEXT_EXTENSIONS | PDF_EXTENSIONS:
+                yield path
+
+
+def extract_path(path: Path, label: str | None = None) -> ExtractedDocument:
+    suffix = path.suffix.lower()
+    title = label or path.name
+    if suffix in PDF_EXTENSIONS:
+        text = extract_pdf(path)
+        kind = "pdf"
+    elif suffix in {".html", ".htm"}:
+        text = html_to_text(read_text_file(path))
+        kind = "html"
+    elif suffix in TEXT_EXTENSIONS:
+        text = read_text_file(path)
+        kind = "text"
+    else:
+        raise RuntimeError(f"Unsupported file type: {path}")
+
+    return ExtractedDocument(
+        source=str(path),
+        title=title,
+        kind=kind,
+        text=normalize_text(text),
+    )
+
+
+def extract_source(source: str, work_dir: Path) -> list[ExtractedDocument]:
+    if re.match(r"^https?://", source):
+        downloaded = download_url(source, work_dir)
+        doc = extract_path(downloaded, label=source)
+        doc.source = source
+        return [doc]
+
+    path = Path(source).expanduser().resolve()
+    if path.is_dir():
+        docs = []
+        for file_path in iter_folder_files(path):
+            try:
+                docs.append(extract_path(file_path))
+            except RuntimeError as exc:
+                print(f"warning: {exc}", file=sys.stderr)
+        return docs
+
+    if path.is_file():
+        return [extract_path(path)]
+
+    raise RuntimeError(f"Source not found: {source}")
+
+
+def split_text(text: str, chunk_chars: int) -> list[str]:
+    paragraphs = re.split(r"\n\s*\n", text)
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    for paragraph in paragraphs:
+        paragraph = paragraph.strip()
+        if not paragraph:
+            continue
+        piece_len = len(paragraph) + 2
+        if current and current_len + piece_len > chunk_chars:
+            chunks.append("\n\n".join(current).strip())
+            current = []
+            current_len = 0
+        if piece_len > chunk_chars:
+            for start in range(0, len(paragraph), chunk_chars):
+                chunks.append(paragraph[start : start + chunk_chars].strip())
+            continue
+        current.append(paragraph)
+        current_len += piece_len
+
+    if current:
+        chunks.append("\n\n".join(current).strip())
+
+    return [chunk for chunk in chunks if chunk]
+
+
+def write_chunks(docs: list[ExtractedDocument], out_dir: Path, chunk_chars: int) -> dict:
+    chunks_dir = out_dir / "chunks"
+    chunks_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "chunk_chars": chunk_chars,
+        "documents": [],
+        "chunks": [],
+    }
+
+    chunk_index = 1
+    for doc in docs:
+        doc_hash = hashlib.sha256(doc.text.encode("utf-8", errors="ignore")).hexdigest()[:12]
+        doc_chunks = split_text(doc.text, chunk_chars)
+        doc_record = {
+            "source": doc.source,
+            "title": doc.title,
+            "kind": doc.kind,
+            "characters": len(doc.text),
+            "sha256_12": doc_hash,
+            "chunk_count": len(doc_chunks),
+        }
+        manifest["documents"].append(doc_record)
+
+        for local_index, chunk in enumerate(doc_chunks, start=1):
+            slug = slugify(Path(doc.title).stem or f"source-{chunk_index}")
+            filename = f"{chunk_index:04d}-{slug}.md"
+            chunk_path = chunks_dir / filename
+            chunk_path.write_text(
+                "\n".join(
+                    [
+                        f"# Chunk {chunk_index:04d}",
+                        "",
+                        f"Source: {doc.source}",
+                        f"Document chunk: {local_index}/{len(doc_chunks)}",
+                        f"Characters: {len(chunk)}",
+                        "",
+                        "---",
+                        "",
+                        chunk,
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            manifest["chunks"].append(
+                {
+                    "file": str(chunk_path.relative_to(out_dir)),
+                    "source": doc.source,
+                    "document_chunk": local_index,
+                    "characters": len(chunk),
+                }
+            )
+            chunk_index += 1
+
+    return manifest
+
+
+def write_index(out_dir: Path, manifest: dict) -> None:
+    lines = [
+        "# Source Index",
+        "",
+        "Read this file first, then open only the chunks needed for the target skill.",
+        "",
+        "## Documents",
+        "",
+        "| Source | Kind | Characters | Chunks |",
+        "|--------|------|------------|--------|",
+    ]
+
+    for doc in manifest["documents"]:
+        lines.append(
+            f"| {doc['source']} | {doc['kind']} | {doc['characters']} | {doc['chunk_count']} |"
+        )
+
+    lines.extend(["", "## Chunks", "", "| File | Source | Characters |", "|------|--------|------------|"])
+    for chunk in manifest["chunks"]:
+        lines.append(f"| {chunk['file']} | {chunk['source']} | {chunk['characters']} |")
+
+    (out_dir / "source-index.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def cleanup_output(path_value: str) -> int:
+    target = Path(path_value).expanduser().resolve()
+    if not target.exists():
+        print(f"Already removed: {target}")
+        return 0
+
+    if not target.is_dir():
+        raise RuntimeError(f"Cleanup target is not a directory: {target}")
+
+    parts = set(target.parts)
+    if not any("aif-distillation" in part for part in parts):
+        raise RuntimeError(f"Refusing cleanup because target is not an aif-distillation directory: {target}")
+
+    if not (target / "manifest.json").is_file() or not (target / "source-index.md").is_file():
+        raise RuntimeError(f"Refusing cleanup because extraction markers are missing: {target}")
+
+    shutil.rmtree(target)
+    print(f"Removed: {target}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract and chunk material for aif-distillation.")
+    parser.add_argument("sources", nargs="*", help="Local file, local directory, or URL.")
+    parser.add_argument("--out", help="Output directory. Defaults to a new temp directory.")
+    parser.add_argument("--chunk-chars", type=int, default=18000, help="Approximate max characters per chunk.")
+    parser.add_argument("--cleanup", help="Remove an extraction output directory created by this script.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.cleanup:
+        if args.sources:
+            raise RuntimeError("--cleanup cannot be combined with sources.")
+        return cleanup_output(args.cleanup)
+
+    if not args.sources:
+        raise RuntimeError("At least one source is required unless --cleanup is used.")
+
+    out_dir = Path(args.out).expanduser().resolve() if args.out else Path(tempfile.mkdtemp(prefix="aif-distillation-"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="aif-distillation-download-") as download_dir:
+        docs: list[ExtractedDocument] = []
+        for source in args.sources:
+            docs.extend(extract_source(source, Path(download_dir)))
+
+    docs = [doc for doc in docs if doc.text.strip()]
+    if not docs:
+        raise RuntimeError("No readable text extracted from sources.")
+
+    manifest = write_chunks(docs, out_dir, args.chunk_chars)
+    (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    write_index(out_dir, manifest)
+
+    print(f"Output: {out_dir}")
+    print(f"Documents: {len(manifest['documents'])}")
+    print(f"Chunks: {len(manifest['chunks'])}")
+    print(f"Index: {out_dir / 'source-index.md'}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/skills/aif-distillation/scripts/material-prep.py
+++ b/skills/aif-distillation/scripts/material-prep.py
@@ -9,6 +9,7 @@ directory for the caller to read and remove after distillation.
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import hashlib
 import html
 import json
@@ -20,10 +21,15 @@ import sys
 import tempfile
 import urllib.parse
 import urllib.request
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+
+TOOL_MARKER_FILE = ".aif-distillation-material-prep.json"
+TOOL_MARKER_NAME = "ai-factory/aif-distillation/material-prep"
+TOOL_MARKER_VERSION = "1"
 
 TEXT_EXTENSIONS = {
     ".adoc",
@@ -82,6 +88,45 @@ SKIP_DIRS = {
     "__pycache__",
 }
 
+SENSITIVE_DIR_NAMES = {
+    ".ai-factory",
+    ".aws",
+    ".azure",
+    ".claude",
+    ".codex",
+    ".config",
+    ".cursor",
+    ".gcp",
+    ".github",
+    ".kube",
+    ".ssh",
+    ".vscode",
+    "credential",
+    "credentials",
+    "private",
+    "secret",
+    "secrets",
+}
+
+SENSITIVE_FILE_PATTERNS = (
+    ".env",
+    ".env.*",
+    "*credential*",
+    "*credentials*",
+    "*password*",
+    "*passwd*",
+    "*private*",
+    "*secret*",
+    "*token*",
+    "*.key",
+    "*.key.*",
+    "id_dsa*",
+    "id_ecdsa*",
+    "id_ed25519*",
+    "id_rsa*",
+    "known_hosts",
+)
+
 
 @dataclass
 class ExtractedDocument:
@@ -89,6 +134,19 @@ class ExtractedDocument:
     title: str
     kind: str
     text: str
+
+
+def is_hidden_name(name: str) -> bool:
+    return name.startswith(".") and name not in {".", ".."}
+
+
+def is_sensitive_dir_name(name: str) -> bool:
+    return name.lower() in SENSITIVE_DIR_NAMES
+
+
+def is_sensitive_file_name(name: str) -> bool:
+    lowered = name.lower()
+    return any(fnmatch.fnmatchcase(lowered, pattern) for pattern in SENSITIVE_FILE_PATTERNS)
 
 
 def slugify(value: str, fallback: str = "source") -> str:
@@ -184,6 +242,21 @@ def convert_github_blob_url(url: str) -> str:
     return url
 
 
+def validate_explicit_source_path(path: Path, include_sensitive: bool) -> None:
+    if include_sensitive:
+        return
+
+    sensitive_parts = [
+        part
+        for index, part in enumerate(path.parts)
+        if is_sensitive_dir_name(part) and not (index == 1 and path.parts[0] == "/" and part == "private")
+    ]
+    if sensitive_parts or is_sensitive_file_name(path.name):
+        raise RuntimeError(
+            f"Refusing sensitive-looking source path without --include-sensitive: {path}"
+        )
+
+
 def download_url(url: str, work_dir: Path) -> Path:
     download_url_value = convert_github_blob_url(url)
     parsed = urllib.parse.urlparse(download_url_value)
@@ -201,10 +274,24 @@ def download_url(url: str, work_dir: Path) -> Path:
     return target
 
 
-def iter_folder_files(root: Path) -> Iterable[Path]:
+def iter_folder_files(root: Path, include_hidden: bool = False, include_sensitive: bool = False) -> Iterable[Path]:
     for current_root, dirs, files in os.walk(root):
-        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        kept_dirs = []
+        for dirname in sorted(dirs):
+            if dirname in SKIP_DIRS:
+                continue
+            if not include_hidden and is_hidden_name(dirname):
+                continue
+            if not include_sensitive and is_sensitive_dir_name(dirname):
+                continue
+            kept_dirs.append(dirname)
+        dirs[:] = kept_dirs
+
         for filename in sorted(files):
+            if not include_hidden and is_hidden_name(filename):
+                continue
+            if not include_sensitive and is_sensitive_file_name(filename):
+                continue
             path = Path(current_root) / filename
             if path.suffix.lower() in TEXT_EXTENSIONS | PDF_EXTENSIONS:
                 yield path
@@ -233,7 +320,12 @@ def extract_path(path: Path, label: str | None = None) -> ExtractedDocument:
     )
 
 
-def extract_source(source: str, work_dir: Path) -> list[ExtractedDocument]:
+def extract_source(
+    source: str,
+    work_dir: Path,
+    include_hidden: bool = False,
+    include_sensitive: bool = False,
+) -> list[ExtractedDocument]:
     if re.match(r"^https?://", source):
         downloaded = download_url(source, work_dir)
         doc = extract_path(downloaded, label=source)
@@ -241,9 +333,11 @@ def extract_source(source: str, work_dir: Path) -> list[ExtractedDocument]:
         return [doc]
 
     path = Path(source).expanduser().resolve()
+    validate_explicit_source_path(path, include_sensitive)
+
     if path.is_dir():
         docs = []
-        for file_path in iter_folder_files(path):
+        for file_path in iter_folder_files(path, include_hidden=include_hidden, include_sensitive=include_sensitive):
             try:
                 docs.append(extract_path(file_path))
             except RuntimeError as exc:
@@ -288,6 +382,9 @@ def write_chunks(docs: list[ExtractedDocument], out_dir: Path, chunk_chars: int)
     chunks_dir = out_dir / "chunks"
     chunks_dir.mkdir(parents=True, exist_ok=True)
     manifest = {
+        "tool": TOOL_MARKER_NAME,
+        "tool_version": TOOL_MARKER_VERSION,
+        "marker_file": TOOL_MARKER_FILE,
         "chunk_chars": chunk_chars,
         "documents": [],
         "chunks": [],
@@ -365,6 +462,52 @@ def write_index(out_dir: Path, manifest: dict) -> None:
     (out_dir / "source-index.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+def marker_path(out_dir: Path) -> Path:
+    return out_dir / TOOL_MARKER_FILE
+
+
+def has_valid_marker(out_dir: Path) -> bool:
+    try:
+        marker = json.loads(marker_path(out_dir).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return marker.get("tool") == TOOL_MARKER_NAME and marker.get("version") == TOOL_MARKER_VERSION
+
+
+def write_marker(out_dir: Path) -> None:
+    marker_path(out_dir).write_text(
+        json.dumps(
+            {
+                "tool": TOOL_MARKER_NAME,
+                "version": TOOL_MARKER_VERSION,
+                "run_id": str(uuid.uuid4()),
+                "ownership": "This directory is generated working output and may be removed by material-prep.py --cleanup.",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def prepare_output_dir(out_dir: Path) -> None:
+    if out_dir.exists():
+        if not out_dir.is_dir():
+            raise RuntimeError(f"Output path exists and is not a directory: {out_dir}")
+
+        has_entries = any(out_dir.iterdir())
+        if has_entries and not has_valid_marker(out_dir):
+            raise RuntimeError(
+                f"Refusing to write into non-empty output directory without {TOOL_MARKER_FILE}: {out_dir}"
+            )
+
+        if has_valid_marker(out_dir):
+            shutil.rmtree(out_dir)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    write_marker(out_dir)
+
+
 def cleanup_output(path_value: str) -> int:
     target = Path(path_value).expanduser().resolve()
     if not target.exists():
@@ -374,12 +517,8 @@ def cleanup_output(path_value: str) -> int:
     if not target.is_dir():
         raise RuntimeError(f"Cleanup target is not a directory: {target}")
 
-    parts = set(target.parts)
-    if not any("aif-distillation" in part for part in parts):
-        raise RuntimeError(f"Refusing cleanup because target is not an aif-distillation directory: {target}")
-
-    if not (target / "manifest.json").is_file() or not (target / "source-index.md").is_file():
-        raise RuntimeError(f"Refusing cleanup because extraction markers are missing: {target}")
+    if not has_valid_marker(target):
+        raise RuntimeError(f"Refusing cleanup because {TOOL_MARKER_FILE} is missing or invalid: {target}")
 
     shutil.rmtree(target)
     print(f"Removed: {target}")
@@ -392,6 +531,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--out", help="Output directory. Defaults to a new temp directory.")
     parser.add_argument("--chunk-chars", type=int, default=18000, help="Approximate max characters per chunk.")
     parser.add_argument("--cleanup", help="Remove an extraction output directory created by this script.")
+    parser.add_argument("--include-hidden", action="store_true", help="Include hidden files and directories during folder extraction.")
+    parser.add_argument("--include-sensitive", action="store_true", help="Include credential-like paths. Unsafe; use only for intentional source material.")
     return parser.parse_args()
 
 
@@ -406,12 +547,19 @@ def main() -> int:
         raise RuntimeError("At least one source is required unless --cleanup is used.")
 
     out_dir = Path(args.out).expanduser().resolve() if args.out else Path(tempfile.mkdtemp(prefix="aif-distillation-"))
-    out_dir.mkdir(parents=True, exist_ok=True)
+    prepare_output_dir(out_dir)
 
     with tempfile.TemporaryDirectory(prefix="aif-distillation-download-") as download_dir:
         docs: list[ExtractedDocument] = []
         for source in args.sources:
-            docs.extend(extract_source(source, Path(download_dir)))
+            docs.extend(
+                extract_source(
+                    source,
+                    Path(download_dir),
+                    include_hidden=args.include_hidden,
+                    include_sensitive=args.include_sensitive,
+                )
+            )
 
     docs = [doc for doc in docs if doc.text.strip()]
     if not docs:

--- a/skills/aif-distillation/scripts/material-prep.py
+++ b/skills/aif-distillation/scripts/material-prep.py
@@ -149,6 +149,14 @@ def is_sensitive_file_name(name: str) -> bool:
     return any(fnmatch.fnmatchcase(lowered, pattern) for pattern in SENSITIVE_FILE_PATTERNS)
 
 
+def has_hidden_part(path: Path) -> bool:
+    return any(is_hidden_name(part) for part in path.parts)
+
+
+def has_sensitive_part(path: Path) -> bool:
+    return any(is_sensitive_dir_name(part) for part in path.parts[:-1]) or is_sensitive_file_name(path.name)
+
+
 def slugify(value: str, fallback: str = "source") -> str:
     value = value.lower()
     value = re.sub(r"[^a-z0-9]+", "-", value)
@@ -274,10 +282,57 @@ def download_url(url: str, work_dir: Path) -> Path:
     return target
 
 
-def iter_folder_files(root: Path, include_hidden: bool = False, include_sensitive: bool = False) -> Iterable[Path]:
+def is_allowed_folder_file(
+    path: Path,
+    root: Path,
+    include_hidden: bool = False,
+    include_sensitive: bool = False,
+    include_symlinks: bool = False,
+) -> bool:
+    try:
+        visible_relative = path.relative_to(root)
+    except ValueError:
+        return False
+
+    if not include_hidden and has_hidden_part(visible_relative):
+        return False
+    if not include_sensitive and has_sensitive_part(visible_relative):
+        return False
+
+    if not path.is_symlink():
+        return True
+
+    if not include_symlinks:
+        return False
+
+    resolved = path.resolve()
+    try:
+        resolved_relative = resolved.relative_to(root)
+    except ValueError:
+        return False
+
+    if not resolved.is_file():
+        return False
+    if not include_hidden and has_hidden_part(resolved_relative):
+        return False
+    if not include_sensitive and has_sensitive_part(resolved_relative):
+        return False
+
+    return True
+
+
+def iter_folder_files(
+    root: Path,
+    include_hidden: bool = False,
+    include_sensitive: bool = False,
+    include_symlinks: bool = False,
+) -> Iterable[Path]:
     for current_root, dirs, files in os.walk(root):
         kept_dirs = []
         for dirname in sorted(dirs):
+            dir_path = Path(current_root) / dirname
+            if dir_path.is_symlink():
+                continue
             if dirname in SKIP_DIRS:
                 continue
             if not include_hidden and is_hidden_name(dirname):
@@ -293,7 +348,13 @@ def iter_folder_files(root: Path, include_hidden: bool = False, include_sensitiv
             if not include_sensitive and is_sensitive_file_name(filename):
                 continue
             path = Path(current_root) / filename
-            if path.suffix.lower() in TEXT_EXTENSIONS | PDF_EXTENSIONS:
+            if path.suffix.lower() in TEXT_EXTENSIONS | PDF_EXTENSIONS and is_allowed_folder_file(
+                path,
+                root,
+                include_hidden=include_hidden,
+                include_sensitive=include_sensitive,
+                include_symlinks=include_symlinks,
+            ):
                 yield path
 
 
@@ -325,6 +386,7 @@ def extract_source(
     work_dir: Path,
     include_hidden: bool = False,
     include_sensitive: bool = False,
+    include_symlinks: bool = False,
 ) -> list[ExtractedDocument]:
     if re.match(r"^https?://", source):
         downloaded = download_url(source, work_dir)
@@ -337,7 +399,12 @@ def extract_source(
 
     if path.is_dir():
         docs = []
-        for file_path in iter_folder_files(path, include_hidden=include_hidden, include_sensitive=include_sensitive):
+        for file_path in iter_folder_files(
+            path,
+            include_hidden=include_hidden,
+            include_sensitive=include_sensitive,
+            include_symlinks=include_symlinks,
+        ):
             try:
                 docs.append(extract_path(file_path))
             except RuntimeError as exc:
@@ -533,6 +600,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--cleanup", help="Remove an extraction output directory created by this script.")
     parser.add_argument("--include-hidden", action="store_true", help="Include hidden files and directories during folder extraction.")
     parser.add_argument("--include-sensitive", action="store_true", help="Include credential-like paths. Unsafe; use only for intentional source material.")
+    parser.add_argument("--include-symlinks", action="store_true", help="Include symlinked files that resolve inside the selected folder and pass the same hidden/sensitive filters.")
     return parser.parse_args()
 
 
@@ -558,6 +626,7 @@ def main() -> int:
                     Path(download_dir),
                     include_hidden=args.include_hidden,
                     include_sensitive=args.include_sensitive,
+                    include_symlinks=args.include_symlinks,
                 )
             )
 

--- a/src/cli/wizard/skill-hints.ts
+++ b/src/cli/wizard/skill-hints.ts
@@ -5,6 +5,7 @@ const SKILL_HINTS: Record<string, string> = {
     'aif-build-automation': 'Build file automation',
     'aif-ci': 'CI/CD pipeline setup',
     'aif-commit': 'Conventional commit helper',
+    'aif-distillation': 'Distill sources into skills',
     'aif-dockerize': 'Docker and Compose setup',
     'aif-docs': 'Docs generation and maintenance',
     'aif-evolve': 'Evolve skills from patches',


### PR DESCRIPTION
## Summary

- Add the built-in `aif-distillation` skill for turning books, documents, folders, and URLs into reusable Agent Skills.
- Include distillation protocol, output structure guidance, large-material chunking helper, and request examples.
- Make the skill config-aware for language settings and align generated skills with artifact ownership and context-gate expectations.
- Update docs, AGENTS guidance, and wizard skill hints for the new skill.

## Verification

- `bash skills/aif-skill-generator/scripts/validate.sh skills/aif-distillation`
- `python3 skills/aif-skill-generator/scripts/security-scan.py skills/aif-distillation`
- `npm run build`
- `npm test`