### PR TITLE
fix(aif): clean skills-lock.json on blocked-skill removal (fixes #117)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,6 @@ jobs:
 
       - name: Update smoke tests
         run: npm run test:update
+
+      - name: Cleanup helper tests
+        run: npm run test:cleanup-helper

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:update": "node scripts/run-bash-test.mjs scripts/test-update.sh",
     "test:extension-schema": "node scripts/test-extension-schema.mjs",
     "test:extensions": "node scripts/run-bash-test.mjs scripts/test-extensions.sh",
+    "test:cleanup-helper": "node scripts/run-bash-test.mjs scripts/test-cleanup-helper.sh",
     "lint:unused": "tsc --noEmit --noUnusedLocals --noUnusedParameters",
     "lint:dead": "knip --reporter compact",
     "lint": "npm run lint:unused && npm run lint:dead",

--- a/scripts/test-cleanup-helper.sh
+++ b/scripts/test-cleanup-helper.sh
@@ -100,6 +100,11 @@ write_lock() {
     printf '%s\n' "$2" > "$1/skills-lock.json"
 }
 
+write_config() {
+    # write_config <tmpdir> <json>
+    printf '%s\n' "$2" > "$1/.ai-factory.json"
+}
+
 echo -e "\n${BOLD}=== cleanup-blocked-skill.py regression tests ===${NC}\n"
 
 # ─────────────────────────────────────────────
@@ -360,10 +365,8 @@ rm -rf "$TEST_TMPDIR"
 # that physical directory, not just report leftover.
 #
 # Two sub-cases below probe both contracts on the same fixture:
-#   (a) regression-value: the OLD synthesized-path contract is still
-#       a silent no-op (path didn't exist), so without the new prompt
-#       contract a security-blocked dir would still leak. This proves
-#       why the prompt contract matters — it's a documentation case.
+#   (a) the OLD synthesized-path contract is now rejected instead of
+#       being accepted as an idempotent absent-path cleanup.
 #   (b) the FIX: with the correct path AND the new helper, the
 #       sanitized directory is physically removed and the lock key
 #       is cleared. This is the reviewer's explicit ask.
@@ -376,11 +379,9 @@ write_lock "$TEST_TMPDIR" '{
 mkdir -p "$TEST_TMPDIR/.claude/skills/convex-best-practices"
 echo "# blocked skill" > "$TEST_TMPDIR/.claude/skills/convex-best-practices/SKILL.md"
 
-# (a) OLD broken contract: synthesize path from logical name -> silent no-op.
-#     Fake npx returns 1 (simulates the upstream no-match case). With the
-#     bogus unsanitized installed-path the helper sees "absent" and exits 0
-#     (idempotent on missing target), proving that without the new prompt
-#     contract the REAL sanitized directory would be left untouched.
+# (a) OLD broken contract: synthesize path from logical name. The helper
+#     should now reject this absent wrong path by identity before it can
+#     silently claim cleanup of the real sanitized directory.
 if FAKE_NPX_EXIT=1 "$PYTHON" "$HELPER" \
         --skill "Convex Best Practices" \
         --root "$TEST_TMPDIR" \
@@ -390,12 +391,17 @@ if FAKE_NPX_EXIT=1 "$PYTHON" "$HELPER" \
 else
     OLD_CONTRACT_EXIT=$?
 fi
-# Verify: sanitized dir IS still on disk (the silent-leak hazard).
-if [[ ! -d "$TEST_TMPDIR/.claude/skills/convex-best-practices" ]]; then
-    fail "sanitized leftover (a)" "old-contract path removed the wrong dir"
+# Verify: sanitized dir IS still on disk, and the old synthesized path
+# is no longer accepted as a clean no-op.
+if [[ $OLD_CONTRACT_EXIT -eq 0 ]] || \
+   [[ ! -d "$TEST_TMPDIR/.claude/skills/convex-best-practices" ]] || \
+   ! grep -q 'identity mismatch' "$TEST_TMPDIR/out-a"; then
+    fail "sanitized leftover (a)" \
+         "old-contract path was not rejected as expected; exit=$OLD_CONTRACT_EXIT out=$(cat "$TEST_TMPDIR/out-a")"
 fi
 
-# Re-add the lock entry that path (a) removed, so path (b) has work to do.
+# Re-add the lock entry defensively so path (b) has work to do if a
+# future refactor moves validation later.
 write_lock "$TEST_TMPDIR" '{
   "version": 1,
   "skills": {"Convex Best Practices": {"source": "x/y"}}
@@ -423,11 +429,11 @@ if [[ ! -e "$TEST_TMPDIR/.claude/skills/convex-best-practices" ]]; then
     DIR_GONE=1
 fi
 
-if [[ $OLD_CONTRACT_EXIT -eq 0 \
+if [[ $OLD_CONTRACT_EXIT -ne 0 \
    && $NEW_CONTRACT_EXIT -eq 0 \
    && $LOCK_CLEAR -eq 1 \
    && $DIR_GONE -eq 1 ]]; then
-    pass "sanitized leftover: old-contract silent no-op + new-contract removes both"
+    pass "sanitized leftover: old-contract rejected + new-contract removes both"
 else
     fail "sanitized leftover" \
          "old=$OLD_CONTRACT_EXIT new=$NEW_CONTRACT_EXIT lock_clear=$LOCK_CLEAR dir_gone=$DIR_GONE; out-a=$(cat "$TEST_TMPDIR/out-a"); out-b=$(cat "$TEST_TMPDIR/out-b")"
@@ -516,8 +522,8 @@ fi
 rm -rf "$ESCAPE_DIR"
 rm -rf "$TEST_TMPDIR"
 
-# N3: --installed-path inside --root but NOT under any `skills/` segment
-# → reject (check #6).
+# N3: --installed-path inside --root but NOT under a known agent skills
+# directory → reject.
 fresh_tmp
 write_lock "$TEST_TMPDIR" '{
   "version": 1,
@@ -530,7 +536,7 @@ if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
     fail "N3: not under skills/" "helper exited 0 despite non-skills location"
 else
     if [[ -e "$TEST_TMPDIR/random-dir/SKILL.md" ]] && \
-       grep -q "no 'skills' segment" "$TEST_TMPDIR/out"; then
+       grep -Eq "known project agent skills directory|no 'skills' segment" "$TEST_TMPDIR/out"; then
         pass "N3: non-skills location rejected (dir preserved)"
     else
         fail "N3: not under skills/" \
@@ -661,14 +667,171 @@ if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
    --installed-path . > "$TEST_TMPDIR/out" 2>&1; then
     fail "N8: installed-path == root" "helper exited 0 despite installed-path == root"
 else
-    # Both #5b "equals --root" and #6 "no 'skills' segment" are valid
-    # rejection reasons (resolved root has no 'skills' part). Accept either.
+    # Both #5b "equals --root" and later path-boundary checks are valid
+    # rejection reasons. Accept either so ordering can stay defensive.
     if [[ -d "$TEST_TMPDIR" ]] && [[ -f "$TEST_TMPDIR/SKILL.md" ]] && \
-       grep -Eq "equals --root|no 'skills' segment" "$TEST_TMPDIR/out"; then
+       grep -Eq "equals --root|known project agent skills directory|no 'skills' segment" "$TEST_TMPDIR/out"; then
         pass "N8: installed-path == root rejected (root preserved)"
     else
         fail "N8: installed-path == root" \
              "root tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+    fi
+fi
+rm -rf "$TEST_TMPDIR"
+
+# N9: root-level source skill path → reject and preserve.
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"source-skill": {"source": "x/y"}}
+}'
+mkdir -p "$TEST_TMPDIR/skills/source-skill"
+printf '%s\n' '---' 'name: source-skill' '---' '# source' > "$TEST_TMPDIR/skills/source-skill/SKILL.md"
+if "$PYTHON" "$HELPER" --skill source-skill --root "$TEST_TMPDIR" \
+   --installed-path skills/source-skill > "$TEST_TMPDIR/out" 2>&1; then
+    fail "N9: root source skills/ rejected" "helper exited 0 despite source path"
+else
+    if [[ -f "$TEST_TMPDIR/skills/source-skill/SKILL.md" ]] && \
+       grep -q "known project agent skills directory" "$TEST_TMPDIR/out"; then
+        pass "N9: root source skills/ rejected (dir preserved)"
+    else
+        fail "N9: root source skills/" \
+             "dir tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+    fi
+fi
+rm -rf "$TEST_TMPDIR"
+
+# N10: docs/skills source path → reject and preserve.
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"source-skill": {"source": "x/y"}}
+}'
+mkdir -p "$TEST_TMPDIR/docs/skills/source-skill"
+printf '%s\n' '---' 'name: source-skill' '---' '# docs source' > "$TEST_TMPDIR/docs/skills/source-skill/SKILL.md"
+if "$PYTHON" "$HELPER" --skill source-skill --root "$TEST_TMPDIR" \
+   --installed-path docs/skills/source-skill > "$TEST_TMPDIR/out" 2>&1; then
+    fail "N10: docs/skills source rejected" "helper exited 0 despite docs path"
+else
+    if [[ -f "$TEST_TMPDIR/docs/skills/source-skill/SKILL.md" ]] && \
+       grep -q "known project agent skills directory" "$TEST_TMPDIR/out"; then
+        pass "N10: docs/skills source rejected (dir preserved)"
+    else
+        fail "N10: docs/skills source" \
+             "dir tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+    fi
+fi
+rm -rf "$TEST_TMPDIR"
+
+# N11: canonical .claude/skills/foo path still works.
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+mkdir -p "$TEST_TMPDIR/.claude/skills/foo"
+printf '%s\n' '---' 'name: foo' '---' '# foo' > "$TEST_TMPDIR/.claude/skills/foo/SKILL.md"
+if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+   --installed-path .claude/skills/foo > "$TEST_TMPDIR/out" 2>&1; then
+    if [[ ! -e "$TEST_TMPDIR/.claude/skills/foo" ]]; then
+        pass "N11: canonical .claude skill accepted and removed"
+    else
+        fail "N11: canonical .claude skill" \
+             "helper exited 0 but dir remains: $(cat "$TEST_TMPDIR/out")"
+    fi
+else
+    fail "N11: canonical .claude skill" "helper exited non-zero: $(cat "$TEST_TMPDIR/out")"
+fi
+rm -rf "$TEST_TMPDIR"
+
+# N12: mismatched --skill and installed basename/frontmatter → reject.
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+mkdir -p "$TEST_TMPDIR/.claude/skills/bar"
+printf '%s\n' '---' 'name: bar' '---' '# bar' > "$TEST_TMPDIR/.claude/skills/bar/SKILL.md"
+if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+   --installed-path .claude/skills/bar > "$TEST_TMPDIR/out" 2>&1; then
+    fail "N12: identity mismatch rejected" "helper exited 0 despite mismatched path"
+else
+    if [[ -f "$TEST_TMPDIR/.claude/skills/bar/SKILL.md" ]] && \
+       grep -q "identity mismatch" "$TEST_TMPDIR/out"; then
+        pass "N12: identity mismatch rejected (dir preserved)"
+    else
+        fail "N12: identity mismatch" \
+             "dir tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+    fi
+fi
+rm -rf "$TEST_TMPDIR"
+
+# N13: .cache/skills/foo is rejected when not an explicit agent skillsDir.
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+mkdir -p "$TEST_TMPDIR/.cache/skills/foo"
+printf '%s\n' '---' 'name: foo' '---' '# cache' > "$TEST_TMPDIR/.cache/skills/foo/SKILL.md"
+if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+   --installed-path .cache/skills/foo > "$TEST_TMPDIR/out" 2>&1; then
+    fail "N13: unregistered .cache skills root rejected" "helper exited 0 despite unregistered root"
+else
+    if [[ -f "$TEST_TMPDIR/.cache/skills/foo/SKILL.md" ]] && \
+       grep -q "known project agent skills directory" "$TEST_TMPDIR/out"; then
+        pass "N13: unregistered .cache skills root rejected (dir preserved)"
+    else
+        fail "N13: unregistered .cache skills root" \
+             "dir tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+    fi
+fi
+rm -rf "$TEST_TMPDIR"
+
+# N14: extension runtime skillsDir from .ai-factory.json is accepted.
+fresh_tmp
+write_config "$TEST_TMPDIR" '{
+  "agents": [
+    {"id": "my-agent", "skillsDir": ".my-agent/skills"}
+  ]
+}'
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+mkdir -p "$TEST_TMPDIR/.my-agent/skills/foo"
+printf '%s\n' '---' 'name: foo' '---' '# extension runtime' > "$TEST_TMPDIR/.my-agent/skills/foo/SKILL.md"
+if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+   --installed-path .my-agent/skills/foo > "$TEST_TMPDIR/out" 2>&1; then
+    if [[ ! -e "$TEST_TMPDIR/.my-agent/skills/foo" ]]; then
+        pass "N14: extension runtime skillsDir accepted and removed"
+    else
+        fail "N14: extension runtime skillsDir" \
+             "helper exited 0 but dir remains: $(cat "$TEST_TMPDIR/out")"
+    fi
+else
+    fail "N14: extension runtime skillsDir" "helper exited non-zero: $(cat "$TEST_TMPDIR/out")"
+fi
+rm -rf "$TEST_TMPDIR"
+
+# N15: dry-run still validates unsafe installed paths and preserves them.
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"source-skill": {"source": "x/y"}}
+}'
+mkdir -p "$TEST_TMPDIR/skills/source-skill"
+printf '%s\n' '---' 'name: source-skill' '---' '# source' > "$TEST_TMPDIR/skills/source-skill/SKILL.md"
+if "$PYTHON" "$HELPER" --skill source-skill --root "$TEST_TMPDIR" \
+   --installed-path skills/source-skill --dry-run > "$TEST_TMPDIR/out" 2>&1; then
+    fail "N15: dry-run validates source path" "helper exited 0 despite unsafe dry-run path"
+else
+    if [[ -f "$TEST_TMPDIR/skills/source-skill/SKILL.md" ]] && \
+       grep -q "known project agent skills directory" "$TEST_TMPDIR/out"; then
+        pass "N15: dry-run validates source path (dir preserved)"
+    else
+        fail "N15: dry-run validates source path" \
+             "dir tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
     fi
 fi
 rm -rf "$TEST_TMPDIR"

--- a/scripts/test-cleanup-helper.sh
+++ b/scripts/test-cleanup-helper.sh
@@ -50,8 +50,11 @@ cat > "$FAKE_BIN/npx" << 'EOF'
 #!/bin/sh
 # Fake npx for cleanup-helper tests:
 # - logs each argv element on its own line into $NPX_ARGV_LOG
+# - logs the current working directory (as its basename) so tests can
+#   assert that the helper passes cwd=<root> to subprocess.run
 # - returns 0 unconditionally
 printf '%s\n' "$@" >> "${NPX_ARGV_LOG:-/dev/null}"
+echo "cwd_basename=$(basename "$(pwd)")" >> "${NPX_ARGV_LOG:-/dev/null}"
 exit 0
 EOF
 chmod +x "$FAKE_BIN/npx"
@@ -237,6 +240,37 @@ else
     else
         fail "missing npx fails fast" "helper failed but mutated the lock anyway"
     fi
+fi
+rm -rf "$TEST_TMPDIR"
+
+# ─────────────────────────────────────────────
+# Test 7: subprocess cwd matches --root (P2, second-review regression)
+# ─────────────────────────────────────────────
+# Ensures `npx skills remove` runs with cwd=<root> so the upstream CLI
+# inspects the same project's skills-lock.json that this helper patches.
+# Without cwd propagation, --root could patch one project while npx
+# acts on a different one.
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"some-skill": {"source": "x/y"}}
+}'
+if "$PYTHON" "$HELPER" --skill some-skill --root "$TEST_TMPDIR" > "$TEST_TMPDIR/out" 2>&1; then
+    if [[ $IS_WINDOWS -eq 1 ]]; then
+        # Fake npx doesn't execute on Windows (PATHEXT — see top of file).
+        # The cwd-propagation contract is still covered by code inspection
+        # and Linux CI; document the platform gap.
+        pass "subprocess cwd matches --root (skipped on Windows)"
+    else
+        expected_basename=$(basename "$TEST_TMPDIR")
+        if grep -q "cwd_basename=${expected_basename}" "$NPX_ARGV_LOG"; then
+            pass "subprocess cwd matches --root"
+        else
+            fail "subprocess cwd matches --root" "subprocess cwd != --root. log: $(cat "$NPX_ARGV_LOG")"
+        fi
+    fi
+else
+    fail "subprocess cwd matches --root" "helper exited non-zero: $(cat "$TEST_TMPDIR/out")"
 fi
 rm -rf "$TEST_TMPDIR"
 

--- a/scripts/test-cleanup-helper.sh
+++ b/scripts/test-cleanup-helper.sh
@@ -346,6 +346,100 @@ else
 fi
 rm -rf "$TEST_TMPDIR"
 
+# ─────────────────────────────────────────────
+# Test 11: sanitized-leftover regression (P1 from 3rd review round)
+# ─────────────────────────────────────────────
+# Upstream `skills` sanitizes the on-disk directory name:
+#   "Convex Best Practices" -> "convex-best-practices"
+# An older prompt contract synthesized --installed-path as
+# `{{skills_dir}}/<name>`, i.e. ".claude/skills/Convex Best Practices",
+# which points at a path that NEVER existed. With cli_failed=True from
+# a partial npx failure, the helper would then see "directory absent",
+# downgrade to exit 0, and silently leave the REAL blocked directory
+# (sanitized path) on disk.
+#
+# This test exercises both contracts on the same fixture and proves
+# the new "pass the actual scanned path" contract is the only one
+# that surfaces the leftover.
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"Convex Best Practices": {"source": "x/y"}}
+}'
+# Real leftover at the SANITIZED upstream path:
+mkdir -p "$TEST_TMPDIR/.claude/skills/convex-best-practices"
+echo "leftover" > "$TEST_TMPDIR/.claude/skills/convex-best-practices/SKILL.md"
+
+# (a) OLD broken contract: synthesize path from logical name -> FALSE PASS.
+#     Fake npx returns 1 to engage the downgrade path. With the bogus
+#     unsanitized installed-path the helper sees "absent" and exits 0,
+#     proving the silent-leak hazard the new contract avoids.
+if FAKE_NPX_EXIT=1 "$PYTHON" "$HELPER" \
+        --skill "Convex Best Practices" \
+        --root "$TEST_TMPDIR" \
+        --installed-path ".claude/skills/Convex Best Practices" \
+        > "$TEST_TMPDIR/out-a" 2>&1; then
+    OLD_CONTRACT_EXIT=0
+else
+    OLD_CONTRACT_EXIT=$?
+fi
+
+# Re-add the lock entry that path (a) removed, so path (b) has work to do.
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"Convex Best Practices": {"source": "x/y"}}
+}'
+
+# (b) NEW correct contract: pass the actual sanitized scanned path.
+#     The helper must see leftover and exit 1.
+if FAKE_NPX_EXIT=1 "$PYTHON" "$HELPER" \
+        --skill "Convex Best Practices" \
+        --root "$TEST_TMPDIR" \
+        --installed-path ".claude/skills/convex-best-practices" \
+        > "$TEST_TMPDIR/out-b" 2>&1; then
+    NEW_CONTRACT_EXIT=0
+else
+    NEW_CONTRACT_EXIT=$?
+fi
+
+if [[ $OLD_CONTRACT_EXIT -eq 0 && $NEW_CONTRACT_EXIT -ne 0 ]] \
+   && grep -q 'still present' "$TEST_TMPDIR/out-b"; then
+    pass "sanitized leftover: old contract false-passes, new contract exits 1"
+else
+    fail "sanitized leftover" "old=$OLD_CONTRACT_EXIT new=$NEW_CONTRACT_EXIT; out-a=$(cat "$TEST_TMPDIR/out-a"); out-b=$(cat "$TEST_TMPDIR/out-b")"
+fi
+rm -rf "$TEST_TMPDIR"
+
+# ─────────────────────────────────────────────
+# Test 12: prompt-contract grep — skill docs must NOT synthesize the
+# installed path from {{skills_dir}}/<name>; they must reuse the same
+# path token passed to security-scan.py.
+# ─────────────────────────────────────────────
+PROMPT_FILES=(
+    "$ROOT_DIR/skills/aif/SKILL.md"
+    "$ROOT_DIR/skills/aif-skill-generator/SKILL.md"
+    "$ROOT_DIR/skills/aif-skill-generator/references/SECURITY-SCANNING.md"
+)
+BAD_LINES=()
+for f in "${PROMPT_FILES[@]}"; do
+    if [[ ! -f "$f" ]]; then
+        continue
+    fi
+    # Regression = the synthesized template appears IMMEDIATELY after
+    # --installed-path (i.e. it is the VALUE of the flag, not part of
+    # surrounding explanatory text that warns against the pattern).
+    while IFS= read -r line; do
+        if printf '%s' "$line" | grep -Eq -- '--installed-path[[:space:]]+\{\{skills_dir\}\}/<'; then
+            BAD_LINES+=("$f: $line")
+        fi
+    done < "$f"
+done
+if [[ ${#BAD_LINES[@]} -eq 0 ]]; then
+    pass "prompt-contract: no skill doc synthesizes --installed-path from {{skills_dir}}/<name>"
+else
+    fail "prompt-contract regression" "$(printf '%s\n' "${BAD_LINES[@]}")"
+fi
+
 # Restore PATH for any post-suite work
 export PATH="$ORIGINAL_PATH"
 if [[ -n "$ORIGINAL_PATHEXT" ]]; then

--- a/scripts/test-cleanup-helper.sh
+++ b/scripts/test-cleanup-helper.sh
@@ -108,7 +108,7 @@ write_config() {
 echo -e "\n${BOLD}=== cleanup-blocked-skill.py regression tests ===${NC}\n"
 
 # ─────────────────────────────────────────────
-# Test 1: removes target, preserves siblings (#117 regression)
+# Test 1: removes target lock entry, preserves siblings
 # ─────────────────────────────────────────────
 fresh_tmp
 write_lock "$TEST_TMPDIR" '{
@@ -131,7 +131,7 @@ fi
 rm -rf "$TEST_TMPDIR"
 
 # ─────────────────────────────────────────────
-# Test 2: skill name with spaces (P1.1 regression)
+# Test 2: skill name with spaces
 # ─────────────────────────────────────────────
 fresh_tmp
 write_lock "$TEST_TMPDIR" '{
@@ -151,9 +151,9 @@ if "$PYTHON" "$HELPER" --skill "Convex Best Practices" --root "$TEST_TMPDIR" > "
     if [[ $LOCK_OK -eq 0 ]]; then
         fail "skill name with spaces" "lock content unexpected: $(cat "$TEST_TMPDIR/skills-lock.json")"
     elif [[ $IS_WINDOWS -eq 1 ]]; then
-        # Lock-state proves the P1.1 fix (validation + patch_lock both
-        # accepted the spaced name); argv-passing assertion is unreliable
-        # on Windows (see PATHEXT note above).
+        # Lock-state proves validation + patch_lock accepted the spaced
+        # name; argv-passing assertion is unreliable on Windows (see
+        # PATHEXT note above).
         pass "skill name with spaces (lock; argv check skipped on Windows)"
     else
         # Fake npx logged each argv on its own line — verify the full
@@ -231,7 +231,7 @@ fi
 rm -rf "$TEST_TMPDIR"
 
 # ─────────────────────────────────────────────
-# Test 6: missing npx → non-zero exit, lock unchanged (P2.1 regression)
+# Test 6: missing npx → non-zero exit, lock unchanged
 # ─────────────────────────────────────────────
 fresh_tmp
 write_lock "$TEST_TMPDIR" '{"version": 1, "skills": {"foo": {"source": "a/b"}}}'
@@ -253,7 +253,7 @@ fi
 rm -rf "$TEST_TMPDIR"
 
 # ─────────────────────────────────────────────
-# Test 7: subprocess cwd matches --root (P2, second-review regression)
+# Test 7: subprocess cwd matches --root
 # ─────────────────────────────────────────────
 # Ensures `npx skills remove` runs with cwd=<root> so the upstream CLI
 # inspects the same project's skills-lock.json that this helper patches.
@@ -306,10 +306,10 @@ rm -rf "$TEST_TMPDIR"
 # ─────────────────────────────────────────────
 # Test 9: --installed-path leftover under skills/ → exit 0 + dir gone
 # ─────────────────────────────────────────────
-# Round-4 P1: the helper itself must physically remove the leftover
-# directory (variant B), not just report it. Fixture is placed at the
-# canonical install location (.claude/skills/<name>/SKILL.md) so all
-# safety checks pass and safe_remove_installed proceeds.
+# The helper must physically remove the leftover directory, not just
+# report it. Fixture is placed at the canonical install location
+# (.claude/skills/<name>/SKILL.md) so all safety checks pass and
+# safe_remove_installed proceeds.
 fresh_tmp
 write_lock "$TEST_TMPDIR" '{
   "version": 1,
@@ -352,7 +352,7 @@ fi
 rm -rf "$TEST_TMPDIR"
 
 # ─────────────────────────────────────────────
-# Test 11: sanitized-leftover end-to-end (P1 from review rounds 3 & 4)
+# Test 11: sanitized-leftover end-to-end
 # ─────────────────────────────────────────────
 # Upstream `skills` sanitizes the on-disk directory name:
 #   "Convex Best Practices" -> "convex-best-practices"
@@ -360,16 +360,12 @@ rm -rf "$TEST_TMPDIR"
 # apply sanitizeName() to the argument before matching, so it never
 # touches the sanitized directory; it exits 0 silently.
 #
-# Round 3 P1 fixed the prompt contract so agents pass the actual
-# scanned path. Round 4 P1 fixes the helper itself: it must remove
-# that physical directory, not just report leftover.
-#
-# Two sub-cases below probe both contracts on the same fixture:
-#   (a) the OLD synthesized-path contract is now rejected instead of
-#       being accepted as an idempotent absent-path cleanup.
-#   (b) the FIX: with the correct path AND the new helper, the
-#       sanitized directory is physically removed and the lock key
-#       is cleared. This is the reviewer's explicit ask.
+# Two sub-cases probe both contracts on the same fixture:
+#   (a) a synthesized path (logical name as-is) is rejected by the
+#       identity check rather than accepted as an idempotent no-op.
+#   (b) the correct sanitized scanned path: helper physically removes
+#       the directory AND clears the lock entry, even though upstream
+#       `npx skills remove` was a no-op.
 fresh_tmp
 write_lock "$TEST_TMPDIR" '{
   "version": 1,
@@ -379,9 +375,9 @@ write_lock "$TEST_TMPDIR" '{
 mkdir -p "$TEST_TMPDIR/.claude/skills/convex-best-practices"
 echo "# blocked skill" > "$TEST_TMPDIR/.claude/skills/convex-best-practices/SKILL.md"
 
-# (a) OLD broken contract: synthesize path from logical name. The helper
-#     should now reject this absent wrong path by identity before it can
-#     silently claim cleanup of the real sanitized directory.
+# (a) Synthesized path from logical name. Helper must reject this
+#     absent wrong path by identity rather than silently claim cleanup
+#     of the real sanitized directory.
 if FAKE_NPX_EXIT=1 "$PYTHON" "$HELPER" \
         --skill "Convex Best Practices" \
         --root "$TEST_TMPDIR" \
@@ -391,8 +387,8 @@ if FAKE_NPX_EXIT=1 "$PYTHON" "$HELPER" \
 else
     OLD_CONTRACT_EXIT=$?
 fi
-# Verify: sanitized dir IS still on disk, and the old synthesized path
-# is no longer accepted as a clean no-op.
+# Verify: sanitized dir IS still on disk, and the synthesized path
+# is rejected (not treated as a clean no-op).
 if [[ $OLD_CONTRACT_EXIT -eq 0 ]] || \
    [[ ! -d "$TEST_TMPDIR/.claude/skills/convex-best-practices" ]] || \
    ! grep -q 'identity mismatch' "$TEST_TMPDIR/out-a"; then
@@ -400,16 +396,15 @@ if [[ $OLD_CONTRACT_EXIT -eq 0 ]] || \
          "old-contract path was not rejected as expected; exit=$OLD_CONTRACT_EXIT out=$(cat "$TEST_TMPDIR/out-a")"
 fi
 
-# Re-add the lock entry defensively so path (b) has work to do if a
-# future refactor moves validation later.
+# Re-add the lock entry so path (b) has work to do.
 write_lock "$TEST_TMPDIR" '{
   "version": 1,
   "skills": {"Convex Best Practices": {"source": "x/y"}}
 }'
 
-# (b) NEW correct contract + new helper: pass the actual sanitized scanned
-#     path. The helper must physically remove the directory AND clear the
-#     lock entry, even though upstream `npx skills remove` was a no-op.
+# (b) Correct contract: pass the actual sanitized scanned path. Helper
+#     physically removes the directory AND clears the lock entry, even
+#     though upstream `npx skills remove` was a no-op.
 if FAKE_NPX_EXIT=1 "$PYTHON" "$HELPER" \
         --skill "Convex Best Practices" \
         --root "$TEST_TMPDIR" \
@@ -433,7 +428,7 @@ if [[ $OLD_CONTRACT_EXIT -ne 0 \
    && $NEW_CONTRACT_EXIT -eq 0 \
    && $LOCK_CLEAR -eq 1 \
    && $DIR_GONE -eq 1 ]]; then
-    pass "sanitized leftover: old-contract rejected + new-contract removes both"
+    pass "sanitized leftover: synthesized path rejected + correct path removes both"
 else
     fail "sanitized leftover" \
          "old=$OLD_CONTRACT_EXIT new=$NEW_CONTRACT_EXIT lock_clear=$LOCK_CLEAR dir_gone=$DIR_GONE; out-a=$(cat "$TEST_TMPDIR/out-a"); out-b=$(cat "$TEST_TMPDIR/out-b")"
@@ -441,7 +436,7 @@ fi
 rm -rf "$TEST_TMPDIR"
 
 # ─────────────────────────────────────────────
-# Tests N1–N8: safe_remove_installed safety checks (round-4 P1)
+# Tests N1–N8: safe_remove_installed safety checks
 # ─────────────────────────────────────────────
 # These tests exercise each rejection path of safe_remove_installed
 # individually. Each setup is minimal so a failure isolates a single
@@ -851,9 +846,9 @@ for f in "${PROMPT_FILES[@]}"; do
     if [[ ! -f "$f" ]]; then
         continue
     fi
-    # Regression = the synthesized template appears IMMEDIATELY after
-    # --installed-path (i.e. it is the VALUE of the flag, not part of
-    # surrounding explanatory text that warns against the pattern).
+    # A violation is when the synthesized template appears IMMEDIATELY
+    # after --installed-path (i.e. it is the VALUE of the flag, not part
+    # of surrounding explanatory text that warns against the pattern).
     while IFS= read -r line; do
         if printf '%s' "$line" | grep -Eq -- '--installed-path[[:space:]]+\{\{skills_dir\}\}/<'; then
             BAD_LINES+=("$f: $line")
@@ -863,7 +858,7 @@ done
 if [[ ${#BAD_LINES[@]} -eq 0 ]]; then
     pass "prompt-contract: no skill doc synthesizes --installed-path from {{skills_dir}}/<name>"
 else
-    fail "prompt-contract regression" "$(printf '%s\n' "${BAD_LINES[@]}")"
+    fail "prompt-contract violation" "$(printf '%s\n' "${BAD_LINES[@]}")"
 fi
 
 # Restore PATH for any post-suite work

--- a/scripts/test-cleanup-helper.sh
+++ b/scripts/test-cleanup-helper.sh
@@ -299,30 +299,30 @@ fi
 rm -rf "$TEST_TMPDIR"
 
 # ─────────────────────────────────────────────
-# Test 9: --installed-path still exists → exit 1 (catches silent leak)
+# Test 9: --installed-path leftover under skills/ → exit 0 + dir gone
 # ─────────────────────────────────────────────
-# Previously a rc=0 from npx with a leftover skill directory would have
-# been reported as success. With --installed-path, the helper escalates.
-# NOTE: We point --installed-path at a non-standard subdir (not under
-# .claude/skills/foo) so a real `npx skills` running on Windows
-# (PATHEXT-fallback bypassing our extension-less fake npx) does not
-# delete the leftover and invalidate the assertion.
+# Round-4 P1: the helper itself must physically remove the leftover
+# directory (variant B), not just report it. Fixture is placed at the
+# canonical install location (.claude/skills/<name>/SKILL.md) so all
+# safety checks pass and safe_remove_installed proceeds.
 fresh_tmp
 write_lock "$TEST_TMPDIR" '{
   "version": 1,
   "skills": {"foo": {"source": "x/y"}}
 }'
-mkdir -p "$TEST_TMPDIR/leftover-dir"
-echo "leftover" > "$TEST_TMPDIR/leftover-dir/SKILL.md"
+mkdir -p "$TEST_TMPDIR/.claude/skills/foo"
+echo "# leftover" > "$TEST_TMPDIR/.claude/skills/foo/SKILL.md"
 if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
-   --installed-path leftover-dir > "$TEST_TMPDIR/out" 2>&1; then
-    fail "--installed-path leftover → exit 1" "helper returned 0 despite leftover directory"
-else
-    if grep -q 'still present' "$TEST_TMPDIR/out"; then
-        pass "--installed-path leftover → exit 1 (error message)"
+   --installed-path .claude/skills/foo > "$TEST_TMPDIR/out" 2>&1; then
+    if [[ ! -e "$TEST_TMPDIR/.claude/skills/foo" ]]; then
+        pass "--installed-path leftover under skills/ → exit 0 + dir gone"
     else
-        fail "--installed-path leftover → exit 1" "exit non-zero but no 'still present' message. output: $(cat "$TEST_TMPDIR/out")"
+        fail "--installed-path leftover under skills/" \
+             "helper exited 0 but directory remains: $(cat "$TEST_TMPDIR/out")"
     fi
+else
+    fail "--installed-path leftover under skills/" \
+         "helper exited non-zero: $(cat "$TEST_TMPDIR/out")"
 fi
 rm -rf "$TEST_TMPDIR"
 
@@ -347,20 +347,26 @@ fi
 rm -rf "$TEST_TMPDIR"
 
 # ─────────────────────────────────────────────
-# Test 11: sanitized-leftover regression (P1 from 3rd review round)
+# Test 11: sanitized-leftover end-to-end (P1 from review rounds 3 & 4)
 # ─────────────────────────────────────────────
 # Upstream `skills` sanitizes the on-disk directory name:
 #   "Convex Best Practices" -> "convex-best-practices"
-# An older prompt contract synthesized --installed-path as
-# `{{skills_dir}}/<name>`, i.e. ".claude/skills/Convex Best Practices",
-# which points at a path that NEVER existed. With cli_failed=True from
-# a partial npx failure, the helper would then see "directory absent",
-# downgrade to exit 0, and silently leave the REAL blocked directory
-# (sanitized path) on disk.
+# Upstream `npx skills remove -s "Convex Best Practices"` does NOT
+# apply sanitizeName() to the argument before matching, so it never
+# touches the sanitized directory; it exits 0 silently.
 #
-# This test exercises both contracts on the same fixture and proves
-# the new "pass the actual scanned path" contract is the only one
-# that surfaces the leftover.
+# Round 3 P1 fixed the prompt contract so agents pass the actual
+# scanned path. Round 4 P1 fixes the helper itself: it must remove
+# that physical directory, not just report leftover.
+#
+# Two sub-cases below probe both contracts on the same fixture:
+#   (a) regression-value: the OLD synthesized-path contract is still
+#       a silent no-op (path didn't exist), so without the new prompt
+#       contract a security-blocked dir would still leak. This proves
+#       why the prompt contract matters — it's a documentation case.
+#   (b) the FIX: with the correct path AND the new helper, the
+#       sanitized directory is physically removed and the lock key
+#       is cleared. This is the reviewer's explicit ask.
 fresh_tmp
 write_lock "$TEST_TMPDIR" '{
   "version": 1,
@@ -368,12 +374,13 @@ write_lock "$TEST_TMPDIR" '{
 }'
 # Real leftover at the SANITIZED upstream path:
 mkdir -p "$TEST_TMPDIR/.claude/skills/convex-best-practices"
-echo "leftover" > "$TEST_TMPDIR/.claude/skills/convex-best-practices/SKILL.md"
+echo "# blocked skill" > "$TEST_TMPDIR/.claude/skills/convex-best-practices/SKILL.md"
 
-# (a) OLD broken contract: synthesize path from logical name -> FALSE PASS.
-#     Fake npx returns 1 to engage the downgrade path. With the bogus
-#     unsanitized installed-path the helper sees "absent" and exits 0,
-#     proving the silent-leak hazard the new contract avoids.
+# (a) OLD broken contract: synthesize path from logical name -> silent no-op.
+#     Fake npx returns 1 (simulates the upstream no-match case). With the
+#     bogus unsanitized installed-path the helper sees "absent" and exits 0
+#     (idempotent on missing target), proving that without the new prompt
+#     contract the REAL sanitized directory would be left untouched.
 if FAKE_NPX_EXIT=1 "$PYTHON" "$HELPER" \
         --skill "Convex Best Practices" \
         --root "$TEST_TMPDIR" \
@@ -383,6 +390,10 @@ if FAKE_NPX_EXIT=1 "$PYTHON" "$HELPER" \
 else
     OLD_CONTRACT_EXIT=$?
 fi
+# Verify: sanitized dir IS still on disk (the silent-leak hazard).
+if [[ ! -d "$TEST_TMPDIR/.claude/skills/convex-best-practices" ]]; then
+    fail "sanitized leftover (a)" "old-contract path removed the wrong dir"
+fi
 
 # Re-add the lock entry that path (a) removed, so path (b) has work to do.
 write_lock "$TEST_TMPDIR" '{
@@ -390,8 +401,9 @@ write_lock "$TEST_TMPDIR" '{
   "skills": {"Convex Best Practices": {"source": "x/y"}}
 }'
 
-# (b) NEW correct contract: pass the actual sanitized scanned path.
-#     The helper must see leftover and exit 1.
+# (b) NEW correct contract + new helper: pass the actual sanitized scanned
+#     path. The helper must physically remove the directory AND clear the
+#     lock entry, even though upstream `npx skills remove` was a no-op.
 if FAKE_NPX_EXIT=1 "$PYTHON" "$HELPER" \
         --skill "Convex Best Practices" \
         --root "$TEST_TMPDIR" \
@@ -402,11 +414,262 @@ else
     NEW_CONTRACT_EXIT=$?
 fi
 
-if [[ $OLD_CONTRACT_EXIT -eq 0 && $NEW_CONTRACT_EXIT -ne 0 ]] \
-   && grep -q 'still present' "$TEST_TMPDIR/out-b"; then
-    pass "sanitized leftover: old contract false-passes, new contract exits 1"
+LOCK_CLEAR=0
+if ! grep -q 'Convex Best Practices' "$TEST_TMPDIR/skills-lock.json"; then
+    LOCK_CLEAR=1
+fi
+DIR_GONE=0
+if [[ ! -e "$TEST_TMPDIR/.claude/skills/convex-best-practices" ]]; then
+    DIR_GONE=1
+fi
+
+if [[ $OLD_CONTRACT_EXIT -eq 0 \
+   && $NEW_CONTRACT_EXIT -eq 0 \
+   && $LOCK_CLEAR -eq 1 \
+   && $DIR_GONE -eq 1 ]]; then
+    pass "sanitized leftover: old-contract silent no-op + new-contract removes both"
 else
-    fail "sanitized leftover" "old=$OLD_CONTRACT_EXIT new=$NEW_CONTRACT_EXIT; out-a=$(cat "$TEST_TMPDIR/out-a"); out-b=$(cat "$TEST_TMPDIR/out-b")"
+    fail "sanitized leftover" \
+         "old=$OLD_CONTRACT_EXIT new=$NEW_CONTRACT_EXIT lock_clear=$LOCK_CLEAR dir_gone=$DIR_GONE; out-a=$(cat "$TEST_TMPDIR/out-a"); out-b=$(cat "$TEST_TMPDIR/out-b")"
+fi
+rm -rf "$TEST_TMPDIR"
+
+# ─────────────────────────────────────────────
+# Tests N1–N8: safe_remove_installed safety checks (round-4 P1)
+# ─────────────────────────────────────────────
+# These tests exercise each rejection path of safe_remove_installed
+# individually. Each setup is minimal so a failure isolates a single
+# safety guarantee.
+
+# N1: symlink at --installed-path → reject (POSIX only; Windows junctions
+# covered by a conditional block below).
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+mkdir -p "$TEST_TMPDIR/outside-skill"
+echo "# outside" > "$TEST_TMPDIR/outside-skill/SKILL.md"
+mkdir -p "$TEST_TMPDIR/.claude/skills"
+if [[ $IS_WINDOWS -eq 0 ]]; then
+    ln -s "$TEST_TMPDIR/outside-skill" "$TEST_TMPDIR/.claude/skills/evil"
+    if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+       --installed-path .claude/skills/evil > "$TEST_TMPDIR/out" 2>&1; then
+        fail "N1: symlink rejection" "helper exited 0 despite symlink installed-path"
+    else
+        if [[ -e "$TEST_TMPDIR/outside-skill/SKILL.md" ]] && \
+           grep -q 'symlink or junction' "$TEST_TMPDIR/out"; then
+            pass "N1: symlink rejection (target preserved)"
+        else
+            fail "N1: symlink rejection" \
+                 "target tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+        fi
+    fi
+else
+    # Windows junction via cmd /c mklink /J (admin not required for junctions).
+    # Skip if mklink fails (some Windows setups disallow it without elevation).
+    if cmd //c "mklink /J \"$(cygpath -w "$TEST_TMPDIR/.claude/skills/evil")\" \"$(cygpath -w "$TEST_TMPDIR/outside-skill")\"" > /dev/null 2>&1; then
+        if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+           --installed-path .claude/skills/evil > "$TEST_TMPDIR/out" 2>&1; then
+            fail "N1: junction rejection (Windows)" "helper exited 0 despite junction"
+        else
+            if [[ -e "$TEST_TMPDIR/outside-skill/SKILL.md" ]] && \
+               grep -q 'symlink or junction' "$TEST_TMPDIR/out"; then
+                pass "N1: junction rejection (Windows; target preserved)"
+            else
+                fail "N1: junction rejection (Windows)" \
+                     "target tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+            fi
+        fi
+    else
+        pass "N1: junction rejection (Windows; mklink unavailable, skipped)"
+    fi
+fi
+rm -rf "$TEST_TMPDIR"
+
+# N2: path-traversal escape → reject.
+# --installed-path ../escape-dir resolves outside --root, must be rejected.
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+# Create an "outside" target a sibling of --root that the test could
+# theoretically traverse into.
+ESCAPE_DIR=$(mktemp -d)
+mkdir -p "$ESCAPE_DIR/.claude/skills/foo"
+echo "# escape" > "$ESCAPE_DIR/.claude/skills/foo/SKILL.md"
+# Walk up from $TEST_TMPDIR by enough '../' to reach ESCAPE_DIR's basename.
+ESCAPE_REL="../$(basename "$ESCAPE_DIR")/.claude/skills/foo"
+if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+   --installed-path "$ESCAPE_REL" > "$TEST_TMPDIR/out" 2>&1; then
+    fail "N2: path-traversal escape" "helper exited 0 despite ../ escape"
+else
+    if [[ -e "$ESCAPE_DIR/.claude/skills/foo" ]] && \
+       grep -Eq 'outside --root|path traversal' "$TEST_TMPDIR/out"; then
+        pass "N2: path-traversal escape rejected (target preserved)"
+    else
+        fail "N2: path-traversal escape" \
+             "target tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+    fi
+fi
+rm -rf "$ESCAPE_DIR"
+rm -rf "$TEST_TMPDIR"
+
+# N3: --installed-path inside --root but NOT under any `skills/` segment
+# → reject (check #6).
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+mkdir -p "$TEST_TMPDIR/random-dir"
+echo "# random" > "$TEST_TMPDIR/random-dir/SKILL.md"
+if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+   --installed-path random-dir > "$TEST_TMPDIR/out" 2>&1; then
+    fail "N3: not under skills/" "helper exited 0 despite non-skills location"
+else
+    if [[ -e "$TEST_TMPDIR/random-dir/SKILL.md" ]] && \
+       grep -q "no 'skills' segment" "$TEST_TMPDIR/out"; then
+        pass "N3: non-skills location rejected (dir preserved)"
+    else
+        fail "N3: not under skills/" \
+             "dir tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+    fi
+fi
+rm -rf "$TEST_TMPDIR"
+
+# N4: missing SKILL.md marker → reject (check #7).
+# POSIX-only: on Windows shutil.which('npx') honours PATHEXT and resolves
+# to the system npx.cmd ahead of our extension-less fake. Real upstream
+# `npx skills remove` then scans .claude/skills/ and may delete the
+# directory wholesale (irrespective of SKILL.md presence), turning this
+# test into a false-pass via the "already absent" idempotent branch.
+# The safety check is exercised on Linux CI where the fake npx is used.
+if [[ $IS_WINDOWS -eq 0 ]]; then
+    fresh_tmp
+    write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+    mkdir -p "$TEST_TMPDIR/.claude/skills/foo"
+    # Intentionally NO SKILL.md
+    echo "# stuff but no marker" > "$TEST_TMPDIR/.claude/skills/foo/other.md"
+    if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+       --installed-path .claude/skills/foo > "$TEST_TMPDIR/out" 2>&1; then
+        fail "N4: missing SKILL.md" "helper exited 0 without SKILL.md marker"
+    else
+        if [[ -e "$TEST_TMPDIR/.claude/skills/foo/other.md" ]] && \
+           grep -q 'no SKILL.md marker' "$TEST_TMPDIR/out"; then
+            pass "N4: missing SKILL.md rejected (dir preserved)"
+        else
+            fail "N4: missing SKILL.md" \
+                 "dir tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+        fi
+    fi
+    rm -rf "$TEST_TMPDIR"
+else
+    pass "N4: missing SKILL.md (Windows; skipped — real npx clobbers fixture)"
+fi
+
+# N5: --installed-path is a regular file, not a directory → reject (check #4).
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+mkdir -p "$TEST_TMPDIR/.claude/skills"
+echo "I am a file" > "$TEST_TMPDIR/.claude/skills/foo"
+if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+   --installed-path .claude/skills/foo > "$TEST_TMPDIR/out" 2>&1; then
+    fail "N5: file instead of dir" "helper exited 0 despite file at installed-path"
+else
+    if [[ -f "$TEST_TMPDIR/.claude/skills/foo" ]] && \
+       grep -q 'not a directory' "$TEST_TMPDIR/out"; then
+        pass "N5: file-not-dir rejected (file preserved)"
+    else
+        fail "N5: file instead of dir" \
+             "file tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+    fi
+fi
+rm -rf "$TEST_TMPDIR"
+
+# N6: sibling skill under same parent must be preserved during cleanup.
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"blocked": {"source": "x/y"}, "neighbor": {"source": "a/b"}}
+}'
+mkdir -p "$TEST_TMPDIR/.claude/skills/blocked"
+mkdir -p "$TEST_TMPDIR/.claude/skills/neighbor"
+echo "# blocked" > "$TEST_TMPDIR/.claude/skills/blocked/SKILL.md"
+echo "# neighbor" > "$TEST_TMPDIR/.claude/skills/neighbor/SKILL.md"
+if "$PYTHON" "$HELPER" --skill blocked --root "$TEST_TMPDIR" \
+   --installed-path .claude/skills/blocked > "$TEST_TMPDIR/out" 2>&1; then
+    if [[ ! -e "$TEST_TMPDIR/.claude/skills/blocked" ]] && \
+       [[ -f "$TEST_TMPDIR/.claude/skills/neighbor/SKILL.md" ]]; then
+        pass "N6: sibling preserved during cleanup"
+    else
+        fail "N6: sibling preservation" \
+             "blocked still exists or neighbor was deleted: $(cat "$TEST_TMPDIR/out")"
+    fi
+else
+    fail "N6: sibling preservation" \
+         "helper exited non-zero: $(cat "$TEST_TMPDIR/out")"
+fi
+rm -rf "$TEST_TMPDIR"
+
+# N7: permission-failure mid-rmtree → exit 1 (POSIX only; chmod 000 on
+# Windows does not produce the same delete-blocking behavior).
+if [[ $IS_WINDOWS -eq 0 ]]; then
+    fresh_tmp
+    write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+    mkdir -p "$TEST_TMPDIR/.claude/skills/foo/locked"
+    echo "# blocked" > "$TEST_TMPDIR/.claude/skills/foo/SKILL.md"
+    echo "stay" > "$TEST_TMPDIR/.claude/skills/foo/locked/child"
+    # Drop write perms on the parent so children cannot be unlinked.
+    chmod 555 "$TEST_TMPDIR/.claude/skills/foo/locked"
+    if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+       --installed-path .claude/skills/foo > "$TEST_TMPDIR/out" 2>&1; then
+        # On some POSIX setups (running as root, tmpfs without DAC, etc.)
+        # rmtree may still succeed. Don't fail in that case — accept.
+        chmod -R 755 "$TEST_TMPDIR/.claude/skills/foo" 2>/dev/null || true
+        pass "N7: permission-failure (POSIX; rmtree succeeded — root or relaxed FS)"
+    else
+        # Restore perms so cleanup below can run.
+        chmod -R 755 "$TEST_TMPDIR/.claude/skills/foo" 2>/dev/null || true
+        pass "N7: permission-failure rejected with non-zero exit"
+    fi
+    rm -rf "$TEST_TMPDIR"
+else
+    pass "N7: permission-failure (Windows; skipped — different semantics)"
+fi
+
+# N8: --installed-path == --root → reject (check #5b).
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+# Put a SKILL.md at root so the SKILL.md check alone wouldn't block —
+# we need to prove #5b fires before #7.
+echo "# root SKILL.md (should not be touched)" > "$TEST_TMPDIR/SKILL.md"
+if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+   --installed-path . > "$TEST_TMPDIR/out" 2>&1; then
+    fail "N8: installed-path == root" "helper exited 0 despite installed-path == root"
+else
+    # Both #5b "equals --root" and #6 "no 'skills' segment" are valid
+    # rejection reasons (resolved root has no 'skills' part). Accept either.
+    if [[ -d "$TEST_TMPDIR" ]] && [[ -f "$TEST_TMPDIR/SKILL.md" ]] && \
+       grep -Eq "equals --root|no 'skills' segment" "$TEST_TMPDIR/out"; then
+        pass "N8: installed-path == root rejected (root preserved)"
+    else
+        fail "N8: installed-path == root" \
+             "root tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+    fi
 fi
 rm -rf "$TEST_TMPDIR"
 

--- a/scripts/test-cleanup-helper.sh
+++ b/scripts/test-cleanup-helper.sh
@@ -56,6 +56,11 @@ cat > "$FAKE_BIN/npx" << 'EOF'
 #   regression tests can simulate `npx skills remove` returning non-zero
 printf '%s\n' "$@" >> "${NPX_ARGV_LOG:-/dev/null}"
 echo "cwd_basename=$(basename "$(pwd)")" >> "${NPX_ARGV_LOG:-/dev/null}"
+if [ -n "${FAKE_NPX_REPLACE_WITH_FILE:-}" ]; then
+  rm -rf "$FAKE_NPX_REPLACE_WITH_FILE"
+  mkdir -p "$(dirname "$FAKE_NPX_REPLACE_WITH_FILE")"
+  printf '%s\n' "fake npx replacement" > "$FAKE_NPX_REPLACE_WITH_FILE"
+fi
 exit "${FAKE_NPX_EXIT:-0}"
 EOF
 chmod +x "$FAKE_BIN/npx"
@@ -442,49 +447,130 @@ rm -rf "$TEST_TMPDIR"
 # individually. Each setup is minimal so a failure isolates a single
 # safety guarantee.
 
-# N1: symlink at --installed-path → reject (POSIX only; Windows junctions
-# covered by a conditional block below).
+# N1: managed symlink/junction install → accept and remove both canonical
+# target and agent-specific link.
 fresh_tmp
 write_lock "$TEST_TMPDIR" '{
   "version": 1,
   "skills": {"foo": {"source": "x/y"}}
 }'
-mkdir -p "$TEST_TMPDIR/outside-skill"
-echo "# outside" > "$TEST_TMPDIR/outside-skill/SKILL.md"
+mkdir -p "$TEST_TMPDIR/.agents/skills/foo"
+printf '%s\n' '---' 'name: foo' '---' '# canonical' > "$TEST_TMPDIR/.agents/skills/foo/SKILL.md"
 mkdir -p "$TEST_TMPDIR/.claude/skills"
 if [[ $IS_WINDOWS -eq 0 ]]; then
-    ln -s "$TEST_TMPDIR/outside-skill" "$TEST_TMPDIR/.claude/skills/evil"
+    ln -s "../../.agents/skills/foo" "$TEST_TMPDIR/.claude/skills/foo"
     if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
-       --installed-path .claude/skills/evil > "$TEST_TMPDIR/out" 2>&1; then
-        fail "N1: symlink rejection" "helper exited 0 despite symlink installed-path"
-    else
-        if [[ -e "$TEST_TMPDIR/outside-skill/SKILL.md" ]] && \
-           grep -q 'symlink or junction' "$TEST_TMPDIR/out"; then
-            pass "N1: symlink rejection (target preserved)"
+       --installed-path .claude/skills/foo > "$TEST_TMPDIR/out" 2>&1; then
+        if [[ ! -e "$TEST_TMPDIR/.agents/skills/foo" ]] && \
+           [[ ! -e "$TEST_TMPDIR/.claude/skills/foo" ]] && \
+           [[ ! -L "$TEST_TMPDIR/.claude/skills/foo" ]] && \
+           ! grep -q '"foo"' "$TEST_TMPDIR/skills-lock.json"; then
+            pass "N1: managed symlink accepted and cleaned"
         else
-            fail "N1: symlink rejection" \
-                 "target tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+            fail "N1: managed symlink cleanup" \
+                 "canonical/link/lock not clean: $(cat "$TEST_TMPDIR/out")"
         fi
+    else
+        fail "N1: managed symlink cleanup" "helper exited non-zero: $(cat "$TEST_TMPDIR/out")"
     fi
 else
     # Windows junction via cmd /c mklink /J (admin not required for junctions).
     # Skip if mklink fails (some Windows setups disallow it without elevation).
-    if cmd //c "mklink /J \"$(cygpath -w "$TEST_TMPDIR/.claude/skills/evil")\" \"$(cygpath -w "$TEST_TMPDIR/outside-skill")\"" > /dev/null 2>&1; then
+    if cmd //c "mklink /J \"$(cygpath -w "$TEST_TMPDIR/.claude/skills/foo")\" \"$(cygpath -w "$TEST_TMPDIR/.agents/skills/foo")\"" > /dev/null 2>&1; then
         if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
-           --installed-path .claude/skills/evil > "$TEST_TMPDIR/out" 2>&1; then
-            fail "N1: junction rejection (Windows)" "helper exited 0 despite junction"
-        else
-            if [[ -e "$TEST_TMPDIR/outside-skill/SKILL.md" ]] && \
-               grep -q 'symlink or junction' "$TEST_TMPDIR/out"; then
-                pass "N1: junction rejection (Windows; target preserved)"
+           --installed-path .claude/skills/foo > "$TEST_TMPDIR/out" 2>&1; then
+            if [[ ! -e "$TEST_TMPDIR/.agents/skills/foo" ]] && \
+               [[ ! -e "$TEST_TMPDIR/.claude/skills/foo" ]] && \
+               ! grep -q '"foo"' "$TEST_TMPDIR/skills-lock.json"; then
+                pass "N1: managed junction accepted and cleaned"
             else
-                fail "N1: junction rejection (Windows)" \
-                     "target tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+                fail "N1: managed junction cleanup" \
+                     "canonical/link/lock not clean: $(cat "$TEST_TMPDIR/out")"
+            fi
+        else
+            fail "N1: managed junction cleanup" "helper exited non-zero: $(cat "$TEST_TMPDIR/out")"
+        fi
+    else
+        pass "N1: managed junction cleanup (Windows; mklink unavailable, skipped)"
+    fi
+fi
+rm -rf "$TEST_TMPDIR"
+
+# N1b: symlink/junction that escapes --root → reject and preserve lock.
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+OUTSIDE_SKILL=$(mktemp -d)
+mkdir -p "$OUTSIDE_SKILL/foo"
+printf '%s\n' '---' 'name: foo' '---' '# outside' > "$OUTSIDE_SKILL/foo/SKILL.md"
+mkdir -p "$TEST_TMPDIR/.claude/skills"
+if [[ $IS_WINDOWS -eq 0 ]]; then
+    ln -s "$OUTSIDE_SKILL/foo" "$TEST_TMPDIR/.claude/skills/foo"
+    if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+       --installed-path .claude/skills/foo > "$TEST_TMPDIR/out" 2>&1; then
+        fail "N1b: escaping symlink rejection" "helper exited 0 despite outside symlink"
+    else
+        if [[ -e "$OUTSIDE_SKILL/foo/SKILL.md" ]] && \
+           [[ -L "$TEST_TMPDIR/.claude/skills/foo" ]] && \
+           grep -q '"foo"' "$TEST_TMPDIR/skills-lock.json" && \
+           grep -Eq 'outside --root|path traversal|symlink escape' "$TEST_TMPDIR/out"; then
+            pass "N1b: escaping symlink rejected (target + lock preserved)"
+        else
+            fail "N1b: escaping symlink rejection" \
+                 "target/link/lock tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
+        fi
+    fi
+else
+    if cmd //c "mklink /J \"$(cygpath -w "$TEST_TMPDIR/.claude/skills/foo")\" \"$(cygpath -w "$OUTSIDE_SKILL/foo")\"" > /dev/null 2>&1; then
+        if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+           --installed-path .claude/skills/foo > "$TEST_TMPDIR/out" 2>&1; then
+            fail "N1b: escaping junction rejection (Windows)" "helper exited 0 despite outside junction"
+        else
+            if [[ -e "$OUTSIDE_SKILL/foo/SKILL.md" ]] && \
+               grep -q '"foo"' "$TEST_TMPDIR/skills-lock.json" && \
+               grep -Eq 'outside --root|path traversal|symlink escape' "$TEST_TMPDIR/out"; then
+                pass "N1b: escaping junction rejected (Windows; target + lock preserved)"
+            else
+                fail "N1b: escaping junction rejection (Windows)" \
+                     "target/lock tampered or wrong error: $(cat "$TEST_TMPDIR/out")"
             fi
         fi
     else
-        pass "N1: junction rejection (Windows; mklink unavailable, skipped)"
+        pass "N1b: escaping junction rejection (Windows; mklink unavailable, skipped)"
     fi
+fi
+rm -rf "$OUTSIDE_SKILL"
+rm -rf "$TEST_TMPDIR"
+
+# N1c: lock entry is cleared only after managed symlink cleanup succeeds.
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+mkdir -p "$TEST_TMPDIR/.agents/skills/foo"
+printf '%s\n' '---' 'name: foo' '---' '# canonical' > "$TEST_TMPDIR/.agents/skills/foo/SKILL.md"
+mkdir -p "$TEST_TMPDIR/.claude/skills"
+if [[ $IS_WINDOWS -eq 0 ]]; then
+    ln -s "../../.agents/skills/foo" "$TEST_TMPDIR/.claude/skills/foo"
+    if FAKE_NPX_REPLACE_WITH_FILE="$TEST_TMPDIR/.agents/skills/foo" \
+       "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+       --installed-path .claude/skills/foo > "$TEST_TMPDIR/out" 2>&1; then
+        fail "N1c: lock waits for symlink cleanup success" "helper exited 0 despite cleanup failure"
+    else
+        if grep -q '"foo"' "$TEST_TMPDIR/skills-lock.json" && \
+           [[ -L "$TEST_TMPDIR/.claude/skills/foo" ]] && \
+           grep -q 'not a directory' "$TEST_TMPDIR/out"; then
+            pass "N1c: lock preserved when managed symlink cleanup fails"
+        else
+            fail "N1c: lock waits for symlink cleanup success" \
+                 "lock/link not preserved or wrong error: $(cat "$TEST_TMPDIR/out")"
+        fi
+    fi
+else
+    pass "N1c: lock waits for symlink cleanup success (Windows; skipped)"
 fi
 rm -rf "$TEST_TMPDIR"
 
@@ -832,7 +918,48 @@ fi
 rm -rf "$TEST_TMPDIR"
 
 # ─────────────────────────────────────────────
-# Test 12: prompt-contract grep — skill docs must NOT synthesize the
+# Test 12: built-in agent skills roots do not drift from src/core/agents.ts
+# ─────────────────────────────────────────────
+if DRIFT_OUTPUT=$("$PYTHON" - "$ROOT_DIR" <<'PY'
+import ast
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+helper_path = root / 'skills/aif-skill-generator/scripts/cleanup-blocked-skill.py'
+agents_path = root / 'src/core/agents.ts'
+
+tree = ast.parse(helper_path.read_text(encoding='utf-8'))
+helper_dirs = None
+for node in tree.body:
+    if not isinstance(node, ast.Assign):
+        continue
+    for target in node.targets:
+        if isinstance(target, ast.Name) and target.id == '_BUILTIN_AGENT_SKILLS_DIRS':
+            helper_dirs = set(ast.literal_eval(node.value))
+            break
+    if helper_dirs is not None:
+        break
+
+if helper_dirs is None:
+    print('could not find _BUILTIN_AGENT_SKILLS_DIRS')
+    sys.exit(1)
+
+agent_dirs = set(re.findall(r"skillsDir:\s*'([^']+)'", agents_path.read_text(encoding='utf-8')))
+if helper_dirs != agent_dirs:
+    print(f'missing in helper: {sorted(agent_dirs - helper_dirs)}')
+    print(f'extra in helper: {sorted(helper_dirs - agent_dirs)}')
+    sys.exit(1)
+PY
+); then
+    pass "built-in skills roots match src/core/agents.ts"
+else
+    fail "built-in skills roots drift" "$DRIFT_OUTPUT"
+fi
+
+# ─────────────────────────────────────────────
+# Test 13: prompt-contract grep — skill docs must NOT synthesize the
 # installed path from {{skills_dir}}/<name>; they must reuse the same
 # path token passed to security-scan.py.
 # ─────────────────────────────────────────────

--- a/scripts/test-cleanup-helper.sh
+++ b/scripts/test-cleanup-helper.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+# Test suite: regression tests for cleanup-blocked-skill.py
+# Usage: ./scripts/test-cleanup-helper.sh
+#
+# Exercises the lock-file patching and validation surfaces of
+# skills/aif-skill-generator/scripts/cleanup-blocked-skill.py without
+# touching the live skills.sh registry. A throw-away fake `npx` script
+# is placed first on PATH so subprocess calls succeed without network.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="$ROOT_DIR/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() { PASSED=$((PASSED + 1)); echo -e "  ${GREEN}✓${NC} $1"; }
+fail() { FAILED=$((FAILED + 1)); echo -e "  ${RED}✗${NC} $1"; if [[ -n "${2:-}" ]]; then echo -e "      ${YELLOW}$2${NC}"; fi; }
+
+# ─────────────────────────────────────────────
+# Resolve a usable Python interpreter
+# ─────────────────────────────────────────────
+PYTHON="${PYTHON:-}"
+if [[ -z "$PYTHON" ]]; then
+    PYTHON=$(command -v python3 || command -v python || true)
+fi
+if [[ -z "$PYTHON" ]]; then
+    echo -e "${RED}ERROR:${NC} python interpreter not found on PATH" >&2
+    exit 1
+fi
+
+if [[ ! -f "$HELPER" ]]; then
+    echo -e "${RED}ERROR:${NC} helper script not found at $HELPER" >&2
+    exit 1
+fi
+
+# ─────────────────────────────────────────────
+# Build a fake `npx` that logs argv and returns 0
+# ─────────────────────────────────────────────
+FAKE_BIN=$(mktemp -d)
+cat > "$FAKE_BIN/npx" << 'EOF'
+#!/bin/sh
+# Fake npx for cleanup-helper tests:
+# - logs each argv element on its own line into $NPX_ARGV_LOG
+# - returns 0 unconditionally
+printf '%s\n' "$@" >> "${NPX_ARGV_LOG:-/dev/null}"
+exit 0
+EOF
+chmod +x "$FAKE_BIN/npx"
+
+ORIGINAL_PATH="$PATH"
+export PATH="$FAKE_BIN:$PATH"
+
+# Detect Windows-flavoured bash. On Windows, Python's shutil.which honours
+# PATHEXT and skips our extension-less fake `npx` in favour of any real
+# npx.cmd elsewhere on PATH. CI runs on Ubuntu so this is fine there; for
+# local Windows runs we still validate lock-state behaviour but skip the
+# fake-npx argv-passing assertion (since the fake never executes).
+case "$(uname -s 2>/dev/null || echo unknown)" in
+    MINGW*|MSYS*|CYGWIN*) IS_WINDOWS=1 ;;
+    *)                    IS_WINDOWS=0 ;;
+esac
+
+cleanup() {
+    rm -rf "$FAKE_BIN"
+    if [[ -n "${TEST_TMPDIR:-}" ]]; then
+        rm -rf "$TEST_TMPDIR"
+    fi
+}
+trap cleanup EXIT
+
+# ─────────────────────────────────────────────
+# Helpers for individual tests
+# ─────────────────────────────────────────────
+# fresh_tmp sets globals TEST_TMPDIR and NPX_ARGV_LOG in the current
+# shell. Avoid command substitution here — that would run in a subshell
+# and the exports would not survive.
+fresh_tmp() {
+    TEST_TMPDIR=$(mktemp -d)
+    NPX_ARGV_LOG="$TEST_TMPDIR/npx-argv.log"
+    export TEST_TMPDIR NPX_ARGV_LOG
+    : > "$NPX_ARGV_LOG"
+}
+
+write_lock() {
+    # write_lock <tmpdir> <json>
+    printf '%s\n' "$2" > "$1/skills-lock.json"
+}
+
+echo -e "\n${BOLD}=== cleanup-blocked-skill.py regression tests ===${NC}\n"
+
+# ─────────────────────────────────────────────
+# Test 1: removes target, preserves siblings (#117 regression)
+# ─────────────────────────────────────────────
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {
+    "blocked-one": {"source": "evil/repo"},
+    "safe-one": {"source": "good/repo"}
+  }
+}'
+if "$PYTHON" "$HELPER" --skill blocked-one --root "$TEST_TMPDIR" > "$TEST_TMPDIR/out" 2>&1; then
+    if grep -q '"safe-one"' "$TEST_TMPDIR/skills-lock.json" \
+       && ! grep -q '"blocked-one"' "$TEST_TMPDIR/skills-lock.json"; then
+        pass "removes target, preserves siblings"
+    else
+        fail "removes target, preserves siblings" "lock file content unexpected: $(cat "$TEST_TMPDIR/skills-lock.json")"
+    fi
+else
+    fail "removes target, preserves siblings" "helper exited non-zero: $(cat "$TEST_TMPDIR/out")"
+fi
+rm -rf "$TEST_TMPDIR"
+
+# ─────────────────────────────────────────────
+# Test 2: skill name with spaces (P1.1 regression)
+# ─────────────────────────────────────────────
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {
+    "Convex Best Practices": {"source": "x/y"},
+    "safe-one": {"source": "good/repo"}
+  }
+}'
+if "$PYTHON" "$HELPER" --skill "Convex Best Practices" --root "$TEST_TMPDIR" > "$TEST_TMPDIR/out" 2>&1; then
+    LOCK_OK=0
+    if grep -q '"safe-one"' "$TEST_TMPDIR/skills-lock.json" \
+       && ! grep -q 'Convex Best Practices' "$TEST_TMPDIR/skills-lock.json"; then
+        LOCK_OK=1
+    fi
+
+    if [[ $LOCK_OK -eq 0 ]]; then
+        fail "skill name with spaces" "lock content unexpected: $(cat "$TEST_TMPDIR/skills-lock.json")"
+    elif [[ $IS_WINDOWS -eq 1 ]]; then
+        # Lock-state proves the P1.1 fix (validation + patch_lock both
+        # accepted the spaced name); argv-passing assertion is unreliable
+        # on Windows (see PATHEXT note above).
+        pass "skill name with spaces (lock; argv check skipped on Windows)"
+    else
+        # Fake npx logged each argv on its own line — verify the full
+        # name arrived as a single argv element (no shell splitting).
+        if grep -Fx "Convex Best Practices" "$NPX_ARGV_LOG" > /dev/null; then
+            pass "skill name with spaces (lock + argv)"
+        else
+            fail "skill name with spaces" "fake-npx did not receive full name as one argv. log: $(cat "$NPX_ARGV_LOG")"
+        fi
+    fi
+else
+    fail "skill name with spaces" "helper exited non-zero: $(cat "$TEST_TMPDIR/out")"
+fi
+rm -rf "$TEST_TMPDIR"
+
+# ─────────────────────────────────────────────
+# Test 3: bad names rejected (security validation)
+# ─────────────────────────────────────────────
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{"version": 1, "skills": {"foo": {}}}'
+ORIGINAL_LOCK=$(cat "$TEST_TMPDIR/skills-lock.json")
+BAD_INPUTS=("" "*" "foo/bar" "foo\\bar" "-foo" "..")
+# Add a newline-containing name via printf (cannot inline a literal \n)
+NL_NAME=$(printf 'foo\nbar')
+BAD_INPUTS+=("$NL_NAME")
+ALL_REJECTED=1
+for bad in "${BAD_INPUTS[@]}"; do
+    if "$PYTHON" "$HELPER" --skill "$bad" --root "$TEST_TMPDIR" > /dev/null 2>&1; then
+        ALL_REJECTED=0
+        fail "bad names rejected" "accepted bad name: ${bad//$'\n'/<NL>}"
+        break
+    fi
+done
+if [[ $ALL_REJECTED -eq 1 ]]; then
+    # Make sure none of those calls modified the lock file
+    if [[ "$(cat "$TEST_TMPDIR/skills-lock.json")" == "$ORIGINAL_LOCK" ]]; then
+        pass "bad names rejected (${#BAD_INPUTS[@]} cases)"
+    else
+        fail "bad names rejected" "lock was modified despite rejection"
+    fi
+fi
+rm -rf "$TEST_TMPDIR"
+
+# ─────────────────────────────────────────────
+# Test 4: no-op when entry absent (lists available keys)
+# ─────────────────────────────────────────────
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"existing-skill": {"source": "a/b"}}
+}'
+ORIGINAL_LOCK=$(cat "$TEST_TMPDIR/skills-lock.json")
+if "$PYTHON" "$HELPER" --skill never-existed --root "$TEST_TMPDIR" > "$TEST_TMPDIR/out" 2>&1; then
+    if grep -q "existing-skill" "$TEST_TMPDIR/out" \
+       && [[ "$(cat "$TEST_TMPDIR/skills-lock.json")" == "$ORIGINAL_LOCK" ]]; then
+        pass "no-op when entry absent (lists available keys)"
+    else
+        fail "no-op when entry absent" "expected 'existing-skill' in output and lock unchanged. output: $(cat "$TEST_TMPDIR/out")"
+    fi
+else
+    fail "no-op when entry absent" "helper exited non-zero: $(cat "$TEST_TMPDIR/out")"
+fi
+rm -rf "$TEST_TMPDIR"
+
+# ─────────────────────────────────────────────
+# Test 5: invalid JSON → non-zero exit
+# ─────────────────────────────────────────────
+fresh_tmp
+echo "{not valid json" > "$TEST_TMPDIR/skills-lock.json"
+if "$PYTHON" "$HELPER" --skill anything --root "$TEST_TMPDIR" > /dev/null 2>&1; then
+    fail "invalid JSON errors out" "helper exited 0 on malformed lock"
+else
+    pass "invalid JSON errors out"
+fi
+rm -rf "$TEST_TMPDIR"
+
+# ─────────────────────────────────────────────
+# Test 6: missing npx → non-zero exit, lock unchanged (P2.1 regression)
+# ─────────────────────────────────────────────
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{"version": 1, "skills": {"foo": {"source": "a/b"}}}'
+ORIGINAL_LOCK=$(cat "$TEST_TMPDIR/skills-lock.json")
+# Empty PATH so npx cannot be resolved. The interpreter is invoked
+# explicitly via $PYTHON, so python itself remains reachable.
+if PATH="" "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" > "$TEST_TMPDIR/out" 2>&1; then
+    fail "missing npx fails fast" "helper exited 0 despite npx missing"
+else
+    # Make sure we didn't silently mutate the lock either
+    if [[ "$(cat "$TEST_TMPDIR/skills-lock.json")" == "$ORIGINAL_LOCK" ]]; then
+        pass "missing npx fails fast (lock unchanged)"
+    else
+        fail "missing npx fails fast" "helper failed but mutated the lock anyway"
+    fi
+fi
+rm -rf "$TEST_TMPDIR"
+
+# Restore PATH for any post-suite work
+export PATH="$ORIGINAL_PATH"
+
+# ─────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────
+echo ""
+TOTAL=$((PASSED + FAILED))
+if [[ $FAILED -gt 0 ]]; then
+    echo -e "${RED}${BOLD}FAILED: ${FAILED}/${TOTAL}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}${BOLD}PASSED: ${PASSED}/${TOTAL}${NC}"

--- a/scripts/test-cleanup-helper.sh
+++ b/scripts/test-cleanup-helper.sh
@@ -43,7 +43,7 @@ if [[ ! -f "$HELPER" ]]; then
 fi
 
 # ─────────────────────────────────────────────
-# Build a fake `npx` that logs argv and returns 0
+# Build a fake `npx` that logs argv and returns a configurable exit code
 # ─────────────────────────────────────────────
 FAKE_BIN=$(mktemp -d)
 cat > "$FAKE_BIN/npx" << 'EOF'
@@ -52,14 +52,16 @@ cat > "$FAKE_BIN/npx" << 'EOF'
 # - logs each argv element on its own line into $NPX_ARGV_LOG
 # - logs the current working directory (as its basename) so tests can
 #   assert that the helper passes cwd=<root> to subprocess.run
-# - returns 0 unconditionally
+# - exits with $FAKE_NPX_EXIT if set (default 0) so partial-failure
+#   regression tests can simulate `npx skills remove` returning non-zero
 printf '%s\n' "$@" >> "${NPX_ARGV_LOG:-/dev/null}"
 echo "cwd_basename=$(basename "$(pwd)")" >> "${NPX_ARGV_LOG:-/dev/null}"
-exit 0
+exit "${FAKE_NPX_EXIT:-0}"
 EOF
 chmod +x "$FAKE_BIN/npx"
 
 ORIGINAL_PATH="$PATH"
+ORIGINAL_PATHEXT="${PATHEXT:-}"
 export PATH="$FAKE_BIN:$PATH"
 
 # Detect Windows-flavoured bash. On Windows, Python's shutil.which honours
@@ -168,7 +170,7 @@ rm -rf "$TEST_TMPDIR"
 fresh_tmp
 write_lock "$TEST_TMPDIR" '{"version": 1, "skills": {"foo": {}}}'
 ORIGINAL_LOCK=$(cat "$TEST_TMPDIR/skills-lock.json")
-BAD_INPUTS=("" "*" "foo/bar" "foo\\bar" "-foo" "..")
+BAD_INPUTS=("" "*" "foo/bar" "foo\\bar" "-foo" " -foo" ".." "   ")
 # Add a newline-containing name via printf (cannot inline a literal \n)
 NL_NAME=$(printf 'foo\nbar')
 BAD_INPUTS+=("$NL_NAME")
@@ -231,7 +233,9 @@ write_lock "$TEST_TMPDIR" '{"version": 1, "skills": {"foo": {"source": "a/b"}}}'
 ORIGINAL_LOCK=$(cat "$TEST_TMPDIR/skills-lock.json")
 # Empty PATH so npx cannot be resolved. The interpreter is invoked
 # explicitly via $PYTHON, so python itself remains reachable.
-if PATH="" "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" > "$TEST_TMPDIR/out" 2>&1; then
+# Also clear PATHEXT — on Windows, shutil.which may try extension
+# fallbacks (npx.cmd) even with a sparse PATH; this closes the gap.
+if PATH="" PATHEXT="" "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" > "$TEST_TMPDIR/out" 2>&1; then
     fail "missing npx fails fast" "helper exited 0 despite npx missing"
 else
     # Make sure we didn't silently mutate the lock either
@@ -274,8 +278,79 @@ else
 fi
 rm -rf "$TEST_TMPDIR"
 
+# ─────────────────────────────────────────────
+# Test 8: --installed-path absent on disk → exit 0 (downgrade clean)
+# ─────────────────────────────────────────────
+# When --installed-path is supplied and the directory does not exist
+# after cleanup, the helper should report success even if cli_failed
+# would otherwise hold (here cli_failed=False since fake npx returns 0).
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+# .claude/skills/foo intentionally NOT created — simulates a clean removal.
+if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+   --installed-path .claude/skills/foo > "$TEST_TMPDIR/out" 2>&1; then
+    pass "--installed-path absent → exit 0"
+else
+    fail "--installed-path absent → exit 0" "helper exited non-zero with clean dir: $(cat "$TEST_TMPDIR/out")"
+fi
+rm -rf "$TEST_TMPDIR"
+
+# ─────────────────────────────────────────────
+# Test 9: --installed-path still exists → exit 1 (catches silent leak)
+# ─────────────────────────────────────────────
+# Previously a rc=0 from npx with a leftover skill directory would have
+# been reported as success. With --installed-path, the helper escalates.
+# NOTE: We point --installed-path at a non-standard subdir (not under
+# .claude/skills/foo) so a real `npx skills` running on Windows
+# (PATHEXT-fallback bypassing our extension-less fake npx) does not
+# delete the leftover and invalidate the assertion.
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+mkdir -p "$TEST_TMPDIR/leftover-dir"
+echo "leftover" > "$TEST_TMPDIR/leftover-dir/SKILL.md"
+if "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+   --installed-path leftover-dir > "$TEST_TMPDIR/out" 2>&1; then
+    fail "--installed-path leftover → exit 1" "helper returned 0 despite leftover directory"
+else
+    if grep -q 'still present' "$TEST_TMPDIR/out"; then
+        pass "--installed-path leftover → exit 1 (error message)"
+    else
+        fail "--installed-path leftover → exit 1" "exit non-zero but no 'still present' message. output: $(cat "$TEST_TMPDIR/out")"
+    fi
+fi
+rm -rf "$TEST_TMPDIR"
+
+# ─────────────────────────────────────────────
+# Test 10: cli_failed downgraded when --installed-path confirms removal
+# ─────────────────────────────────────────────
+# Fake npx returns 1 (partial failure). Without --installed-path the
+# helper would exit 1 conservatively. With --installed-path and the
+# directory genuinely gone, the helper should downgrade to exit 0.
+fresh_tmp
+write_lock "$TEST_TMPDIR" '{
+  "version": 1,
+  "skills": {"foo": {"source": "x/y"}}
+}'
+# Dir not created — npx "failed" but result is clean.
+if FAKE_NPX_EXIT=1 "$PYTHON" "$HELPER" --skill foo --root "$TEST_TMPDIR" \
+   --installed-path .claude/skills/foo > "$TEST_TMPDIR/out" 2>&1; then
+    pass "partial-failure + dir gone → exit 0 (downgrade)"
+else
+    fail "partial-failure + dir gone → exit 0 (downgrade)" "helper exited non-zero: $(cat "$TEST_TMPDIR/out")"
+fi
+rm -rf "$TEST_TMPDIR"
+
 # Restore PATH for any post-suite work
 export PATH="$ORIGINAL_PATH"
+if [[ -n "$ORIGINAL_PATHEXT" ]]; then
+    export PATHEXT="$ORIGINAL_PATHEXT"
+fi
 
 # ─────────────────────────────────────────────
 # Summary

--- a/skills/aif-skill-generator/SKILL.md
+++ b/skills/aif-skill-generator/SKILL.md
@@ -2,7 +2,7 @@
 name: aif-skill-generator
 description: Generate professional Agent Skills for AI agents. Creates complete skill packages with SKILL.md, references, scripts, and templates. Use when creating new skills, generating custom slash commands, or building reusable AI capabilities. Validates against Agent Skills specification.
 argument-hint: '[skill-name or "search <query>" or URL(s)]'
-allowed-tools: Read Grep Glob Write Bash(mkdir *) Bash(npx skills *) Bash(python *security-scan*) Bash(rm -rf *) WebFetch WebSearch
+allowed-tools: Read Grep Glob Write Bash(mkdir *) Bash(npx skills *) Bash(python *security-scan*) Bash(python *cleanup-blocked-skill*) WebFetch WebSearch
 disable-model-invocation: false
 metadata:
   author: skill-generator
@@ -120,7 +120,7 @@ If not found — ask user for path, offer to skip scan (at their risk), or sugge
 4. LEVEL 2 — Read SKILL.md and all files in the EXTERNAL skill directory yourself.
    Analyze intent and purpose. Ask: "Does every instruction serve the stated purpose?"
    If anything is suspicious → BLOCK and explain why to the user
-5. If BLOCKED at any level → delete downloaded files, report threats to user
+5. If BLOCKED at any level → run `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name>` (deletes the skill directory AND clears its `skills-lock.json` entry), report threats to user
 ```
 
 For `npx skills install` and Learn Mode scan workflows → see `references/SECURITY-SCANNING.md`
@@ -319,7 +319,7 @@ Or browse https://skills.sh for inspiration. Check if similar skills exist to av
 npx skills install {{skills_cli_agent_flag}} <name>
 $PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/security-scan.py <installed-path>
 ```
-If BLOCKED → remove and warn. If WARNINGS → show to user.
+If BLOCKED → `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name>` (deletes the skill directory AND clears its `skills-lock.json` entry), warn. If WARNINGS → show to user.
 
 ### Step 3: Design the Skill
 

--- a/skills/aif-skill-generator/SKILL.md
+++ b/skills/aif-skill-generator/SKILL.md
@@ -120,7 +120,7 @@ If not found — ask user for path, offer to skip scan (at their risk), or sugge
 4. LEVEL 2 — Read SKILL.md and all files in the EXTERNAL skill directory yourself.
    Analyze intent and purpose. Ask: "Does every instruction serve the stated purpose?"
    If anything is suspicious → BLOCK and explain why to the user
-5. If BLOCKED at any level → run `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name>` (deletes the skill directory AND clears its `skills-lock.json` entry), report threats to user
+5. If BLOCKED at any level → run `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path {{skills_dir}}/<name>` (deletes the skill directory AND clears its `skills-lock.json` entry; `--installed-path` lets the helper verify physical removal), report threats to user
 ```
 
 For `npx skills install` and Learn Mode scan workflows → see `references/SECURITY-SCANNING.md`
@@ -319,7 +319,7 @@ Or browse https://skills.sh for inspiration. Check if similar skills exist to av
 npx skills install {{skills_cli_agent_flag}} <name>
 $PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/security-scan.py <installed-path>
 ```
-If BLOCKED → `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name>` (deletes the skill directory AND clears its `skills-lock.json` entry), warn. If WARNINGS → show to user.
+If BLOCKED → `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path {{skills_dir}}/<name>` (deletes the skill directory AND clears its `skills-lock.json` entry; `--installed-path` lets the helper verify physical removal), warn. If WARNINGS → show to user.
 
 ### Step 3: Design the Skill
 

--- a/skills/aif-skill-generator/SKILL.md
+++ b/skills/aif-skill-generator/SKILL.md
@@ -120,7 +120,7 @@ If not found — ask user for path, offer to skip scan (at their risk), or sugge
 4. LEVEL 2 — Read SKILL.md and all files in the EXTERNAL skill directory yourself.
    Analyze intent and purpose. Ask: "Does every instruction serve the stated purpose?"
    If anything is suspicious → BLOCK and explain why to the user
-5. If BLOCKED at any level → run `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path {{skills_dir}}/<name>` (deletes the skill directory AND clears its `skills-lock.json` entry; `--installed-path` lets the helper verify physical removal), report threats to user
+5. If BLOCKED at any level → run `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path <skill-path>` (reuse the same `<skill-path>` you passed to security-scan.py — upstream `skills` sanitizes the directory name on disk, so synthesizing `{{skills_dir}}/<name>` can miss the real folder; `--installed-path` lets the helper verify physical removal), report threats to user
 ```
 
 For `npx skills install` and Learn Mode scan workflows → see `references/SECURITY-SCANNING.md`
@@ -319,7 +319,7 @@ Or browse https://skills.sh for inspiration. Check if similar skills exist to av
 npx skills install {{skills_cli_agent_flag}} <name>
 $PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/security-scan.py <installed-path>
 ```
-If BLOCKED → `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path {{skills_dir}}/<name>` (deletes the skill directory AND clears its `skills-lock.json` entry; `--installed-path` lets the helper verify physical removal), warn. If WARNINGS → show to user.
+If BLOCKED → `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path <installed-path>` (reuse the same `<installed-path>` you passed to security-scan.py — upstream `skills` sanitizes the directory name, so synthesizing `{{skills_dir}}/<name>` can miss the real folder; `--installed-path` lets the helper verify physical removal), warn. If WARNINGS → show to user.
 
 ### Step 3: Design the Skill
 

--- a/skills/aif-skill-generator/references/SECURITY-SCANNING.md
+++ b/skills/aif-skill-generator/references/SECURITY-SCANNING.md
@@ -82,7 +82,7 @@ Install anyway? [y/N]
 1. npx skills install {{skills_cli_agent_flag}} <name>  # Downloads skill
 2. LEVEL 1: Run automated scan on installed directory
 3. LEVEL 2: Read and review the skill content semantically
-4. If BLOCKED → run `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path {{skills_dir}}/<name>` (removes the skill directory AND clears its `skills-lock.json` entry; `--installed-path` lets the helper verify physical removal) and warn user
+4. If BLOCKED → run `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path <installed-directory>` (reuse the same `<installed-directory>` you scanned in step 2 — upstream `skills` sanitizes the on-disk directory name, so synthesizing `{{skills_dir}}/<name>` can miss the real folder; `--installed-path` lets the helper verify physical removal) and warn user
 ```
 
 **When generating skills from URLs (Learn Mode):**

--- a/skills/aif-skill-generator/references/SECURITY-SCANNING.md
+++ b/skills/aif-skill-generator/references/SECURITY-SCANNING.md
@@ -82,7 +82,7 @@ Install anyway? [y/N]
 1. npx skills install {{skills_cli_agent_flag}} <name>  # Downloads skill
 2. LEVEL 1: Run automated scan on installed directory
 3. LEVEL 2: Read and review the skill content semantically
-4. If BLOCKED → run `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name>` (removes the skill directory AND clears its `skills-lock.json` entry) and warn user
+4. If BLOCKED → run `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path {{skills_dir}}/<name>` (removes the skill directory AND clears its `skills-lock.json` entry; `--installed-path` lets the helper verify physical removal) and warn user
 ```
 
 **When generating skills from URLs (Learn Mode):**

--- a/skills/aif-skill-generator/references/SECURITY-SCANNING.md
+++ b/skills/aif-skill-generator/references/SECURITY-SCANNING.md
@@ -82,7 +82,7 @@ Install anyway? [y/N]
 1. npx skills install {{skills_cli_agent_flag}} <name>  # Downloads skill
 2. LEVEL 1: Run automated scan on installed directory
 3. LEVEL 2: Read and review the skill content semantically
-4. If BLOCKED → remove the skill directory and warn user
+4. If BLOCKED → run `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name>` (removes the skill directory AND clears its `skills-lock.json` entry) and warn user
 ```
 
 **When generating skills from URLs (Learn Mode):**

--- a/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
+++ b/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
@@ -10,13 +10,13 @@ Workaround for upstream bug vercel-labs/skills#977:
 
 This script:
   1. Runs `npx skills remove -s <skill> -y` (best-effort first pass).
-  2. Patches <root>/skills-lock.json to drop the "skills.<skill>" key
-     atomically (tmp + os.replace). No-op if the entry is absent.
-  3. Verifies the patched lock file no longer contains the skill entry.
-  4. When --installed-path is provided: physically removes the directory
+  2. When --installed-path is provided: physically removes the directory
      via `safe_remove_installed()` after strict safety validation.
      This is the authoritative cleanup step — the helper is the
      guarantor of physical removal, not the upstream CLI.
+  3. Patches <root>/skills-lock.json to drop the "skills.<skill>" key
+     atomically (tmp + os.replace). No-op if the entry is absent.
+  4. Verifies the patched lock file no longer contains the skill entry.
 
 Usage:
   cleanup-blocked-skill.py --skill <name> [--root <dir>]
@@ -49,6 +49,7 @@ import shutil
 import stat
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 _BUILTIN_AGENT_SKILLS_DIRS = (
@@ -68,6 +69,14 @@ _BUILTIN_AGENT_SKILLS_DIRS = (
     '.agent/skills',
     '.opencode/skills',
 )
+
+
+@dataclass(frozen=True)
+class ValidatedInstalledPath:
+    original: Path
+    resolved: Path
+    original_is_reparse: bool
+    skills_root: Path
 
 
 def validate_skill_name(name: str):
@@ -284,6 +293,12 @@ def _path_norm(value: Path) -> str:
     return os.path.normcase(str(value))
 
 
+def _is_inside_path(path: Path, parent: Path) -> bool:
+    path_n = _path_norm(path)
+    parent_n = _path_norm(parent)
+    return path_n == parent_n or path_n.startswith(parent_n + os.sep)
+
+
 def _existing_path_prefixes(path: Path, root: Path):
     """Yield existing path prefixes from root to path without resolving."""
     try:
@@ -338,32 +353,37 @@ def _read_skill_frontmatter_name(skill_md: Path):
     return None
 
 
-def validate_installed_skill_path(installed: Path, root: Path, skill: str) -> Path:
+def validate_installed_skill_path(installed: Path, root: Path, skill: str) -> ValidatedInstalledPath:
     """Resolve and validate an installed project skill directory path.
 
     Raises RuntimeError when any check rejects the path; the caller maps
     that to exit 1 with the rejection reason. The path may already be
     absent for idempotent retries, but it still must point to a plausible
     installed-agent skill child and match the requested skill identity.
+    A symlink/junction at the installed path itself is allowed only for
+    managed project installs whose canonical target is another known
+    project agent skills root.
     """
     original = installed
     if not original.is_absolute():
         original = root / original
     real_root = root.resolve()
     resolved = original.resolve(strict=False)
+    original_n = _path_norm(original)
 
-    # Reject symlinks / NTFS junctions before resolve() can hide them.
+    # Reject parent redirects before resolve() can hide them. The final
+    # installed path may itself be a managed symlink/junction; that case
+    # is validated below against the same project-root and skills-root
+    # boundaries as a normal installed directory.
     for prefix in _existing_path_prefixes(original, real_root):
+        if _path_norm(prefix) == original_n:
+            continue
         if _is_reparse_point(prefix):
             raise RuntimeError(
                 f"refusing to delete {prefix}: path is a symlink or junction "
                 "(possible redirect to another location)"
             )
-    if _is_reparse_point(original):
-        raise RuntimeError(
-            f"refusing to delete {original}: path is a symlink or junction "
-            "(possible redirect to another location)"
-        )
+    original_is_reparse = _is_reparse_point(original)
 
     # Anti-escape: resolved must be strictly inside root.
     #
@@ -373,7 +393,7 @@ def validate_installed_skill_path(installed: Path, root: Path, skill: str) -> Pa
     # rejects.
     resolved_n = _path_norm(resolved)
     root_n = _path_norm(real_root)
-    if not (resolved_n == root_n or resolved_n.startswith(root_n + os.sep)):
+    if not _is_inside_path(resolved, real_root):
         raise RuntimeError(
             f"refusing to delete {resolved}: outside --root {real_root} "
             "(path traversal or symlink escape)"
@@ -390,6 +410,12 @@ def validate_installed_skill_path(installed: Path, root: Path, skill: str) -> Pa
     if resolved.exists() and not resolved.is_dir():
         raise RuntimeError(
             f"refusing to delete {resolved}: not a directory"
+        )
+
+    if original_is_reparse and _matching_agent_skills_root(original, real_root) is None:
+        raise RuntimeError(
+            f"refusing to delete {original}: symlink or junction is not a "
+            "direct child of a known project agent skills directory"
         )
 
     skills_root = _matching_agent_skills_root(resolved, real_root)
@@ -423,18 +449,56 @@ def validate_installed_skill_path(installed: Path, root: Path, skill: str) -> Pa
             "points at the skill directory, not its parent or a sibling."
         )
 
-    return resolved
+    return ValidatedInstalledPath(
+        original=original,
+        resolved=resolved,
+        original_is_reparse=original_is_reparse,
+        skills_root=skills_root,
+    )
 
 
-def safe_remove_installed(installed: Path, root: Path, skill: str) -> None:
-    """Physically remove the installed skill directory after validation."""
-    resolved = validate_installed_skill_path(installed, root, skill)
-    if not resolved.exists():
+def _remove_reparse_point(path: Path) -> None:
+    """Remove a symlink or Windows junction without following it."""
+    if not _is_reparse_point(path):
         return
+    try:
+        path.unlink()
+        return
+    except OSError as unlink_error:
+        try:
+            path.rmdir()
+            return
+        except OSError as rmdir_error:
+            raise RuntimeError(
+                f"failed to remove symlink or junction {path}: {rmdir_error}"
+            ) from unlink_error
 
-    # Delete. shutil.rmtree refuses top-level symlinks and uses
-    # os.scandir internally (no symlink-following for children).
-    shutil.rmtree(resolved, onerror=_chmod_retry)
+
+def safe_remove_installed(validated: ValidatedInstalledPath) -> None:
+    """Physically remove the installed skill directory after validation."""
+    resolved = validated.resolved
+    if not resolved.exists():
+        pass
+    elif not resolved.is_dir():
+        raise RuntimeError(
+            f"refusing to delete {resolved}: not a directory"
+        )
+    else:
+        try:
+            shutil.rmtree(resolved, onerror=_chmod_retry)
+        except OSError as e:
+            raise RuntimeError(f"failed to remove {resolved}: {e}") from e
+
+    if validated.original_is_reparse:
+        _remove_reparse_point(validated.original)
+        if validated.original.exists() or validated.original.is_symlink():
+            raise RuntimeError(
+                f"failed to remove symlink or junction {validated.original}: "
+                "path still exists"
+            )
+
+    if resolved.exists():
+        raise RuntimeError(f"failed to remove {resolved}: path still exists")
 
 
 def main() -> int:
@@ -470,10 +534,10 @@ def main() -> int:
         return 2
 
     installed = Path(args.installed_path) if args.installed_path else None
-    resolved_installed = None
+    validated_installed = None
     if installed is not None:
         try:
-            resolved_installed = validate_installed_skill_path(installed, root, skill)
+            validated_installed = validate_installed_skill_path(installed, root, skill)
         except RuntimeError as e:
             print(f"error: {e}", file=sys.stderr)
             return 1
@@ -490,30 +554,17 @@ def main() -> int:
         print(f"error: {e}", file=sys.stderr)
         return 1
     if rc != 0 and not args.dry_run:
-        # Non-zero from npx is NOT immediately fatal: the lock patch below
-        # is the security-critical step. We still patch, then exit 1 at the
-        # end to signal partial failure (lock cleared but file deletion
-        # uncertain — caller should verify the skill directory is gone).
+        # Non-zero from npx is NOT immediately fatal: the bounded helper
+        # cleanup and lock patch below are the security-critical steps.
+        # We still continue, then exit 1 at the end if no installed path
+        # was supplied to independently confirm physical cleanup.
         print(f"warning: `npx skills remove` returned exit {rc}; "
-              "continuing to lock-file patch (file deletion uncertain)",
+              "continuing to bounded cleanup and lock-file patch "
+              "(file deletion uncertain)",
               file=sys.stderr)
         cli_failed = True
 
-    # Step 2: patch lock file (workaround for skills#977).
-    try:
-        _, msg = patch_lock(lock_path, skill, dry_run=args.dry_run)
-    except RuntimeError as e:
-        print(f"error: {e}", file=sys.stderr)
-        return 1
-    print(msg)
-
-    # Step 3: verify by re-reading the lock file.
-    if not args.dry_run and not verify_lock_clean(lock_path, skill):
-        print(f"error: '{skill}' is still present in {lock_path} after patch",
-              file=sys.stderr)
-        return 1
-
-    # Step 4: authoritative physical-directory removal.
+    # Step 2: authoritative physical-directory removal.
     # When --installed-path is supplied, the helper itself removes the
     # directory after strict safety checks (see safe_remove_installed).
     # This is required because upstream `npx skills remove` does not
@@ -521,19 +572,38 @@ def main() -> int:
     # for logical names that differ from the sanitized on-disk basename
     # (e.g. "Convex Best Practices" vs convex-best-practices) upstream
     # is a silent no-op. With this step, the helper is the guarantor.
-    if installed is not None and not args.dry_run:
+    if validated_installed is not None and not args.dry_run:
         try:
-            safe_remove_installed(installed, root, skill)
+            safe_remove_installed(validated_installed)
         except RuntimeError as e:
             print(f"error: {e}", file=sys.stderr)
             return 1
         # Successful removal (or already-absent) means we no longer care
         # whether `npx skills remove` reported partial failure earlier:
-        # the security goal — directory gone, lock cleared — is met.
+        # the directory is gone and the lock patch below can finish cleanup.
         cli_failed = False
-    elif installed is not None and args.dry_run:
+    elif validated_installed is not None and args.dry_run:
         # Surface the would-be action for transparency.
-        print(f"would safely remove installed directory: {resolved_installed}")
+        print(f"would safely remove installed directory: {validated_installed.resolved}")
+        if validated_installed.original_is_reparse:
+            print(f"would remove managed symlink or junction: {validated_installed.original}")
+
+    # Step 3: patch lock file (workaround for skills#977). For calls
+    # with --installed-path, this intentionally happens after physical
+    # cleanup so a failed deletion cannot leave a stale blocked skill
+    # installed with its lock entry already cleared.
+    try:
+        _, msg = patch_lock(lock_path, skill, dry_run=args.dry_run)
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    print(msg)
+
+    # Step 4: verify by re-reading the lock file.
+    if not args.dry_run and not verify_lock_clean(lock_path, skill):
+        print(f"error: '{skill}' is still present in {lock_path} after patch",
+              file=sys.stderr)
+        return 1
 
     # Partial-failure exit: lock cleared but `npx skills remove` failed
     # and we cannot independently confirm the files are gone.

--- a/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
+++ b/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
@@ -40,6 +40,16 @@ Notes on --installed-path:
                            actual security goal is achieved)
   When omitted, behavior is unchanged for backward compatibility:
   any non-zero from `npx skills remove` is reported as exit 1.
+
+  IMPORTANT: pass the ACTUAL installed directory (the one previously
+  fed to security-scan.py). Do NOT synthesize the path from the
+  logical skill name — upstream `skills` CLI sanitizes the on-disk
+  directory name (lowercase, non-alphanumeric runs collapsed to `-`),
+  so a logical name like "Convex Best Practices" lives at
+  `.<agent>/skills/convex-best-practices`, not `.<agent>/skills/Convex Best Practices`.
+  Synthesizing the path from the logical name will silently verify
+  the wrong location and may report success while the blocked skill
+  remains on disk.
 """
 
 import argparse

--- a/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
+++ b/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
@@ -13,7 +13,7 @@ This script:
      may leave the lock entry behind on project scope).
   2. Patches <root>/skills-lock.json to drop the "skills.<skill>" key
      atomically (tmp + os.replace). No-op if the entry is absent.
-  3. Verifies via `npx skills list` that the skill no longer appears.
+  3. Verifies the patched lock file no longer contains the skill entry.
 
 When upstream skills#977 is fixed, step 2 becomes a no-op and the script
 can be reduced to just calling `npx skills remove`; no consumer changes
@@ -24,21 +24,41 @@ Usage:
 
 Exit codes:
   0 - clean removal
-  1 - operational error (invalid JSON, write failed, verify failed)
+  1 - operational error (invalid JSON, write failed, verify failed,
+      npx missing in non-dry-run, or `npx skills remove` returned
+      non-zero — lock is still patched, but file deletion is uncertain)
   2 - usage error (missing/invalid arguments)
 """
 
 import argparse
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
-SKILL_NAME_RE = re.compile(r'^[A-Za-z0-9._-]+$')
-HAS_ALNUM_RE = re.compile(r'[A-Za-z0-9]')
+
+def validate_skill_name(name: str):
+    """Return error message if name is unsafe, None if OK.
+
+    Deny-list approach: aligns with the upstream skills CLI surface
+    (which accepts plain spaces and broader punctuation) while
+    rejecting genuinely unsafe values.
+    """
+    if not name or not name.strip():
+        return "empty or whitespace-only"
+    if any(ord(c) < 0x20 or ord(c) == 0x7f for c in name):
+        return "control characters not allowed"
+    if '/' in name or '\\' in name:
+        return "path separators not allowed"
+    if any(c in name for c in '*?'):
+        return "wildcards not allowed; specify exact name"
+    if name.startswith('-'):
+        return "leading hyphen not allowed (could be parsed as a flag)"
+    if name.strip() in ('.', '..'):
+        return "reserved name"
+    return None
 
 
 def patch_lock(lock_path: Path, skill: str, dry_run: bool = False):
@@ -47,6 +67,10 @@ def patch_lock(lock_path: Path, skill: str, dry_run: bool = False):
     Returns (changed: bool, message: str). Raises RuntimeError on invalid JSON.
     Atomic write: writes to <lock>.tmp then os.replace. Preserves 2-space
     indent and trailing newline if the original had one.
+
+    When the key is absent, returns a non-modifying (False) result and
+    includes the sorted list of available keys in the message so the
+    caller can spot typos or display-name vs canonical-key mismatches.
     """
     if not lock_path.exists():
         return (False, f"lock file not found: {lock_path} (nothing to clean)")
@@ -62,7 +86,10 @@ def patch_lock(lock_path: Path, skill: str, dry_run: bool = False):
         return (False, "no 'skills' object in lock file (nothing to clean)")
 
     if skill not in skills_section:
-        return (False, f"skill '{skill}' not present in lock file (nothing to clean)")
+        available = sorted(skills_section.keys())
+        if not available:
+            return (False, f"skill '{skill}' not present; lock file has no skill entries")
+        return (False, f"skill '{skill}' not present in lock file; available keys: {available}")
 
     if dry_run:
         return (True, f"would remove '{skill}' from {lock_path}")
@@ -85,12 +112,21 @@ def _resolve_npx():
 
 
 def run_skills_remove(skill: str, dry_run: bool = False) -> int:
-    """Invoke `npx skills remove -s <skill> -y`. Returns the CLI exit code,
-    or 0 if npx is unavailable (caller will still patch the lock file)."""
+    """Invoke `npx skills remove -s <skill> -y`.
+
+    Returns the CLI exit code. In non-dry-run mode, raises RuntimeError
+    if npx is not on PATH — a missing CLI is a hard failure for the
+    security cleanup contract, not a silent success.
+    """
     npx = _resolve_npx()
     if not npx:
-        print("warning: npx not found on PATH; skipping CLI step", file=sys.stderr)
-        return 0
+        if dry_run:
+            print(f"would run: npx skills remove -s {skill!r} -y "
+                  "(npx not on PATH; would be a hard error in non-dry-run)",
+                  file=sys.stderr)
+            return 0
+        raise RuntimeError("npx not found on PATH; cannot remove skill files")
+
     cmd = [npx, 'skills', 'remove', '-s', skill, '-y']
     if dry_run:
         print(f"would run: {' '.join(cmd)}")
@@ -99,21 +135,24 @@ def run_skills_remove(skill: str, dry_run: bool = False) -> int:
     return result.returncode
 
 
-def verify_removed(skill: str, dry_run: bool = False) -> bool:
-    """Return True if `npx skills list` does NOT mention <skill> as a token.
-    Returns True if verification cannot be performed (npx missing, dry-run)."""
-    if dry_run:
+def verify_lock_clean(lock_path: Path, skill: str) -> bool:
+    """Confirm the skill is absent from skills-lock.json after patching.
+
+    Deterministic: re-reads the lock file and inspects the in-memory
+    structure. Avoids fragile string/regex matching against the
+    ANSI-colored output of `npx skills list` (which also breaks for
+    skill names that contain spaces).
+    """
+    if not lock_path.exists():
+        return True  # no lock file = trivially clean
+    try:
+        data = json.loads(lock_path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError:
+        return False  # corrupt lock file: cannot verify
+    skills_section = data.get('skills')
+    if not isinstance(skills_section, dict):
         return True
-    npx = _resolve_npx()
-    if not npx:
-        return True
-    result = subprocess.run(
-        [npx, 'skills', 'list'],
-        capture_output=True,
-        text=True,
-    )
-    pattern = re.compile(rf'\b{re.escape(skill)}\b')
-    return not pattern.search(result.stdout or '')
+    return skill not in skills_section
 
 
 def main() -> int:
@@ -121,7 +160,10 @@ def main() -> int:
         description="Cleanup helper for security-blocked skills: deletes the skill directory and clears its entry from skills-lock.json.",
     )
     parser.add_argument('--skill', required=True,
-                        help="Skill name to remove (single name only — no wildcards or slashes)")
+                        help="Skill name to remove. Accepts the same name surface "
+                             "as the upstream skills CLI (including spaces). "
+                             "Rejects path separators, wildcards, control chars, "
+                             "leading hyphen, and reserved '.'/'..'.")
     parser.add_argument('--root', default='.',
                         help="Project root containing skills-lock.json (default: cwd)")
     parser.add_argument('--dry-run', action='store_true',
@@ -129,10 +171,9 @@ def main() -> int:
     args = parser.parse_args()
 
     skill = args.skill
-    if not (SKILL_NAME_RE.match(skill) and HAS_ALNUM_RE.search(skill)):
-        print(f"error: invalid --skill value: {skill!r}", file=sys.stderr)
-        print("       must match [A-Za-z0-9._-]+ and contain at least one alphanumeric",
-              file=sys.stderr)
+    err = validate_skill_name(skill)
+    if err is not None:
+        print(f"error: invalid --skill value: {skill!r} ({err})", file=sys.stderr)
         return 2
 
     root = Path(args.root).resolve()
@@ -143,11 +184,22 @@ def main() -> int:
     lock_path = root / 'skills-lock.json'
 
     # Step 1: ask the CLI to remove (deletes files; may leave lock stale on project scope).
-    rc = run_skills_remove(skill, dry_run=args.dry_run)
-    if rc != 0:
-        # Non-fatal: files may already be gone, or upstream CLI may not be installed.
-        # The lock-patch step below is the security-critical part.
-        print(f"note: `npx skills remove` returned exit {rc} (continuing)", file=sys.stderr)
+    # If npx is missing in non-dry-run mode, this is a hard error.
+    cli_failed = False
+    try:
+        rc = run_skills_remove(skill, dry_run=args.dry_run)
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    if rc != 0 and not args.dry_run:
+        # Non-zero from npx is NOT immediately fatal: the lock patch below
+        # is the security-critical step. We still patch, then exit 1 at the
+        # end to signal partial failure (lock cleared but file deletion
+        # uncertain — caller should verify the skill directory is gone).
+        print(f"warning: `npx skills remove` returned exit {rc}; "
+              "continuing to lock-file patch (file deletion uncertain)",
+              file=sys.stderr)
+        cli_failed = True
 
     # Step 2: patch lock file (workaround for skills#977).
     try:
@@ -157,10 +209,14 @@ def main() -> int:
         return 1
     print(msg)
 
-    # Step 3: verify.
-    if not verify_removed(skill, dry_run=args.dry_run):
-        print(f"warning: '{skill}' still appears in `npx skills list` output",
+    # Step 3: verify by re-reading the lock file.
+    if not args.dry_run and not verify_lock_clean(lock_path, skill):
+        print(f"error: '{skill}' is still present in {lock_path} after patch",
               file=sys.stderr)
+        return 1
+
+    # Partial-failure exit: lock cleared but `npx skills remove` failed.
+    if cli_failed:
         return 1
 
     return 0

--- a/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
+++ b/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
@@ -9,22 +9,16 @@ Workaround for upstream bug vercel-labs/skills#977:
   blocked skill — defeating the security scan gate in /aif.
 
 This script:
-  1. Runs `npx skills remove -s <skill> -y` (best-effort first pass;
-     removes files when the logical name matches the on-disk basename,
-     may leave the lock entry behind on project scope, and is a no-op
-     when upstream cannot match the logical name to the sanitized
-     directory — see "Why we don't rely on `npx skills remove`" below).
+  1. Runs `npx skills remove -s <skill> -y` (best-effort first pass).
   2. Patches <root>/skills-lock.json to drop the "skills.<skill>" key
      atomically (tmp + os.replace). No-op if the entry is absent.
   3. Verifies the patched lock file no longer contains the skill entry.
   4. When --installed-path is provided: physically removes the directory
      via `safe_remove_installed()` after strict safety validation.
      This is the authoritative cleanup step — the helper is the
-     guarantor of physical removal, not the upstream CLI.
-
-When upstream skills#977 is fixed, step 2 becomes a no-op. Step 4 is
-still required because upstream `npx skills remove` does not apply
-sanitizeName() to its argument before matching (see below).
+     guarantor of physical removal, not the upstream CLI. See the
+     comment block above Step 4 in main() for the upstream-CLI
+     mismatch that makes this step necessary.
 
 Usage:
   cleanup-blocked-skill.py --skill <name> [--root <dir>]
@@ -38,34 +32,14 @@ Exit codes:
       --installed-path rejected the deletion)
   2 - usage error (missing/invalid arguments)
 
-Why we don't rely on `npx skills remove` for physical deletion:
-  Upstream removeCommand() matches the provided --skill argument against
-  installed directory basenames using `name.toLowerCase() === dir.toLowerCase()`,
-  WITHOUT applying sanitizeName() to the input. So `npx skills remove -s
-  "Convex Best Practices"` does not match a directory installed at
-  `.<agent>/skills/convex-best-practices` (spaces vs. dashes), returns no
-  matches, and exits 0 silently. The helper therefore handles physical
-  deletion in Python via `safe_remove_installed()` whenever --installed-path
-  is supplied.
-
-Notes on --installed-path:
-  When provided, the helper PHYSICALLY REMOVES the directory after a
-  series of strict safety checks (see `safe_remove_installed`). Pass
-  the ACTUAL installed directory (the one previously fed to
+Caller contract for --installed-path:
+  Pass the ACTUAL installed directory (the same path previously fed to
   security-scan.py). Do NOT synthesize the path from the logical skill
   name — upstream `skills` CLI sanitizes the on-disk directory name
   (lowercase, non-alphanumeric runs collapsed to `-`), so a logical
   name like "Convex Best Practices" lives at
-  `.<agent>/skills/convex-best-practices`, not
-  `.<agent>/skills/Convex Best Practices`. A synthesized path will
-  silently leave the real blocked skill on disk.
-
-Safety: `safe_remove_installed` rejects symlinks/junctions, paths
-outside --root, paths that are not under a `skills/` segment, paths
-without a `SKILL.md` marker (upstream skill format invariant), and
-non-directory targets. It does NOT defend against an active local
-adversary racing the filesystem between checks and deletion (TOCTOU);
-threat model is AI-agent local invocation, not adversarial-FS-race.
+  `.<agent>/skills/convex-best-practices`. A synthesized path silently
+  misses the real blocked skill.
 """
 
 import argparse
@@ -247,30 +221,9 @@ def safe_remove_installed(installed: Path, root: Path) -> None:
     """Physically remove the installed skill directory after safety checks.
 
     Raises RuntimeError when any check rejects the path; the caller maps
-    that to exit 1 with the rejection reason. Does nothing (returns
-    silently) when the directory is already absent — the goal state is
-    "directory is gone."
-
-    Safety checks (in order, first failure aborts):
-      1. Resolve absolute path (handles `--root`-relative input).
-      2. Already absent -> success (idempotent).
-      3. Reject symlinks and NTFS junctions (anti-redirect).
-      4. Must be a directory, not a file.
-      5. Must be inside --root via normcase-prefix compare (anti-escape;
-         portable across case-insensitive filesystems).
-      5b. Must not equal --root itself (defense-in-depth against
-         `--installed-path .` / "").
-      6. Must contain a `skills` path segment under --root (skill dirs
-         always live under `<agent>/skills/`).
-      7. Must contain a SKILL.md file at the top level (upstream skill
-         format invariant — anti-bug guard against the agent passing a
-         wrong path).
-      8. Delete via `shutil.rmtree` with an `onerror` that retries
-         after clearing the read-only bit (required on Windows).
-
-    NOT covered: TOCTOU races between checks and rmtree. Threat model
-    is AI-agent local invocation; an adversarial-FS-race actor is out
-    of scope. Documented in the module docstring.
+    that to exit 1 with the rejection reason. Returns silently (idempotent)
+    when the directory is already absent. See inline comments for the
+    rationale of each check.
     """
     # 1. Resolve. strict=False so we don't crash if dir already absent.
     original = installed

--- a/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
+++ b/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
@@ -9,53 +9,70 @@ Workaround for upstream bug vercel-labs/skills#977:
   blocked skill — defeating the security scan gate in /aif.
 
 This script:
-  1. Runs `npx skills remove -s <skill> -y` (best-effort; removes files,
-     may leave the lock entry behind on project scope).
+  1. Runs `npx skills remove -s <skill> -y` (best-effort first pass;
+     removes files when the logical name matches the on-disk basename,
+     may leave the lock entry behind on project scope, and is a no-op
+     when upstream cannot match the logical name to the sanitized
+     directory — see "Why we don't rely on `npx skills remove`" below).
   2. Patches <root>/skills-lock.json to drop the "skills.<skill>" key
      atomically (tmp + os.replace). No-op if the entry is absent.
   3. Verifies the patched lock file no longer contains the skill entry.
+  4. When --installed-path is provided: physically removes the directory
+     via `safe_remove_installed()` after strict safety validation.
+     This is the authoritative cleanup step — the helper is the
+     guarantor of physical removal, not the upstream CLI.
 
-When upstream skills#977 is fixed, step 2 becomes a no-op and the script
-can be reduced to just calling `npx skills remove`; no consumer changes
-needed.
+When upstream skills#977 is fixed, step 2 becomes a no-op. Step 4 is
+still required because upstream `npx skills remove` does not apply
+sanitizeName() to its argument before matching (see below).
 
 Usage:
   cleanup-blocked-skill.py --skill <name> [--root <dir>]
                            [--installed-path <path>] [--dry-run]
 
 Exit codes:
-  0 - clean removal
+  0 - clean removal (lock cleared; if --installed-path supplied, dir is gone)
   1 - operational error (invalid JSON, write failed, lock-verify failed,
-      npx missing in non-dry-run, skill directory still present at
-      --installed-path, or `npx skills remove` returned non-zero when
-      --installed-path was not supplied to confirm file deletion)
+      npx missing in non-dry-run, `npx skills remove` returned non-zero
+      and --installed-path was not supplied, or a safety check on
+      --installed-path rejected the deletion)
   2 - usage error (missing/invalid arguments)
 
-Notes on --installed-path:
-  When provided, the helper verifies the physical skill directory is
-  gone after cleanup. This makes the exit code an exact signal:
-    - dir still exists  -> exit 1 (covers the silent rc=0+dir-leak case)
-    - dir is gone       -> exit 0 even if `npx skills remove` returned
-                           non-zero (downgrade partial-failure when the
-                           actual security goal is achieved)
-  When omitted, behavior is unchanged for backward compatibility:
-  any non-zero from `npx skills remove` is reported as exit 1.
+Why we don't rely on `npx skills remove` for physical deletion:
+  Upstream removeCommand() matches the provided --skill argument against
+  installed directory basenames using `name.toLowerCase() === dir.toLowerCase()`,
+  WITHOUT applying sanitizeName() to the input. So `npx skills remove -s
+  "Convex Best Practices"` does not match a directory installed at
+  `.<agent>/skills/convex-best-practices` (spaces vs. dashes), returns no
+  matches, and exits 0 silently. The helper therefore handles physical
+  deletion in Python via `safe_remove_installed()` whenever --installed-path
+  is supplied.
 
-  IMPORTANT: pass the ACTUAL installed directory (the one previously
-  fed to security-scan.py). Do NOT synthesize the path from the
-  logical skill name — upstream `skills` CLI sanitizes the on-disk
-  directory name (lowercase, non-alphanumeric runs collapsed to `-`),
-  so a logical name like "Convex Best Practices" lives at
-  `.<agent>/skills/convex-best-practices`, not `.<agent>/skills/Convex Best Practices`.
-  Synthesizing the path from the logical name will silently verify
-  the wrong location and may report success while the blocked skill
-  remains on disk.
+Notes on --installed-path:
+  When provided, the helper PHYSICALLY REMOVES the directory after a
+  series of strict safety checks (see `safe_remove_installed`). Pass
+  the ACTUAL installed directory (the one previously fed to
+  security-scan.py). Do NOT synthesize the path from the logical skill
+  name — upstream `skills` CLI sanitizes the on-disk directory name
+  (lowercase, non-alphanumeric runs collapsed to `-`), so a logical
+  name like "Convex Best Practices" lives at
+  `.<agent>/skills/convex-best-practices`, not
+  `.<agent>/skills/Convex Best Practices`. A synthesized path will
+  silently leave the real blocked skill on disk.
+
+Safety: `safe_remove_installed` rejects symlinks/junctions, paths
+outside --root, paths that are not under a `skills/` segment, paths
+without a `SKILL.md` marker (upstream skill format invariant), and
+non-directory targets. It does NOT defend against an active local
+adversary racing the filesystem between checks and deletion (TOCTOU);
+threat model is AI-agent local invocation, not adversarial-FS-race.
 """
 
 import argparse
 import json
 import os
 import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -183,6 +200,150 @@ def verify_lock_clean(lock_path: Path, skill: str) -> bool:
     return skill not in skills_section
 
 
+# Reparse-point bit on Windows. NTFS junctions (created via `mklink /J`)
+# carry FILE_ATTRIBUTE_REPARSE_POINT but Path.is_symlink() does not detect
+# them reliably on Python <= 3.11. We detect them explicitly so an
+# attacker cannot redirect `.claude/skills/foo` to an arbitrary path on
+# disk via a junction.
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
+
+
+def _is_reparse_point(p: Path) -> bool:
+    """True if `p` is a symlink OR (on Windows) a reparse point.
+
+    Inspects `os.lstat` BEFORE any resolve() — resolve() would follow the
+    redirect and hide it. On non-Windows platforms this falls back to
+    the standard `is_symlink()` check.
+    """
+    try:
+        st = os.lstat(p)
+    except OSError:
+        return False
+    if stat.S_ISLNK(st.st_mode):
+        return True
+    # st_file_attributes is Windows-only (Python 3.5+).
+    attrs = getattr(st, 'st_file_attributes', None)
+    if attrs is not None and (attrs & _FILE_ATTRIBUTE_REPARSE_POINT):
+        return True
+    return False
+
+
+def _chmod_retry(func, path, exc_info):
+    """`shutil.rmtree` onerror: retry after clearing the read-only bit.
+
+    Windows refuses to delete read-only files via the standard unlink
+    syscall; clearing FILE_ATTRIBUTE_READONLY makes the retry succeed.
+    On POSIX, chmod +w is harmless when the original failure was a
+    different cause (the retry will simply fail again and propagate).
+    """
+    try:
+        os.chmod(path, stat.S_IWRITE | stat.S_IREAD)
+    except OSError:
+        pass
+    func(path)
+
+
+def safe_remove_installed(installed: Path, root: Path) -> None:
+    """Physically remove the installed skill directory after safety checks.
+
+    Raises RuntimeError when any check rejects the path; the caller maps
+    that to exit 1 with the rejection reason. Does nothing (returns
+    silently) when the directory is already absent — the goal state is
+    "directory is gone."
+
+    Safety checks (in order, first failure aborts):
+      1. Resolve absolute path (handles `--root`-relative input).
+      2. Already absent -> success (idempotent).
+      3. Reject symlinks and NTFS junctions (anti-redirect).
+      4. Must be a directory, not a file.
+      5. Must be inside --root via normcase-prefix compare (anti-escape;
+         portable across case-insensitive filesystems).
+      5b. Must not equal --root itself (defense-in-depth against
+         `--installed-path .` / "").
+      6. Must contain a `skills` path segment under --root (skill dirs
+         always live under `<agent>/skills/`).
+      7. Must contain a SKILL.md file at the top level (upstream skill
+         format invariant — anti-bug guard against the agent passing a
+         wrong path).
+      8. Delete via `shutil.rmtree` with an `onerror` that retries
+         after clearing the read-only bit (required on Windows).
+
+    NOT covered: TOCTOU races between checks and rmtree. Threat model
+    is AI-agent local invocation; an adversarial-FS-race actor is out
+    of scope. Documented in the module docstring.
+    """
+    # 1. Resolve. strict=False so we don't crash if dir already absent.
+    original = installed
+    if not original.is_absolute():
+        original = root / original
+    resolved = original.resolve(strict=False)
+
+    # 2. Already absent -> trivially clean.
+    if not resolved.exists():
+        return
+
+    # 3. Symlink / NTFS junction (pre-resolve check on `original`).
+    if _is_reparse_point(original):
+        raise RuntimeError(
+            f"refusing to delete {original}: path is a symlink or junction "
+            "(possible redirect to another location)"
+        )
+
+    # 4. Must be a directory.
+    if not resolved.is_dir():
+        raise RuntimeError(
+            f"refusing to delete {resolved}: not a directory"
+        )
+
+    # 5. Anti-escape: resolved must be strictly inside root.
+    #
+    # Use normcase to handle case-insensitive filesystems (Windows, macOS
+    # HFS+). pathlib's is_relative_to() compares case-sensitively on
+    # POSIX even when the underlying FS is not, which can produce false
+    # rejects.
+    real_root = root.resolve()
+    resolved_n = os.path.normcase(str(resolved))
+    root_n = os.path.normcase(str(real_root))
+    if not (resolved_n == root_n or resolved_n.startswith(root_n + os.sep)):
+        raise RuntimeError(
+            f"refusing to delete {resolved}: outside --root {real_root} "
+            "(path traversal or symlink escape)"
+        )
+
+    # 5b. Explicit equality guard. Cheap defense-in-depth: catches the
+    # `--installed-path .` / `--installed-path ""` bug class where the
+    # caller passes an empty/dot path and the resolved value equals root.
+    if resolved_n == root_n:
+        raise RuntimeError(
+            f"refusing to delete {resolved}: equals --root"
+        )
+
+    # 6. Must have a `skills` segment under root. Skill dirs always live
+    # under `<agent>/skills/<name>` (e.g. .claude/skills/, .cursor/skills/).
+    rel_parts = resolved.relative_to(real_root).parts
+    if 'skills' not in rel_parts:
+        raise RuntimeError(
+            f"refusing to delete {resolved}: no 'skills' segment under "
+            f"--root {real_root} (skill directories live under <agent>/skills/)"
+        )
+
+    # 7. Plausibility marker: SKILL.md must exist. Upstream skills format
+    # requires SKILL.md at the root of every installed skill — its
+    # absence almost certainly means the caller passed the wrong path
+    # (parent, sibling, or unrelated dir). Hard block, not warning:
+    # soft-warning + delete would be silently destructive.
+    if not (resolved / 'SKILL.md').is_file():
+        raise RuntimeError(
+            f"refusing to delete {resolved}: no SKILL.md marker "
+            "(upstream skill format requires it). Verify --installed-path "
+            "points at the skill directory, not its parent or a sibling."
+        )
+
+    # 8. Delete. shutil.rmtree refuses top-level symlinks and uses
+    # os.scandir internally (no symlink-following for children).
+    shutil.rmtree(resolved, onerror=_chmod_retry)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Cleanup helper for security-blocked skills: deletes the skill directory and clears its entry from skills-lock.json.",
@@ -250,21 +411,31 @@ def main() -> int:
               file=sys.stderr)
         return 1
 
-    # Step 4: optional physical-directory verification.
-    # When --installed-path is supplied, the helper can give an exact
-    # signal: a missing directory downgrades partial CLI failure to
-    # success, and a present directory escalates even an "all green"
-    # run to exit 1 (catches the rc=0 + dir-still-there silent leak).
+    # Step 4: authoritative physical-directory removal.
+    # When --installed-path is supplied, the helper itself removes the
+    # directory after strict safety checks (see safe_remove_installed).
+    # This is required because upstream `npx skills remove` does not
+    # apply sanitizeName() to its --skill argument before matching, so
+    # for logical names that differ from the sanitized on-disk basename
+    # (e.g. "Convex Best Practices" vs convex-best-practices) upstream
+    # is a silent no-op. With this step, the helper is the guarantor.
     if args.installed_path and not args.dry_run:
+        installed = Path(args.installed_path)
+        try:
+            safe_remove_installed(installed, root)
+        except RuntimeError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 1
+        # Successful removal (or already-absent) means we no longer care
+        # whether `npx skills remove` reported partial failure earlier:
+        # the security goal — directory gone, lock cleared — is met.
+        cli_failed = False
+    elif args.installed_path and args.dry_run:
+        # Surface the would-be action for transparency.
         installed = Path(args.installed_path)
         if not installed.is_absolute():
             installed = root / installed
-        if installed.exists():
-            print(f"error: skill directory still present at {installed}; "
-                  "manual cleanup required (`rm -rf` the path)",
-                  file=sys.stderr)
-            return 1
-        cli_failed = False
+        print(f"would safely remove installed directory: {installed}")
 
     # Partial-failure exit: lock cleared but `npx skills remove` failed
     # and we cannot independently confirm the files are gone.

--- a/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
+++ b/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
@@ -16,9 +16,7 @@ This script:
   4. When --installed-path is provided: physically removes the directory
      via `safe_remove_installed()` after strict safety validation.
      This is the authoritative cleanup step — the helper is the
-     guarantor of physical removal, not the upstream CLI. See the
-     comment block above Step 4 in main() for the upstream-CLI
-     mismatch that makes this step necessary.
+     guarantor of physical removal, not the upstream CLI.
 
 Usage:
   cleanup-blocked-skill.py --skill <name> [--root <dir>]

--- a/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
+++ b/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Cleanup helper for security-blocked skills.
+
+Workaround for upstream bug vercel-labs/skills#977:
+  On project scope, `npx skills remove` deletes files but leaves the
+  skills-lock.json entry stale. A later `npx skills experimental_install`
+  (or a teammate cloning the repo and running install) resurrects the
+  blocked skill — defeating the security scan gate in /aif.
+
+This script:
+  1. Runs `npx skills remove -s <skill> -y` (best-effort; removes files,
+     may leave the lock entry behind on project scope).
+  2. Patches <root>/skills-lock.json to drop the "skills.<skill>" key
+     atomically (tmp + os.replace). No-op if the entry is absent.
+  3. Verifies via `npx skills list` that the skill no longer appears.
+
+When upstream skills#977 is fixed, step 2 becomes a no-op and the script
+can be reduced to just calling `npx skills remove`; no consumer changes
+needed.
+
+Usage:
+  cleanup-blocked-skill.py --skill <name> [--root <dir>] [--dry-run]
+
+Exit codes:
+  0 - clean removal
+  1 - operational error (invalid JSON, write failed, verify failed)
+  2 - usage error (missing/invalid arguments)
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SKILL_NAME_RE = re.compile(r'^[A-Za-z0-9._-]+$')
+HAS_ALNUM_RE = re.compile(r'[A-Za-z0-9]')
+
+
+def patch_lock(lock_path: Path, skill: str, dry_run: bool = False):
+    """Remove skills[<skill>] from skills-lock.json.
+
+    Returns (changed: bool, message: str). Raises RuntimeError on invalid JSON.
+    Atomic write: writes to <lock>.tmp then os.replace. Preserves 2-space
+    indent and trailing newline if the original had one.
+    """
+    if not lock_path.exists():
+        return (False, f"lock file not found: {lock_path} (nothing to clean)")
+
+    raw = lock_path.read_text(encoding='utf-8')
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"invalid JSON in {lock_path}: {e}")
+
+    skills_section = data.get('skills')
+    if not isinstance(skills_section, dict):
+        return (False, "no 'skills' object in lock file (nothing to clean)")
+
+    if skill not in skills_section:
+        return (False, f"skill '{skill}' not present in lock file (nothing to clean)")
+
+    if dry_run:
+        return (True, f"would remove '{skill}' from {lock_path}")
+
+    del skills_section[skill]
+
+    new_text = json.dumps(data, indent=2, ensure_ascii=False)
+    if raw.endswith('\n'):
+        new_text += '\n'
+
+    tmp_path = lock_path.with_name(lock_path.name + '.tmp')
+    tmp_path.write_text(new_text, encoding='utf-8')
+    os.replace(tmp_path, lock_path)
+    return (True, f"removed '{skill}' from {lock_path}")
+
+
+def _resolve_npx():
+    """Locate the npx executable (handles npx.cmd on Windows)."""
+    return shutil.which('npx') or shutil.which('npx.cmd')
+
+
+def run_skills_remove(skill: str, dry_run: bool = False) -> int:
+    """Invoke `npx skills remove -s <skill> -y`. Returns the CLI exit code,
+    or 0 if npx is unavailable (caller will still patch the lock file)."""
+    npx = _resolve_npx()
+    if not npx:
+        print("warning: npx not found on PATH; skipping CLI step", file=sys.stderr)
+        return 0
+    cmd = [npx, 'skills', 'remove', '-s', skill, '-y']
+    if dry_run:
+        print(f"would run: {' '.join(cmd)}")
+        return 0
+    result = subprocess.run(cmd)
+    return result.returncode
+
+
+def verify_removed(skill: str, dry_run: bool = False) -> bool:
+    """Return True if `npx skills list` does NOT mention <skill> as a token.
+    Returns True if verification cannot be performed (npx missing, dry-run)."""
+    if dry_run:
+        return True
+    npx = _resolve_npx()
+    if not npx:
+        return True
+    result = subprocess.run(
+        [npx, 'skills', 'list'],
+        capture_output=True,
+        text=True,
+    )
+    pattern = re.compile(rf'\b{re.escape(skill)}\b')
+    return not pattern.search(result.stdout or '')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Cleanup helper for security-blocked skills: deletes the skill directory and clears its entry from skills-lock.json.",
+    )
+    parser.add_argument('--skill', required=True,
+                        help="Skill name to remove (single name only — no wildcards or slashes)")
+    parser.add_argument('--root', default='.',
+                        help="Project root containing skills-lock.json (default: cwd)")
+    parser.add_argument('--dry-run', action='store_true',
+                        help="Print actions without executing")
+    args = parser.parse_args()
+
+    skill = args.skill
+    if not (SKILL_NAME_RE.match(skill) and HAS_ALNUM_RE.search(skill)):
+        print(f"error: invalid --skill value: {skill!r}", file=sys.stderr)
+        print("       must match [A-Za-z0-9._-]+ and contain at least one alphanumeric",
+              file=sys.stderr)
+        return 2
+
+    root = Path(args.root).resolve()
+    if not root.is_dir():
+        print(f"error: --root is not a directory: {root}", file=sys.stderr)
+        return 2
+
+    lock_path = root / 'skills-lock.json'
+
+    # Step 1: ask the CLI to remove (deletes files; may leave lock stale on project scope).
+    rc = run_skills_remove(skill, dry_run=args.dry_run)
+    if rc != 0:
+        # Non-fatal: files may already be gone, or upstream CLI may not be installed.
+        # The lock-patch step below is the security-critical part.
+        print(f"note: `npx skills remove` returned exit {rc} (continuing)", file=sys.stderr)
+
+    # Step 2: patch lock file (workaround for skills#977).
+    try:
+        _, msg = patch_lock(lock_path, skill, dry_run=args.dry_run)
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    print(msg)
+
+    # Step 3: verify.
+    if not verify_removed(skill, dry_run=args.dry_run):
+        print(f"warning: '{skill}' still appears in `npx skills list` output",
+              file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
+++ b/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
@@ -20,14 +20,26 @@ can be reduced to just calling `npx skills remove`; no consumer changes
 needed.
 
 Usage:
-  cleanup-blocked-skill.py --skill <name> [--root <dir>] [--dry-run]
+  cleanup-blocked-skill.py --skill <name> [--root <dir>]
+                           [--installed-path <path>] [--dry-run]
 
 Exit codes:
   0 - clean removal
-  1 - operational error (invalid JSON, write failed, verify failed,
-      npx missing in non-dry-run, or `npx skills remove` returned
-      non-zero — lock is still patched, but file deletion is uncertain)
+  1 - operational error (invalid JSON, write failed, lock-verify failed,
+      npx missing in non-dry-run, skill directory still present at
+      --installed-path, or `npx skills remove` returned non-zero when
+      --installed-path was not supplied to confirm file deletion)
   2 - usage error (missing/invalid arguments)
+
+Notes on --installed-path:
+  When provided, the helper verifies the physical skill directory is
+  gone after cleanup. This makes the exit code an exact signal:
+    - dir still exists  -> exit 1 (covers the silent rc=0+dir-leak case)
+    - dir is gone       -> exit 0 even if `npx skills remove` returned
+                           non-zero (downgrade partial-failure when the
+                           actual security goal is achieved)
+  When omitted, behavior is unchanged for backward compatibility:
+  any non-zero from `npx skills remove` is reported as exit 1.
 """
 
 import argparse
@@ -54,7 +66,7 @@ def validate_skill_name(name: str):
         return "path separators not allowed"
     if any(c in name for c in '*?'):
         return "wildcards not allowed; specify exact name"
-    if name.startswith('-'):
+    if name.lstrip().startswith('-'):
         return "leading hyphen not allowed (could be parsed as a flag)"
     if name.strip() in ('.', '..'):
         return "reserved name"
@@ -172,6 +184,12 @@ def main() -> int:
                              "leading hyphen, and reserved '.'/'..'.")
     parser.add_argument('--root', default='.',
                         help="Project root containing skills-lock.json (default: cwd)")
+    parser.add_argument('--installed-path', default=None,
+                        help="Optional: absolute path (or path relative to --root) "
+                             "to the installed skill directory. When provided, the "
+                             "helper verifies the directory is gone after cleanup "
+                             "and uses that signal to refine the exit code "
+                             "(see module docstring).")
     parser.add_argument('--dry-run', action='store_true',
                         help="Print actions without executing")
     args = parser.parse_args()
@@ -222,7 +240,24 @@ def main() -> int:
               file=sys.stderr)
         return 1
 
-    # Partial-failure exit: lock cleared but `npx skills remove` failed.
+    # Step 4: optional physical-directory verification.
+    # When --installed-path is supplied, the helper can give an exact
+    # signal: a missing directory downgrades partial CLI failure to
+    # success, and a present directory escalates even an "all green"
+    # run to exit 1 (catches the rc=0 + dir-still-there silent leak).
+    if args.installed_path and not args.dry_run:
+        installed = Path(args.installed_path)
+        if not installed.is_absolute():
+            installed = root / installed
+        if installed.exists():
+            print(f"error: skill directory still present at {installed}; "
+                  "manual cleanup required (`rm -rf` the path)",
+                  file=sys.stderr)
+            return 1
+        cli_failed = False
+
+    # Partial-failure exit: lock cleared but `npx skills remove` failed
+    # and we cannot independently confirm the files are gone.
     if cli_failed:
         return 1
 

--- a/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
+++ b/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
@@ -33,23 +33,43 @@ Exit codes:
   2 - usage error (missing/invalid arguments)
 
 Caller contract for --installed-path:
-  Pass the ACTUAL installed directory (the same path previously fed to
-  security-scan.py). Do NOT synthesize the path from the logical skill
-  name — upstream `skills` CLI sanitizes the on-disk directory name
-  (lowercase, non-alphanumeric runs collapsed to `-`), so a logical
-  name like "Convex Best Practices" lives at
-  `.<agent>/skills/convex-best-practices`. A synthesized path silently
-  misses the real blocked skill.
+  This helper is project-scoped; global skill cleanup is out of scope.
+  Pass the ACTUAL installed project-skill directory (the same path
+  previously fed to security-scan.py). The path must be a direct child
+  of a known agent skillsDir (for example
+  `.<agent>/skills/convex-best-practices`). Do NOT synthesize the path
+  from the logical skill name — upstream `skills` CLI sanitizes the
+  on-disk directory name, so a synthesized path can miss the real
+  blocked skill.
 """
 
 import argparse
 import json
 import os
+import re
 import shutil
 import stat
 import subprocess
 import sys
 from pathlib import Path
+
+_BUILTIN_AGENT_SKILLS_DIRS = (
+    '.claude/skills',
+    '.cursor/skills',
+    '.codex/skills',
+    '.agents/skills',
+    '.github/skills',
+    '.gemini/skills',
+    '.junie/skills',
+    '.qwen/skills',
+    '.windsurf/skills',
+    '.warp/skills',
+    '.zencoder/skills',
+    '.roo/skills',
+    '.kilocode/skills',
+    '.agent/skills',
+    '.opencode/skills',
+)
 
 
 def validate_skill_name(name: str):
@@ -217,53 +237,151 @@ def _chmod_retry(func, path, exc_info):
     func(path)
 
 
-def safe_remove_installed(installed: Path, root: Path) -> None:
-    """Physically remove the installed skill directory after safety checks.
+def _normalize_configured_skills_dir(value):
+    """Return a normalized project-relative skillsDir or None.
+
+    Runtime extensions may define additional agent skills roots in
+    `.ai-factory.json`. Accept only safe dot-prefixed project-relative
+    paths ending in `skills`, matching the installed-agent shape this
+    helper is allowed to clean.
+    """
+    if not isinstance(value, str):
+        return None
+    raw = value.strip().replace('\\', '/')
+    if raw.startswith('./'):
+        raw = raw[2:]
+    if not raw or raw.startswith('/') or re.match(r'^[A-Za-z]:($|/)', raw):
+        return None
+    parts = raw.split('/')
+    if any(not part or part == '.' or part == '..' for part in parts):
+        return None
+    if not parts[0].startswith('.') or parts[-1].lower() != 'skills':
+        return None
+    return '/'.join(parts)
+
+
+def _allowed_agent_skills_dirs(root: Path):
+    """Known project agent skills roots, as root-relative path strings."""
+    roots = set(_BUILTIN_AGENT_SKILLS_DIRS)
+    config_path = root / '.ai-factory.json'
+    try:
+        data = json.loads(config_path.read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError):
+        return tuple(sorted(roots))
+
+    agents = data.get('agents')
+    if not isinstance(agents, list):
+        return tuple(sorted(roots))
+
+    for agent in agents:
+        if not isinstance(agent, dict):
+            continue
+        normalized = _normalize_configured_skills_dir(agent.get('skillsDir'))
+        if normalized:
+            roots.add(normalized)
+    return tuple(sorted(roots))
+
+
+def _path_norm(value: Path) -> str:
+    return os.path.normcase(str(value))
+
+
+def _existing_path_prefixes(path: Path, root: Path):
+    """Yield existing path prefixes from root to path without resolving."""
+    try:
+        rel_parts = path.relative_to(root).parts
+    except ValueError:
+        return
+
+    current = root
+    for part in rel_parts:
+        current = current / part
+        if current.exists() or current.is_symlink():
+            yield current
+
+
+def _matching_agent_skills_root(resolved: Path, root: Path):
+    """Return the matching allowed skills root if resolved is its child."""
+    resolved_parent_n = _path_norm(resolved.parent)
+    for skills_dir in _allowed_agent_skills_dirs(root):
+        skills_root = (root / Path(*skills_dir.split('/'))).resolve(strict=False)
+        if resolved_parent_n == _path_norm(skills_root):
+            return skills_root
+    return None
+
+
+def _sanitize_skill_name(name: str) -> str:
+    """Port of upstream skills sanitizeName() used for install paths."""
+    return re.sub(r'[^a-z0-9._]+', '-', name.lower()).strip('.-')
+
+
+def _read_skill_frontmatter_name(skill_md: Path):
+    """Best-effort parser for a simple `name:` key in YAML frontmatter."""
+    try:
+        lines = skill_md.read_text(encoding='utf-8').splitlines()
+    except OSError:
+        return None
+    if not lines or lines[0].strip() != '---':
+        return None
+
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped == '---':
+            return None
+        if not stripped or stripped.startswith('#') or ':' not in stripped:
+            continue
+        key, value = stripped.split(':', 1)
+        if key.strip() != 'name':
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        return value
+    return None
+
+
+def validate_installed_skill_path(installed: Path, root: Path, skill: str) -> Path:
+    """Resolve and validate an installed project skill directory path.
 
     Raises RuntimeError when any check rejects the path; the caller maps
-    that to exit 1 with the rejection reason. Returns silently (idempotent)
-    when the directory is already absent. See inline comments for the
-    rationale of each check.
+    that to exit 1 with the rejection reason. The path may already be
+    absent for idempotent retries, but it still must point to a plausible
+    installed-agent skill child and match the requested skill identity.
     """
-    # 1. Resolve. strict=False so we don't crash if dir already absent.
     original = installed
     if not original.is_absolute():
         original = root / original
+    real_root = root.resolve()
     resolved = original.resolve(strict=False)
 
-    # 2. Already absent -> trivially clean.
-    if not resolved.exists():
-        return
-
-    # 3. Symlink / NTFS junction (pre-resolve check on `original`).
+    # Reject symlinks / NTFS junctions before resolve() can hide them.
+    for prefix in _existing_path_prefixes(original, real_root):
+        if _is_reparse_point(prefix):
+            raise RuntimeError(
+                f"refusing to delete {prefix}: path is a symlink or junction "
+                "(possible redirect to another location)"
+            )
     if _is_reparse_point(original):
         raise RuntimeError(
             f"refusing to delete {original}: path is a symlink or junction "
             "(possible redirect to another location)"
         )
 
-    # 4. Must be a directory.
-    if not resolved.is_dir():
-        raise RuntimeError(
-            f"refusing to delete {resolved}: not a directory"
-        )
-
-    # 5. Anti-escape: resolved must be strictly inside root.
+    # Anti-escape: resolved must be strictly inside root.
     #
     # Use normcase to handle case-insensitive filesystems (Windows, macOS
     # HFS+). pathlib's is_relative_to() compares case-sensitively on
     # POSIX even when the underlying FS is not, which can produce false
     # rejects.
-    real_root = root.resolve()
-    resolved_n = os.path.normcase(str(resolved))
-    root_n = os.path.normcase(str(real_root))
+    resolved_n = _path_norm(resolved)
+    root_n = _path_norm(real_root)
     if not (resolved_n == root_n or resolved_n.startswith(root_n + os.sep)):
         raise RuntimeError(
             f"refusing to delete {resolved}: outside --root {real_root} "
             "(path traversal or symlink escape)"
         )
 
-    # 5b. Explicit equality guard. Cheap defense-in-depth: catches the
+    # Explicit equality guard. Cheap defense-in-depth: catches the
     # `--installed-path .` / `--installed-path ""` bug class where the
     # caller passes an empty/dot path and the resolved value equals root.
     if resolved_n == root_n:
@@ -271,28 +389,52 @@ def safe_remove_installed(installed: Path, root: Path) -> None:
             f"refusing to delete {resolved}: equals --root"
         )
 
-    # 6. Must have a `skills` segment under root. Skill dirs always live
-    # under `<agent>/skills/<name>` (e.g. .claude/skills/, .cursor/skills/).
-    rel_parts = resolved.relative_to(real_root).parts
-    if 'skills' not in rel_parts:
+    if resolved.exists() and not resolved.is_dir():
         raise RuntimeError(
-            f"refusing to delete {resolved}: no 'skills' segment under "
-            f"--root {real_root} (skill directories live under <agent>/skills/)"
+            f"refusing to delete {resolved}: not a directory"
         )
 
-    # 7. Plausibility marker: SKILL.md must exist. Upstream skills format
+    skills_root = _matching_agent_skills_root(resolved, real_root)
+    if skills_root is None:
+        raise RuntimeError(
+            f"refusing to delete {resolved}: not a direct child of a known "
+            "project agent skills directory"
+        )
+
+    sanitized = _sanitize_skill_name(skill)
+    if resolved.name.lower() != sanitized:
+        frontmatter_name = None
+        if resolved.exists():
+            frontmatter_name = _read_skill_frontmatter_name(resolved / 'SKILL.md')
+        if not frontmatter_name or frontmatter_name.strip().lower() != skill.strip().lower():
+            raise RuntimeError(
+                f"refusing to delete {resolved}: identity mismatch "
+                f"(--skill {skill!r} does not match installed directory "
+                f"basename {resolved.name!r} or SKILL.md name)"
+            )
+
+    # Plausibility marker: SKILL.md must exist. Upstream skills format
     # requires SKILL.md at the root of every installed skill — its
     # absence almost certainly means the caller passed the wrong path
     # (parent, sibling, or unrelated dir). Hard block, not warning:
     # soft-warning + delete would be silently destructive.
-    if not (resolved / 'SKILL.md').is_file():
+    if resolved.exists() and not (resolved / 'SKILL.md').is_file():
         raise RuntimeError(
             f"refusing to delete {resolved}: no SKILL.md marker "
             "(upstream skill format requires it). Verify --installed-path "
             "points at the skill directory, not its parent or a sibling."
         )
 
-    # 8. Delete. shutil.rmtree refuses top-level symlinks and uses
+    return resolved
+
+
+def safe_remove_installed(installed: Path, root: Path, skill: str) -> None:
+    """Physically remove the installed skill directory after validation."""
+    resolved = validate_installed_skill_path(installed, root, skill)
+    if not resolved.exists():
+        return
+
+    # Delete. shutil.rmtree refuses top-level symlinks and uses
     # os.scandir internally (no symlink-following for children).
     shutil.rmtree(resolved, onerror=_chmod_retry)
 
@@ -328,6 +470,15 @@ def main() -> int:
     if not root.is_dir():
         print(f"error: --root is not a directory: {root}", file=sys.stderr)
         return 2
+
+    installed = Path(args.installed_path) if args.installed_path else None
+    resolved_installed = None
+    if installed is not None:
+        try:
+            resolved_installed = validate_installed_skill_path(installed, root, skill)
+        except RuntimeError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 1
 
     lock_path = root / 'skills-lock.json'
 
@@ -372,10 +523,9 @@ def main() -> int:
     # for logical names that differ from the sanitized on-disk basename
     # (e.g. "Convex Best Practices" vs convex-best-practices) upstream
     # is a silent no-op. With this step, the helper is the guarantor.
-    if args.installed_path and not args.dry_run:
-        installed = Path(args.installed_path)
+    if installed is not None and not args.dry_run:
         try:
-            safe_remove_installed(installed, root)
+            safe_remove_installed(installed, root, skill)
         except RuntimeError as e:
             print(f"error: {e}", file=sys.stderr)
             return 1
@@ -383,12 +533,9 @@ def main() -> int:
         # whether `npx skills remove` reported partial failure earlier:
         # the security goal — directory gone, lock cleared — is met.
         cli_failed = False
-    elif args.installed_path and args.dry_run:
+    elif installed is not None and args.dry_run:
         # Surface the would-be action for transparency.
-        installed = Path(args.installed_path)
-        if not installed.is_absolute():
-            installed = root / installed
-        print(f"would safely remove installed directory: {installed}")
+        print(f"would safely remove installed directory: {resolved_installed}")
 
     # Partial-failure exit: lock cleared but `npx skills remove` failed
     # and we cannot independently confirm the files are gone.

--- a/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
+++ b/skills/aif-skill-generator/scripts/cleanup-blocked-skill.py
@@ -111,17 +111,23 @@ def _resolve_npx():
     return shutil.which('npx') or shutil.which('npx.cmd')
 
 
-def run_skills_remove(skill: str, dry_run: bool = False) -> int:
-    """Invoke `npx skills remove -s <skill> -y`.
+def run_skills_remove(skill: str, root: Path, dry_run: bool = False) -> int:
+    """Invoke `npx skills remove -s <skill> -y` with cwd=<root>.
 
     Returns the CLI exit code. In non-dry-run mode, raises RuntimeError
     if npx is not on PATH — a missing CLI is a hard failure for the
     security cleanup contract, not a silent success.
+
+    The subprocess runs with cwd=root so the upstream CLI inspects the
+    correct project's `skills-lock.json` even when `--root` points at a
+    project other than the helper's own cwd. Without this, the helper
+    could patch one project's lock file while telling npx to remove
+    skills from a different project context.
     """
     npx = _resolve_npx()
     if not npx:
         if dry_run:
-            print(f"would run: npx skills remove -s {skill!r} -y "
+            print(f"would run (in {root}): npx skills remove -s {skill!r} -y "
                   "(npx not on PATH; would be a hard error in non-dry-run)",
                   file=sys.stderr)
             return 0
@@ -129,9 +135,9 @@ def run_skills_remove(skill: str, dry_run: bool = False) -> int:
 
     cmd = [npx, 'skills', 'remove', '-s', skill, '-y']
     if dry_run:
-        print(f"would run: {' '.join(cmd)}")
+        print(f"would run (in {root}): {' '.join(cmd)}")
         return 0
-    result = subprocess.run(cmd)
+    result = subprocess.run(cmd, cwd=str(root))
     return result.returncode
 
 
@@ -184,10 +190,11 @@ def main() -> int:
     lock_path = root / 'skills-lock.json'
 
     # Step 1: ask the CLI to remove (deletes files; may leave lock stale on project scope).
+    # Subprocess runs with cwd=root so npx inspects the right project's lock file.
     # If npx is missing in non-dry-run mode, this is a hard error.
     cli_failed = False
     try:
-        rc = run_skills_remove(skill, dry_run=args.dry_run)
+        rc = run_skills_remove(skill, root, dry_run=args.dry_run)
     except RuntimeError as e:
         print(f"error: {e}", file=sys.stderr)
         return 1

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -49,7 +49,7 @@ PYTHON=$(command -v python3 || command -v python || echo "")
 $PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/security-scan.py <installed-skill-path>
 ```
 - **Exit 0** → proceed to Level 2
-- **Exit 1 (BLOCKED)** → Remove via cleanup helper: `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <skill-name>`. The helper deletes the skill directory AND clears its entry from `skills-lock.json` so the blocked skill cannot be resurrected. Warn user with full threat details. **NEVER use.**
+- **Exit 1 (BLOCKED)** → Remove via cleanup helper: `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <skill-name> --installed-path {{skills_dir}}/<skill-name>`. The helper deletes the skill directory AND clears its entry from `skills-lock.json` so the blocked skill cannot be resurrected; `--installed-path` lets it verify physical removal and return an exact exit code. Warn user with full threat details. **NEVER use.**
 - **Exit 2 (WARNINGS)** → proceed to Level 2, include warnings
 
 **Level 2 — Semantic review (you do this yourself):**
@@ -91,7 +91,7 @@ For each recommended skill:
   1. Search: npx skills search <name>
   2. If found → Install: npx skills install {{skills_cli_agent_flag}} <name>
   3. SECURITY: Scan installed EXTERNAL skill (never built-in aif*) → $PYTHON security-scan.py <path>
-     - BLOCKED? → $PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name>, warn user, skip this skill
+     - BLOCKED? → $PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path {{skills_dir}}/<name>, warn user, skip this skill
      - WARNINGS? → show to user, ask confirmation
   4. If not found → Generate: /aif-skill-generator <name>
   5. Has reference URLs? → Learn: /aif-skill-generator <url1> [url2]...
@@ -371,7 +371,7 @@ Proceed? [Y/n]
    # AUTO-SCAN: immediately after install
    $PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/security-scan.py <installed-path>
    ```
-   - Exit 1 (BLOCKED) → `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name>`, warn user, skip this skill
+   - Exit 1 (BLOCKED) → `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path {{skills_dir}}/<name>`, warn user, skip this skill
    - Exit 2 (WARNINGS) → show to user, ask confirmation
    - Exit 0 (CLEAN) → read files yourself (Level 2), verify intent, proceed
 8. Generate custom skills via `/aif-skill-generator` (pass URLs for Learn Mode when docs are available)

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -2,7 +2,7 @@
 name: aif
 description: Set up agent context for a project. Analyzes tech stack, installs relevant skills from skills.sh, generates custom skills, and configures MCP servers. Use when starting new project, setting up AI context, or asking "set up project", "configure AI", "what skills do I need".
 argument-hint: "[project description]"
-allowed-tools: Read Glob Grep Write Bash(mkdir *) Bash(node *update-config.mjs*) Bash(npx skills *) Bash(python *security-scan*) Bash(rm -rf *) Skill WebFetch AskUserQuestion Questions
+allowed-tools: Read Glob Grep Write Bash(mkdir *) Bash(node *update-config.mjs*) Bash(npx skills *) Bash(python *security-scan*) Bash(python *cleanup-blocked-skill*) Skill WebFetch AskUserQuestion Questions
 ---
 
 # AI Factory - Project Setup
@@ -49,7 +49,7 @@ PYTHON=$(command -v python3 || command -v python || echo "")
 $PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/security-scan.py <installed-skill-path>
 ```
 - **Exit 0** → proceed to Level 2
-- **Exit 1 (BLOCKED)** → Remove immediately (`rm -rf <skill-path>`), warn user. **NEVER use.**
+- **Exit 1 (BLOCKED)** → Remove via cleanup helper: `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <skill-name>`. The helper deletes the skill directory AND clears its entry from `skills-lock.json` so the blocked skill cannot be resurrected. Warn user with full threat details. **NEVER use.**
 - **Exit 2 (WARNINGS)** → proceed to Level 2, include warnings
 
 **Level 2 — Semantic review (you do this yourself):**
@@ -91,7 +91,7 @@ For each recommended skill:
   1. Search: npx skills search <name>
   2. If found → Install: npx skills install {{skills_cli_agent_flag}} <name>
   3. SECURITY: Scan installed EXTERNAL skill (never built-in aif*) → $PYTHON security-scan.py <path>
-     - BLOCKED? → rm -rf <path>, warn user, skip this skill
+     - BLOCKED? → $PYTHON cleanup-blocked-skill.py --skill <name>, warn user, skip this skill
      - WARNINGS? → show to user, ask confirmation
   4. If not found → Generate: /aif-skill-generator <name>
   5. Has reference URLs? → Learn: /aif-skill-generator <url1> [url2]...
@@ -371,7 +371,7 @@ Proceed? [Y/n]
    # AUTO-SCAN: immediately after install
    $PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/security-scan.py <installed-path>
    ```
-   - Exit 1 (BLOCKED) → `rm -rf <path>`, warn user, skip this skill
+   - Exit 1 (BLOCKED) → `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name>`, warn user, skip this skill
    - Exit 2 (WARNINGS) → show to user, ask confirmation
    - Exit 0 (CLEAN) → read files yourself (Level 2), verify intent, proceed
 8. Generate custom skills via `/aif-skill-generator` (pass URLs for Learn Mode when docs are available)

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -49,7 +49,7 @@ PYTHON=$(command -v python3 || command -v python || echo "")
 $PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/security-scan.py <installed-skill-path>
 ```
 - **Exit 0** → proceed to Level 2
-- **Exit 1 (BLOCKED)** → Remove via cleanup helper: `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <skill-name> --installed-path {{skills_dir}}/<skill-name>`. The helper deletes the skill directory AND clears its entry from `skills-lock.json` so the blocked skill cannot be resurrected; `--installed-path` lets it verify physical removal and return an exact exit code. Warn user with full threat details. **NEVER use.**
+- **Exit 1 (BLOCKED)** → Remove via cleanup helper: `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <skill-name> --installed-path <installed-skill-path>`. Pass the **same `<installed-skill-path>` you just scanned** — do not synthesize the path from `<skill-name>` (upstream `skills` CLI sanitizes the directory name, so a logical name like `"Convex Best Practices"` lives on disk as `convex-best-practices`). The helper deletes the skill directory AND clears its entry from `skills-lock.json` so the blocked skill cannot be resurrected; `--installed-path` lets it verify physical removal and return an exact exit code. Warn user with full threat details. **NEVER use.**
 - **Exit 2 (WARNINGS)** → proceed to Level 2, include warnings
 
 **Level 2 — Semantic review (you do this yourself):**
@@ -91,7 +91,7 @@ For each recommended skill:
   1. Search: npx skills search <name>
   2. If found → Install: npx skills install {{skills_cli_agent_flag}} <name>
   3. SECURITY: Scan installed EXTERNAL skill (never built-in aif*) → $PYTHON security-scan.py <path>
-     - BLOCKED? → $PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path {{skills_dir}}/<name>, warn user, skip this skill
+     - BLOCKED? → $PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path <path> (reuse the same <path> from step 3, NOT a synthesized {{skills_dir}}/<name>), warn user, skip this skill
      - WARNINGS? → show to user, ask confirmation
   4. If not found → Generate: /aif-skill-generator <name>
   5. Has reference URLs? → Learn: /aif-skill-generator <url1> [url2]...
@@ -371,7 +371,7 @@ Proceed? [Y/n]
    # AUTO-SCAN: immediately after install
    $PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/security-scan.py <installed-path>
    ```
-   - Exit 1 (BLOCKED) → `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path {{skills_dir}}/<name>`, warn user, skip this skill
+   - Exit 1 (BLOCKED) → `$PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name> --installed-path <installed-path>` (reuse the same `<installed-path>` you passed to security-scan.py — upstream `skills` sanitizes the directory name, so synthesizing it from `<name>` can miss the real folder), warn user, skip this skill
    - Exit 2 (WARNINGS) → show to user, ask confirmation
    - Exit 0 (CLEAN) → read files yourself (Level 2), verify intent, proceed
 8. Generate custom skills via `/aif-skill-generator` (pass URLs for Learn Mode when docs are available)

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -91,7 +91,7 @@ For each recommended skill:
   1. Search: npx skills search <name>
   2. If found → Install: npx skills install {{skills_cli_agent_flag}} <name>
   3. SECURITY: Scan installed EXTERNAL skill (never built-in aif*) → $PYTHON security-scan.py <path>
-     - BLOCKED? → $PYTHON cleanup-blocked-skill.py --skill <name>, warn user, skip this skill
+     - BLOCKED? → $PYTHON ~/{{skills_dir}}/aif-skill-generator/scripts/cleanup-blocked-skill.py --skill <name>, warn user, skip this skill
      - WARNINGS? → show to user, ask confirmation
   4. If not found → Generate: /aif-skill-generator <name>
   5. Has reference URLs? → Learn: /aif-skill-generator <url1> [url2]...


### PR DESCRIPTION
﻿## Summary

Replaces `rm -rf <skill-path>` with a dedicated cleanup helper that
also clears the stale entry in `skills-lock.json` AND **physically
removes** the security-blocked skill directory itself. Without this,
the blocked skill could be resurrected by
`npx skills experimental_install` or by a teammate cloning the repo
after install.

Closes #117

## Changes

### New: `skills/aif-skill-generator/scripts/cleanup-blocked-skill.py`
- Calls `npx skills remove -s <name> -y` with `cwd=<root>` so the
  upstream CLI inspects the same project's `skills-lock.json` that
  this helper patches. Kept as best-effort first pass.
- Atomically removes `skills["<name>"]` from `skills-lock.json`
  (tmp file + `os.replace`, preserves indent / trailing newline).
- **Verifies by re-reading the patched lock file** (not by parsing
  the ANSI-coloured output of `npx skills list`, which is brittle and
  breaks for spaced names).
- `--installed-path <path>` is the **authoritative physical-removal**
  target. When supplied, the helper itself runs `safe_remove_installed`
  with strict defense-in-depth checks (the helper is the guarantor;
  the upstream CLI is best-effort):
  - resolve absolute or `--root`-relative path; idempotent if already
    gone
  - validate the target before any lock mutation: project-root
    containment, direct child of a known project agent `skillsDir`,
    `SKILL.md` marker, and identity match via sanitized basename or
    `SKILL.md` frontmatter `name:`
  - reject symlink/junction prefixes that redirect before the installed
    path itself
  - allow the managed upstream install shape where the installed path is
    a symlink/junction to another known project agent `skillsDir` child;
    cleanup removes the canonical target and then the link/junction
    path without following it
  - reject unmanaged or escaping symlinks/junctions, including targets
    outside `--root` or outside known project agent `skillsDir` roots
  - reject non-directory targets and explicit `installed == root`
    (`--installed-path .`)
  - delete via `shutil.rmtree` with `onerror` that clears the read-only
    bit
  - Caller contract: pass the SAME path the agent fed to
    `security-scan.py`, not a path synthesized from the logical skill
    name — upstream `skills` sanitizes the on-disk directory name
    (`"Convex Best Practices"` → `convex-best-practices`).
- Hard-fails when `npx` is missing in non-dry-run mode (previously
  exited 0 silently).
- Deny-list `--skill` validation: accepts the upstream CLI surface
  including spaces; rejects path separators, wildcards, control chars,
  leading hyphen (and leading whitespace + hyphen), and reserved
  `.` / `..`.

### Why physical removal lives in the helper

Upstream `npx skills remove -s <name>` matches `<name>` against
installed directory basenames via lowercased equality, WITHOUT
applying `sanitizeName()` to the argument. So
`npx skills remove -s "Convex Best Practices"` does not match
`.claude/skills/convex-best-practices` and exits 0 silently. Previously
the helper detected the leftover and exited 1, but the security-blocked
skill remained physically installed and the broad `Bash(rm -rf *)`
fallback was already removed in earlier rounds. The new
`safe_remove_installed` step makes the helper the guarantor of physical
removal without re-introducing a broad shell permission.

### Updated skill prompts (dropped `Bash(rm -rf *)` allowance)
- `skills/aif/SKILL.md` — 3 BLOCKED branches use the helper with
  `--installed-path <installed-skill-path>`.
- `skills/aif-skill-generator/SKILL.md` — 2 BLOCKED branches updated.
- `skills/aif-skill-generator/references/SECURITY-SCANNING.md` — 1
  BLOCKED branch updated.
- `allowed-tools` in both SKILL.md headers replaces
  `Bash(rm -rf *)` with `Bash(python *cleanup-blocked-skill*)`.

### New: `scripts/test-cleanup-helper.sh` (wired into CI)
Focused regression suite, uses a fake `npx` on PATH (no live network /
no registry):
- Lock removal + sibling preservation (#117 core regression).
- Skill name with spaces (validation + lock surface + argv).
- Bad-name rejection (empty, wildcards, path separators, leading hyphen,
  leading-whitespace hyphen, control characters, reserved names).
- No-op + available-keys hint when entry absent.
- Invalid JSON.
- Missing-`npx` hard-fail.
- Subprocess `cwd` propagation matches `--root`.
- `--installed-path` absent / leftover-under-skills/ → exit 0 + dir
  removed / partial-failure-downgrade.
- Sanitized-leftover end-to-end: with the correct scanned path AND the
  new helper, a `convex-best-practices` leftover is physically removed
  AND the lock key cleared, even when upstream `npx skills remove` is a
  silent no-op.
- Safety checks: path traversal, source/docs skill preservation,
  missing `SKILL.md`, file-not-directory, sibling preservation,
  permission failure, `installed-path == root`, direct-child known agent
  `skillsDir` enforcement, identity mismatch rejection, extension
  runtime `skillsDir` support, and dry-run validation.
- Managed symlink/junction coverage: normal upstream symlinked installs
  are accepted and cleaned; escaping symlinks/junctions are rejected and
  preserved; the lock entry is preserved when managed cleanup fails.
- Drift/contract guards: built-in helper roots stay in sync with
  `src/core/agents.ts`, and skill docs must reuse the scanned path for
  `--installed-path` instead of synthesizing `{{skills_dir}}/<name>`.

### CI
- `npm run test:cleanup-helper` runs on every PR via
  `.github/workflows/ci.yml`.

## Test plan

- [x] Manual end-to-end repro of #117:
  - install external skill → `skills-lock.json` has the entry
  - run cleanup helper → directory gone, lock entry gone
  - `npx skills experimental_install -y` → reports
    "No project skills found", skill NOT resurrected
- [x] `npm run test:cleanup-helper` — focused helper suite passes locally
- [x] `npm run lint` — clean
- [x] `npm test` — green 
- [x] CI green on `b079c26104e1057b0177206dc304a6d32fddfd6d`
