### PR TITLE
fix(skills): honor language policy in workflow skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ Current config keys in active use:
 
 - `paths.*` - artifact discovery for description, architecture, roadmap, research, RULES.md, plan files, fix plans, QA artifacts,
   references, security state, patches, evolutions, loop state, and rules
-- `language.ui` / `language.artifacts` - prompt language vs generated artifact language
+- `language.ui` / `language.artifacts` / `language.technical_terms` - prompt language, generated artifact language, and terminology handling
 - `git.enabled` / `git.base_branch` / `git.create_branches` / `git.branch_prefix` / `git.skip_push_after_commit` - planning, verification, and commit push behavior
 - `workflow.verify_mode` - default verification strictness
 - `rules.base` plus named `rules.<area>` entries - rules hierarchy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ Current config keys in active use:
 
 - `paths.*` - artifact discovery for description, architecture, roadmap, research, RULES.md, plan files, fix plans, QA artifacts,
   references, security state, patches, evolutions, loop state, and rules
-- `language.ui` / `language.artifacts` / `language.technical_terms` - prompt language, generated artifact language, and terminology handling
+- `language.ui` / `language.artifacts` / `language.technical_terms` - prompt/report language, generated artifact language, and terminology handling while preserving commands, paths, identifiers, config keys, and raw errors where required
 - `git.enabled` / `git.base_branch` / `git.create_branches` / `git.branch_prefix` / `git.skip_push_after_commit` - planning, verification, and commit push behavior
 - `workflow.verify_mode` - default verification strictness
 - `rules.base` plus named `rules.<area>` entries - rules hierarchy
@@ -463,7 +463,7 @@ docs/
 3. Decide config policy explicitly:
    - Config-aware skills must read `.ai-factory/config.yaml` first and document exact keys used.
    - Config-agnostic skills must say why they do not read config.
-   - Use `language.ui` for prompts/summaries and `language.artifacts` for generated artifacts when applicable.
+   - Use `language.ui` for prompts/reports/summaries, `language.artifacts` for generated artifacts when applicable, and `language.technical_terms` to preserve stable technical tokens where required.
 4. Add an Artifact Ownership section. Owner commands write only their owned artifacts; non-owner context artifacts stay read-only. Quality gates must follow the shared `aif-gate-result` contract only when they are machine-readable gates.
 5. Never hardcode installed skill directories in built-in skills. Use template variables such as `{{skills_dir}}` or `{{home_skills_dir}}`; the installer resolves them per agent.
 6. If the skill creates user skills, save them in the current agent skills directory (`{{skills_dir}}/<skill-name>/`) with concise lowercase-hyphen names unless the command explicitly supports and receives a custom output path.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -53,8 +53,8 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
 | `language.ui` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-reference`, `/aif-distillation`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa` | UI language for prompts, questions, and summaries; `/aif` resolves it before downstream setup questions |
-| `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-roadmap`, `/aif-implement`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-distillation`, `/aif-qa` | Language for generated artifacts; `/aif` locks it before the first setup artifact so DESCRIPTION/rules base/AGENTS/ARCHITECTURE stay aligned in one run; `/aif-distillation` uses it for generated skill package content; `/aif-qa` uses it for QA markdown artifacts with fallback to `language.ui` |
-| `language.technical_terms` | `keep` | `/aif-distillation`, `/aif-qa` | Present in schema and template; `/aif` preserves an existing value when present and otherwise writes the default `keep`; `/aif-distillation` and `/aif-qa` use it to decide whether human-readable terminology should stay in English, be translated, or use mixed style |
+| `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-distillation`, `/aif-qa` | Language for generated artifacts; `/aif` locks it before the first setup artifact so DESCRIPTION/rules base/AGENTS/ARCHITECTURE stay aligned in one run; `/aif-explore` uses it for persisted research snapshots; `/aif-distillation` uses it for generated skill package content; `/aif-qa` uses it for QA markdown artifacts with fallback to `language.ui` |
+| `language.technical_terms` | `keep` | `/aif-explore`, `/aif-distillation`, `/aif-qa` | Present in schema and template; `/aif` preserves an existing value when present and otherwise writes the default `keep`; `/aif-explore`, `/aif-distillation`, and `/aif-qa` use it to decide whether human-readable terminology should stay in English, be translated, or use mixed style |
 
 ### `paths`
 
@@ -120,7 +120,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 |-------|--------------|---------------|--------------------|
 | `/aif-architecture` | Yes | No | `paths.description`, `paths.architecture`, `language.ui`, `language.artifacts` |
 | `/aif-plan` | Yes | No | `paths.*` for planning artifacts, `language.ui`, `git.*` |
-| `/aif-explore` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.research`, `paths.plan`, `paths.plans`, `paths.rules`, `language.ui` |
+| `/aif-explore` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.research`, `paths.plan`, `paths.plans`, `paths.rules`, `language.ui`, `language.artifacts`, `language.technical_terms` |
 | `/aif-roadmap` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.research`, `paths.rules`, `language.ui`, `language.artifacts` |
 | `/aif-improve` | Yes | No | `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.research`, `paths.description`, `paths.patches`, `language.ui`, `git.enabled`, `git.base_branch`, `git.create_branches` |
 | `/aif-implement` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.research`, `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.patches`, `paths.rules`, `language.ui`, `language.artifacts`, `git.enabled`, `git.base_branch`, `git.create_branches`, `rules.base`, `rules.<area>` |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -135,7 +135,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | `/aif-reference` | Yes | No | `paths.references`, `paths.rules_file`, `language.ui`, `language.artifacts`, `language.technical_terms` |
 | `/aif-distillation` | Yes | No | `language.ui`, `language.artifacts`, `language.technical_terms` |
 | `/aif-security-checklist` | Yes | No | `paths.security`, `language.ui`, `language.artifacts`, `language.technical_terms` |
-| `/aif-rules` | Yes | No | `paths.rules_file`, `paths.rules`, `language.ui`, `language.artifacts`, `language.technical_terms` |
+| `/aif-rules` | Yes | Yes, limited | `paths.rules_file`, `paths.rules`, `language.ui`, `language.artifacts`, `language.technical_terms`; writes only `rules.<area>` registrations and may bootstrap minimal config for first area rule |
 | `/aif-qa` | Yes | No | `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, `language.artifacts`, `language.technical_terms`, `git.enabled`, `git.base_branch` |
 
 ### Config-Agnostic Built-ins

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -53,8 +53,8 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
 | `language.ui` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-reference`, `/aif-distillation`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa` | UI language for prompts, questions, and summaries; `/aif` resolves it before downstream setup questions |
-| `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-distillation`, `/aif-qa` | Language for generated artifacts; `/aif` locks it before the first setup artifact so DESCRIPTION/rules base/AGENTS/ARCHITECTURE stay aligned in one run; `/aif-explore` uses it for persisted research snapshots; `/aif-distillation` uses it for generated skill package content; `/aif-qa` uses it for QA markdown artifacts with fallback to `language.ui` |
-| `language.technical_terms` | `keep` | `/aif-explore`, `/aif-distillation`, `/aif-qa` | Present in schema and template; `/aif` preserves an existing value when present and otherwise writes the default `keep`; `/aif-explore`, `/aif-distillation`, and `/aif-qa` use it to decide whether human-readable terminology should stay in English, be translated, or use mixed style |
+| `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-fix`, `/aif-evolve`, `/aif-reference`, `/aif-distillation`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa` | Language for generated or persisted artifacts; `/aif` locks it before the first setup artifact so DESCRIPTION/rules base/AGENTS/ARCHITECTURE stay aligned in one run; workflow artifact writers use it for plans, research, fix plans, patches, references, rules, security ignore state, docs, evolution reports, and QA artifacts, with fallback to `language.ui` |
+| `language.technical_terms` | `keep` | `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-fix`, `/aif-reference`, `/aif-distillation`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa` | Present in schema and template; `/aif` preserves an existing value when present and otherwise writes the default `keep`; artifact-writing skills use it to decide whether human-readable terminology should stay in English, be translated, or use mixed style while preserving commands, paths, identifiers, config keys, package names, API names, and raw errors where required |
 
 ### `paths`
 
@@ -119,22 +119,23 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | Skill | Reads config | Writes config | Main sections used |
 |-------|--------------|---------------|--------------------|
 | `/aif-architecture` | Yes | No | `paths.description`, `paths.architecture`, `language.ui`, `language.artifacts` |
-| `/aif-plan` | Yes | No | `paths.*` for planning artifacts, `language.ui`, `git.*` |
+| `/aif-plan` | Yes | No | `paths.*` for planning artifacts, `language.ui`, `language.artifacts`, `language.technical_terms`, `git.*` |
 | `/aif-explore` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.research`, `paths.plan`, `paths.plans`, `paths.rules`, `language.ui`, `language.artifacts`, `language.technical_terms` |
 | `/aif-roadmap` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.research`, `paths.rules`, `language.ui`, `language.artifacts` |
-| `/aif-improve` | Yes | No | `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.research`, `paths.description`, `paths.patches`, `language.ui`, `git.enabled`, `git.base_branch`, `git.create_branches` |
+| `/aif-improve` | Yes | No | `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.research`, `paths.description`, `paths.patches`, `language.ui`, `language.artifacts`, `language.technical_terms`, `git.enabled`, `git.base_branch`, `git.create_branches` |
 | `/aif-implement` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.research`, `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.patches`, `paths.rules`, `language.ui`, `language.artifacts`, `git.enabled`, `git.base_branch`, `git.create_branches`, `rules.base`, `rules.<area>` |
-| `/aif-verify` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.specs`, `paths.rules`, `workflow.verify_mode`, `git.enabled`, `git.base_branch`, `git.create_branches`, `rules.base`, `rules.<area>` |
+| `/aif-verify` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.specs`, `paths.rules`, `workflow.verify_mode`, `language.ui`, `git.enabled`, `git.base_branch`, `git.create_branches`, `rules.base`, `rules.<area>` |
 | `/aif-rules-check` | Yes | No | `paths.rules_file`, `paths.rules`, `paths.plan`, `paths.plans`, `language.ui`, `git.enabled`, `git.base_branch`, `rules.base`, `rules.<area>` |
 | `/aif-commit` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.rules`, `paths.plan`, `paths.plans`, `workflow.plan_id_format`, `language.ui`, `git.enabled`, `git.create_branches`, `git.skip_push_after_commit`, `rules.base`, `rules.<area>` |
 | `/aif-review` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.rules`, `language.ui`, `git.base_branch` |
 | `/aif-loop` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.research`, `paths.plan`, `paths.plans`, `paths.evolution`, `language.ui`, `language.artifacts` |
 | `/aif-docs` | Yes | No | `paths.description`, `paths.architecture`, `paths.docs`, `language.ui`, `language.artifacts` |
-| `/aif-fix` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.rules`, `paths.fix_plan`, `paths.patches`, `language.ui`, `rules.base`, `rules.<area>` |
+| `/aif-fix` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.rules`, `paths.fix_plan`, `paths.patches`, `language.ui`, `language.artifacts`, `language.technical_terms`, `rules.base`, `rules.<area>` |
 | `/aif-evolve` | Yes | No | `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.rules`, `paths.patches`, `paths.evolutions`, `language.ui`, `language.artifacts`, `rules.base`, `rules.<area>` |
-| `/aif-reference` | Yes | No | `paths.references`, `paths.rules_file`, `language.ui` |
+| `/aif-reference` | Yes | No | `paths.references`, `paths.rules_file`, `language.ui`, `language.artifacts`, `language.technical_terms` |
 | `/aif-distillation` | Yes | No | `language.ui`, `language.artifacts`, `language.technical_terms` |
-| `/aif-security-checklist` | Yes | No | `paths.security`, `language.ui` |
+| `/aif-security-checklist` | Yes | No | `paths.security`, `language.ui`, `language.artifacts`, `language.technical_terms` |
+| `/aif-rules` | Yes | No | `paths.rules_file`, `paths.rules`, `language.ui`, `language.artifacts`, `language.technical_terms` |
 | `/aif-qa` | Yes | No | `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, `language.artifacts`, `language.technical_terms`, `git.enabled`, `git.base_branch` |
 
 ### Config-Agnostic Built-ins

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -197,8 +197,8 @@ Current config-agnostic built-ins include `/aif-best-practices`, `/aif-build-aut
 
 **Language semantics:**
 - `language.ui` controls prompts, questions, progress updates, summaries, and next-step guidance.
-- `language.artifacts` controls generated or persisted artifacts, including `/aif-explore` research snapshots in `paths.research`.
-- `language.technical_terms` controls whether human-readable terminology is kept, translated, or mixed while commands, paths, identifiers, config keys, package names, and raw errors stay unchanged where required.
+- `language.artifacts` controls generated or persisted artifacts, including plans, fix plans, patches, rules, references, security ignore state, documentation, QA outputs, and `/aif-explore` research snapshots in `paths.research`.
+- `language.technical_terms` controls whether human-readable terminology is kept, translated, or mixed while commands, paths, identifiers, branch names, config keys, package names, API names, machine-readable enum values, and raw errors stay unchanged where required.
 
 **Git workflow semantics:**
 - `git.enabled: false` disables branch/worktree assumptions entirely. `/aif-plan full` still creates a rich full plan, but it stores it in `paths.plans/<slug>.md` without running git commands.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,6 +195,11 @@ Other skills are config-agnostic for now and rely on repository context, explici
 
 Current config-agnostic built-ins include `/aif-best-practices`, `/aif-build-automation`, `/aif-ci`, `/aif-dockerize`, `/aif-grounded`, and `/aif-skill-generator`.
 
+**Language semantics:**
+- `language.ui` controls prompts, questions, progress updates, summaries, and next-step guidance.
+- `language.artifacts` controls generated or persisted artifacts, including `/aif-explore` research snapshots in `paths.research`.
+- `language.technical_terms` controls whether human-readable terminology is kept, translated, or mixed while commands, paths, identifiers, config keys, package names, and raw errors stay unchanged where required.
+
 **Git workflow semantics:**
 - `git.enabled: false` disables branch/worktree assumptions entirely. `/aif-plan full` still creates a rich full plan, but it stores it in `paths.plans/<slug>.md` without running git commands.
 - `git.base_branch` is the branch used for diff, review, verify, rules-check, and merge guidance. Skills must not hardcode `main`.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -46,6 +46,8 @@ If the resolved research artifact exists, `/aif-plan` reads the `Active Summary`
 
 If the resolved roadmap artifact exists, `/aif-plan` may also capture a `Roadmap Linkage` section (milestone name + brief rationale) to make milestone alignment explicit.
 
+Plan prompts and summaries use `language.ui`; saved plan artifacts use `language.artifacts` and preserve commands, paths, branch names, identifiers, config keys, and raw errors according to `language.technical_terms`.
+
 **Parallel mode** — work on multiple features simultaneously using `git worktree`:
 ```
 /aif-plan full --parallel Add Stripe checkout
@@ -85,7 +87,7 @@ Refine an existing plan with a second iteration:
 /aif-improve добавь валидацию и обработку ошибок # Improve based on specific feedback
 ```
 - Plan source priority: `@plan-file` argument, then branch-based `paths.plans/<branch>.md`, then a single named full plan in `paths.plans`, then `paths.plan`, then `paths.fix_plan`
-- Reads `.ai-factory/config.yaml` for `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.research`, `paths.description`, `paths.patches`, and `language.ui`
+- Reads `.ai-factory/config.yaml` for `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.research`, `paths.description`, `paths.patches`, `language.ui`, `language.artifacts`, and `language.technical_terms`
 - `--list` mode is read-only: shows available plan files and exits
 - Performs deeper codebase analysis than the initial `/aif-plan` planning
 - Finds missing tasks (migrations, configs, middleware)
@@ -173,6 +175,7 @@ Verifies completed implementation against the plan:
 - **Issue remediation** — if issues found, first suggests `/aif-fix <issue summary>` (recommended), with optional direct fix in-session
 - **Follow-up suggestions** — if all green, suggests `/aif-security-checklist`, `/aif-review`, then `/aif-commit`
 - **Machine-readable result** — appends a final `aif-gate-result` JSON block with `status: pass|warn|fail`, `blocking`, `blockers`, `affected_files`, and `suggested_next`
+- Uses `language.ui` for prompts, verification reports, context-gate summaries, issue remediation prompts, and follow-up guidance; machine-readable JSON values stay stable
 
 **Strict mode** (`--strict`) is recommended before merging: requires all tasks complete, build passing, tests passing, lint clean, zero TODOs in changed files, and passing architecture/rules/roadmap gates. For `feat`/`fix`/`perf`, missing roadmap milestone linkage is reported as a warning, not a failure.
 
@@ -182,11 +185,12 @@ Bug fix with optional plan-first mode:
 /aif-fix TypeError: Cannot read property 'name' of undefined
 ```
 - Asks to choose mode: **Fix now** (immediate) or **Plan first** (review before fixing)
-- Reads `.ai-factory/config.yaml` for `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.rules`, `paths.fix_plan`, `paths.patches`, named `rules.<area>` entries, and `language.ui`
+- Reads `.ai-factory/config.yaml` for `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.rules`, `paths.fix_plan`, `paths.patches`, named `rules.<area>` entries, `language.ui`, `language.artifacts`, and `language.technical_terms`
 - Investigates codebase to find root cause
 - Applies fix WITH logging (`[FIX]` prefix for easy filtering)
 - Suggests test coverage for the bug
 - Creates a **self-improvement patch** in `paths.patches` (default: `.ai-factory/patches/`)
+- User-facing fix summaries use `language.ui`; `FIX_PLAN.md` and patch artifacts use `language.artifacts` while preserving `[FIX]`, commands, paths, identifiers, raw errors, and patch tags according to `language.technical_terms`
 
 **Plan-first mode** — for complex bugs or when you want to review the approach:
 ```
@@ -423,6 +427,7 @@ Adds project-specific rules and conventions:
 - **Area rules:** `area:api`, `area:frontend`, `area:backend` - creates `<configured rules dir>/<area>.md` and registers it as `rules.<area>` in `.ai-factory/config.yaml`
 - **Rules hierarchy:** `rules.<area>` > `rules/base.md` > `paths.rules_file`
 - Rules are automatically loaded by `/aif-implement` before task execution
+- Prompts and confirmations use `language.ui`; persisted rule artifacts use `language.artifacts` and preserve stable technical tokens according to `language.technical_terms`
 - Use for coding conventions, naming rules, architectural constraints
 
 ### `/aif-commit`
@@ -490,13 +495,13 @@ Creates knowledge references from external sources for AI agents:
 - Synthesizes structured reference documents: overview, core concepts, API/interface, usage patterns, configuration, best practices, pitfalls
 - Saves to `paths.references/<name>.md` with source attribution and timestamps
 - Maintains an index in `paths.references/INDEX.md`
-- Reads `.ai-factory/config.yaml` for `paths.references`, `paths.rules_file`, and `language.ui`
+- Reads `.ai-factory/config.yaml` for `paths.references`, `paths.rules_file`, `language.ui`, `language.artifacts`, and `language.technical_terms`
 - `--update` re-fetches sources and refreshes an existing reference
 - `list` / `show <name>` / `delete <name>` for managing existing references
 - References are available to all AI Factory skills — `/aif-plan`, `/aif-implement`, `/aif-grounded` can read them for domain context
 - Best when AI needs knowledge it wasn't trained on: new libraries, internal APIs, project-specific specs, or rapidly changing documentation
 
-- Config policy: config-aware; reference storage uses `paths.references`
+- Config policy: config-aware; reference storage uses `paths.references`, prompts use `language.ui`, and generated reference files plus `INDEX.md` use `language.artifacts` while preserving source quotes, code examples, API signatures, URLs, paths, and raw errors according to `language.technical_terms`
 
 ### `/aif-distillation <path|url> [path|url...] [--name <skill-name>] [--path <directory>] [--update] [--redact-source-map] [--split|--split-by <strategy>]`
 Distills books, documents, folders, or URLs into one reusable Agent Skill or a split set of focused skills:
@@ -578,9 +583,9 @@ Audit outputs append a final `aif-gate-result` JSON block for full and category 
 - Asks for a reason, saves to `paths.security`
 - Future audits skip these items but still show them in an **"Ignored Items"** section for transparency
 - Review ignored items periodically — risks change over time
-- Reads `.ai-factory/config.yaml` for `paths.security` and `language.ui`
+- Reads `.ai-factory/config.yaml` for `paths.security`, `language.ui`, `language.artifacts`, and `language.technical_terms`
 
-- Config policy: config-aware; persistent ignore state uses `paths.security`
+- Config policy: config-aware; audit summaries use `language.ui`, persistent ignore state uses `paths.security` and `language.artifacts`, and stable IDs/status values remain unchanged under `language.technical_terms`
 
 ### `/aif-qa [--all] [change-summary | test-plan | test-cases] [<branch>]`
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -23,6 +23,7 @@ Explore ideas, constraints, and trade-offs before planning:
 ```
 - Uses a thinking-partner mode: open questions, option mapping, and ASCII visualization
 - Reads project context from the resolved description, architecture, rules, and research artifacts plus active plan files when present
+- Uses `language.ui` for user-facing exploration responses, `language.artifacts` for persisted `paths.research` snapshots, and `language.technical_terms` to preserve commands, paths, identifiers, and config keys where appropriate
 - Does **not** implement code in this mode; when direction is clear, move to `/aif-plan`
 - Can optionally persist exploration context to `paths.research` (default: `.ai-factory/RESEARCH.md`) so you can `/clear` and still feed results into `/aif-plan`
 - Best when the problem is still fuzzy: requirements unclear, trade-offs unresolved, or you want to inspect the codebase before choosing a direction

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -584,6 +584,14 @@ else
     fail "workflow artifact skills missing artifact_language write target contract"
 fi
 
+if grep -Fq 'The next-step templates below define structure only. Render all human-readable text in these user-facing responses in `ui_language`.' "$AIF_PLAN_SKILL" \
+   && grep -Fq 'The completion templates below define structure only. Render all human-readable text in these user-facing responses in `ui_language`.' "$AIF_IMPROVE_SKILL" \
+   && grep -Fq 'The Step 5 and After Fixing output templates define structure only. Render all human-readable text in these user-facing responses in `ui_language`.' "$AIF_FIX_SKILL"; then
+    pass "workflow user-facing templates use ui_language"
+else
+    fail "workflow user-facing templates missing ui_language structure-only contract"
+fi
+
 if grep -Fq 'Preserve markdown structure, checkbox syntax, task IDs, branch names, commit messages, commands, file paths, config keys, package names, API names, `WARN`/`INFO` labels, and raw errors unchanged.' "$AIF_PLAN_SKILL" \
    && grep -Fq 'Preserve Handoff annotations, markdown structure, checkbox syntax, paths, commands, config keys, code identifiers, package names, API names, raw error messages, code snippets, log prefixes such as `[FIX]`, and patch tags unchanged.' "$AIF_FIX_SKILL" \
    && grep -Fq 'Preserve source quotations, source titles, URLs, local paths, code examples, API signatures, command names, config keys, package names, version strings, raw errors, and link targets unchanged.' "$AIF_REFERENCE_SKILL" \
@@ -607,10 +615,11 @@ CONFIG_LANGUAGE_TECH_TERMS_ROW="$(grep -F '| `language.technical_terms` |' "$CON
 CONFIG_AIF_PLAN_ROW="$(grep -F '| `/aif-plan` |' "$CONFIG_REFERENCE_DOC" || true)"
 CONFIG_AIF_IMPROVE_ROW="$(grep -F '| `/aif-improve` |' "$CONFIG_REFERENCE_DOC" || true)"
 CONFIG_AIF_FIX_ROW="$(grep -F '| `/aif-fix` |' "$CONFIG_REFERENCE_DOC" || true)"
-CONFIG_AIF_RULES_ROW="$(grep -F '| `/aif-rules` | Yes | No |' "$CONFIG_REFERENCE_DOC" || true)"
+CONFIG_AIF_RULES_ROW="$(grep -F '| `/aif-rules` | Yes | Yes, limited |' "$CONFIG_REFERENCE_DOC" || true)"
 CONFIG_AIF_REFERENCE_ROW="$(grep -F '| `/aif-reference` |' "$CONFIG_REFERENCE_DOC" || true)"
 CONFIG_AIF_SECURITY_ROW="$(grep -F '| `/aif-security-checklist` |' "$CONFIG_REFERENCE_DOC" || true)"
 CONFIG_AIF_VERIFY_ROW="$(grep -F '| `/aif-verify` |' "$CONFIG_REFERENCE_DOC" || true)"
+CONFIG_AIF_RULES_CONTRADICTORY_ROW="$(grep -F '| `/aif-rules` | Yes | No |' "$CONFIG_REFERENCE_DOC" || true)"
 if [[ "$CONFIG_LANGUAGE_ARTIFACTS_ROW" == *"/aif-plan"* && "$CONFIG_LANGUAGE_ARTIFACTS_ROW" == *"/aif-improve"* && "$CONFIG_LANGUAGE_ARTIFACTS_ROW" == *"/aif-fix"* && "$CONFIG_LANGUAGE_ARTIFACTS_ROW" == *"/aif-rules"* && "$CONFIG_LANGUAGE_ARTIFACTS_ROW" == *"/aif-reference"* && "$CONFIG_LANGUAGE_ARTIFACTS_ROW" == *"/aif-security-checklist"* ]] \
    && [[ "$CONFIG_LANGUAGE_TECH_TERMS_ROW" == *"/aif-plan"* && "$CONFIG_LANGUAGE_TECH_TERMS_ROW" == *"/aif-improve"* && "$CONFIG_LANGUAGE_TECH_TERMS_ROW" == *"/aif-fix"* && "$CONFIG_LANGUAGE_TECH_TERMS_ROW" == *"/aif-rules"* && "$CONFIG_LANGUAGE_TECH_TERMS_ROW" == *"/aif-reference"* && "$CONFIG_LANGUAGE_TECH_TERMS_ROW" == *"/aif-security-checklist"* ]] \
    && [[ "$CONFIG_AIF_PLAN_ROW" == *'`language.artifacts`'* && "$CONFIG_AIF_PLAN_ROW" == *'`language.technical_terms`'* ]] \
@@ -619,7 +628,8 @@ if [[ "$CONFIG_LANGUAGE_ARTIFACTS_ROW" == *"/aif-plan"* && "$CONFIG_LANGUAGE_ART
    && [[ "$CONFIG_AIF_RULES_ROW" == *'`language.artifacts`'* && "$CONFIG_AIF_RULES_ROW" == *'`language.technical_terms`'* ]] \
    && [[ "$CONFIG_AIF_REFERENCE_ROW" == *'`language.artifacts`'* && "$CONFIG_AIF_REFERENCE_ROW" == *'`language.technical_terms`'* ]] \
    && [[ "$CONFIG_AIF_SECURITY_ROW" == *'`language.artifacts`'* && "$CONFIG_AIF_SECURITY_ROW" == *'`language.technical_terms`'* ]] \
-   && [[ "$CONFIG_AIF_VERIFY_ROW" == *'`language.ui`'* ]]; then
+   && [[ "$CONFIG_AIF_VERIFY_ROW" == *'`language.ui`'* ]] \
+   && [[ -z "$CONFIG_AIF_RULES_CONTRADICTORY_ROW" ]]; then
     pass "config reference documents broadened workflow language keys"
 else
     fail "config reference missing broadened workflow language keys"

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -391,6 +391,13 @@ fi
 # /aif localization contract regression checks
 AIF_SKILL="$ROOT_DIR/skills/aif/SKILL.md"
 AIF_EXPLORE_SKILL="$ROOT_DIR/skills/aif-explore/SKILL.md"
+AIF_PLAN_SKILL="$ROOT_DIR/skills/aif-plan/SKILL.md"
+AIF_IMPROVE_SKILL="$ROOT_DIR/skills/aif-improve/SKILL.md"
+AIF_FIX_SKILL="$ROOT_DIR/skills/aif-fix/SKILL.md"
+AIF_RULES_SKILL="$ROOT_DIR/skills/aif-rules/SKILL.md"
+AIF_REFERENCE_SKILL="$ROOT_DIR/skills/aif-reference/SKILL.md"
+AIF_SECURITY_SKILL="$ROOT_DIR/skills/aif-security-checklist/SKILL.md"
+AIF_VERIFY_SKILL="$ROOT_DIR/skills/aif-verify/SKILL.md"
 AIF_COMMIT_SKILL="$ROOT_DIR/skills/aif-commit/SKILL.md"
 AIF_ARCH_SKILL="$ROOT_DIR/skills/aif-architecture/SKILL.md"
 CONFIG_REFERENCE_DOC="$ROOT_DIR/docs/config-reference.md"
@@ -535,11 +542,98 @@ else
 fi
 
 if grep -Fq 'Uses `language.ui` for user-facing exploration responses, `language.artifacts` for persisted `paths.research` snapshots, and `language.technical_terms`' "$SKILLS_DOC" \
-   && grep -Fq '`language.artifacts` controls generated or persisted artifacts, including `/aif-explore` research snapshots in `paths.research`.' "$CONFIGURATION_DOC" \
+   && grep -Fq '`language.artifacts` controls generated or persisted artifacts, including plans, fix plans, patches, rules, references, security ignore state, documentation, QA outputs, and `/aif-explore` research snapshots in `paths.research`.' "$CONFIGURATION_DOC" \
    && grep -Fq '`language.ui` / `language.artifacts` / `language.technical_terms`' "$ROOT_DIR/AGENTS.md"; then
     pass "docs summarize /aif-explore language policy"
 else
     fail "docs missing /aif-explore language policy summary"
+fi
+
+LANGUAGE_ARTIFACT_SKILLS=(
+    "$AIF_PLAN_SKILL"
+    "$AIF_IMPROVE_SKILL"
+    "$AIF_FIX_SKILL"
+    "$AIF_RULES_SKILL"
+    "$AIF_REFERENCE_SKILL"
+    "$AIF_SECURITY_SKILL"
+)
+LANGUAGE_ARTIFACT_CONTRACT_MISSING=0
+for skill_file in "${LANGUAGE_ARTIFACT_SKILLS[@]}"; do
+    if ! grep -Fq 'ui_language = language.ui || "en"' "$skill_file" \
+        || ! grep -Fq 'artifact_language = language.artifacts || language.ui || "en"' "$skill_file" \
+        || ! grep -Fq 'technical_terms_policy = language.technical_terms || "keep"' "$skill_file" \
+        || ! grep -Fq 'Legacy values such as `english` also behave like `keep`.' "$skill_file"; then
+        LANGUAGE_ARTIFACT_CONTRACT_MISSING=1
+        echo "      Missing language variable contract in $skill_file"
+    fi
+done
+if [[ "$LANGUAGE_ARTIFACT_CONTRACT_MISSING" -eq 0 ]]; then
+    pass "workflow artifact skills resolve ui/artifact/technical language variables"
+else
+    fail "workflow artifact skills missing ui/artifact/technical language variables"
+fi
+
+if grep -Fq 'Generated plan artifacts under `paths.plan` or `paths.plans` MUST be written in `artifact_language`.' "$AIF_PLAN_SKILL" \
+   && grep -Fq 'Any generated or updated plan artifact content under `paths.plan`, `paths.plans`, or `paths.fix_plan` MUST be written in `artifact_language`.' "$AIF_IMPROVE_SKILL" \
+   && grep -Fq 'Generated `FIX_PLAN.md` and self-improvement patch files under `paths.patches` MUST be written in `artifact_language`.' "$AIF_FIX_SKILL" \
+   && grep -Fq 'Generated or updated rules artifacts under `paths.rules_file` and `paths.rules/<area>.md` MUST be written in `artifact_language`.' "$AIF_RULES_SKILL" \
+   && grep -Fq 'Generated reference files and the reference `INDEX.md` MUST be written in `artifact_language`.' "$AIF_REFERENCE_SKILL" \
+   && grep -Fq 'The persistent `SECURITY.md` ignored-item artifact under `paths.security` MUST be written in `artifact_language`.' "$AIF_SECURITY_SKILL"; then
+    pass "workflow artifact skills state artifact_language write targets"
+else
+    fail "workflow artifact skills missing artifact_language write target contract"
+fi
+
+if grep -Fq 'Preserve markdown structure, checkbox syntax, task IDs, branch names, commit messages, commands, file paths, config keys, package names, API names, `WARN`/`INFO` labels, and raw errors unchanged.' "$AIF_PLAN_SKILL" \
+   && grep -Fq 'Preserve Handoff annotations, markdown structure, checkbox syntax, paths, commands, config keys, code identifiers, package names, API names, raw error messages, code snippets, log prefixes such as `[FIX]`, and patch tags unchanged.' "$AIF_FIX_SKILL" \
+   && grep -Fq 'Preserve source quotations, source titles, URLs, local paths, code examples, API signatures, command names, config keys, package names, version strings, raw errors, and link targets unchanged.' "$AIF_REFERENCE_SKILL" \
+   && grep -Fq 'Preserve item IDs, dates, author handles, commands, paths, config keys, package names, API names, security category IDs, severity/status enum values, raw errors, and the final `aif-gate-result` JSON schema unchanged.' "$AIF_SECURITY_SKILL"; then
+    pass "workflow artifact skills preserve stable technical tokens"
+else
+    fail "workflow artifact skills missing stable technical token preservation"
+fi
+
+if grep -Fq 'Language:** `language.ui` for prompts, user-visible explanations, verification reports, context-gate summaries, issue remediation prompts, and next-step guidance' "$AIF_VERIFY_SKILL" \
+   && grep -Fq 'ui_language = language.ui || "en"' "$AIF_VERIFY_SKILL" \
+   && grep -Fq 'All AskUserQuestion prompts, user-visible explanations, verification reports, context-gate summaries, issue remediation prompts, and next-step guidance MUST be written in `ui_language`.' "$AIF_VERIFY_SKILL" \
+   && grep -Fq 'Preserve machine-readable `aif-gate-result` JSON schema fields and enum values (`pass`, `warn`, `fail`) unchanged.' "$AIF_VERIFY_SKILL"; then
+    pass "/aif-verify report language contract"
+else
+    fail "/aif-verify report language contract missing"
+fi
+
+CONFIG_LANGUAGE_ARTIFACTS_ROW="$(grep -F '| `language.artifacts` |' "$CONFIG_REFERENCE_DOC" || true)"
+CONFIG_LANGUAGE_TECH_TERMS_ROW="$(grep -F '| `language.technical_terms` |' "$CONFIG_REFERENCE_DOC" || true)"
+CONFIG_AIF_PLAN_ROW="$(grep -F '| `/aif-plan` |' "$CONFIG_REFERENCE_DOC" || true)"
+CONFIG_AIF_IMPROVE_ROW="$(grep -F '| `/aif-improve` |' "$CONFIG_REFERENCE_DOC" || true)"
+CONFIG_AIF_FIX_ROW="$(grep -F '| `/aif-fix` |' "$CONFIG_REFERENCE_DOC" || true)"
+CONFIG_AIF_RULES_ROW="$(grep -F '| `/aif-rules` | Yes | No |' "$CONFIG_REFERENCE_DOC" || true)"
+CONFIG_AIF_REFERENCE_ROW="$(grep -F '| `/aif-reference` |' "$CONFIG_REFERENCE_DOC" || true)"
+CONFIG_AIF_SECURITY_ROW="$(grep -F '| `/aif-security-checklist` |' "$CONFIG_REFERENCE_DOC" || true)"
+CONFIG_AIF_VERIFY_ROW="$(grep -F '| `/aif-verify` |' "$CONFIG_REFERENCE_DOC" || true)"
+if [[ "$CONFIG_LANGUAGE_ARTIFACTS_ROW" == *"/aif-plan"* && "$CONFIG_LANGUAGE_ARTIFACTS_ROW" == *"/aif-improve"* && "$CONFIG_LANGUAGE_ARTIFACTS_ROW" == *"/aif-fix"* && "$CONFIG_LANGUAGE_ARTIFACTS_ROW" == *"/aif-rules"* && "$CONFIG_LANGUAGE_ARTIFACTS_ROW" == *"/aif-reference"* && "$CONFIG_LANGUAGE_ARTIFACTS_ROW" == *"/aif-security-checklist"* ]] \
+   && [[ "$CONFIG_LANGUAGE_TECH_TERMS_ROW" == *"/aif-plan"* && "$CONFIG_LANGUAGE_TECH_TERMS_ROW" == *"/aif-improve"* && "$CONFIG_LANGUAGE_TECH_TERMS_ROW" == *"/aif-fix"* && "$CONFIG_LANGUAGE_TECH_TERMS_ROW" == *"/aif-rules"* && "$CONFIG_LANGUAGE_TECH_TERMS_ROW" == *"/aif-reference"* && "$CONFIG_LANGUAGE_TECH_TERMS_ROW" == *"/aif-security-checklist"* ]] \
+   && [[ "$CONFIG_AIF_PLAN_ROW" == *'`language.artifacts`'* && "$CONFIG_AIF_PLAN_ROW" == *'`language.technical_terms`'* ]] \
+   && [[ "$CONFIG_AIF_IMPROVE_ROW" == *'`language.artifacts`'* && "$CONFIG_AIF_IMPROVE_ROW" == *'`language.technical_terms`'* ]] \
+   && [[ "$CONFIG_AIF_FIX_ROW" == *'`language.artifacts`'* && "$CONFIG_AIF_FIX_ROW" == *'`language.technical_terms`'* ]] \
+   && [[ "$CONFIG_AIF_RULES_ROW" == *'`language.artifacts`'* && "$CONFIG_AIF_RULES_ROW" == *'`language.technical_terms`'* ]] \
+   && [[ "$CONFIG_AIF_REFERENCE_ROW" == *'`language.artifacts`'* && "$CONFIG_AIF_REFERENCE_ROW" == *'`language.technical_terms`'* ]] \
+   && [[ "$CONFIG_AIF_SECURITY_ROW" == *'`language.artifacts`'* && "$CONFIG_AIF_SECURITY_ROW" == *'`language.technical_terms`'* ]] \
+   && [[ "$CONFIG_AIF_VERIFY_ROW" == *'`language.ui`'* ]]; then
+    pass "config reference documents broadened workflow language keys"
+else
+    fail "config reference missing broadened workflow language keys"
+fi
+
+if grep -Fq 'Plan prompts and summaries use `language.ui`; saved plan artifacts use `language.artifacts`' "$SKILLS_DOC" \
+   && grep -Fq 'User-facing fix summaries use `language.ui`; `FIX_PLAN.md` and patch artifacts use `language.artifacts`' "$SKILLS_DOC" \
+   && grep -Fq 'Prompts and confirmations use `language.ui`; persisted rule artifacts use `language.artifacts`' "$SKILLS_DOC" \
+   && grep -Fq 'reference storage uses `paths.references`, prompts use `language.ui`, and generated reference files plus `INDEX.md` use `language.artifacts`' "$SKILLS_DOC" \
+   && grep -Fq 'persistent ignore state uses `paths.security` and `language.artifacts`' "$SKILLS_DOC" \
+   && grep -Fq '`language.artifacts` controls generated or persisted artifacts, including plans, fix plans, patches, rules, references, security ignore state, documentation, QA outputs, and `/aif-explore` research snapshots in `paths.research`.' "$CONFIGURATION_DOC"; then
+    pass "docs summarize broadened workflow language policy"
+else
+    fail "docs missing broadened workflow language policy"
 fi
 
 if grep -Fq '[Enhanced, clear description of the project in English]' "$AIF_SKILL"; then

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -390,11 +390,13 @@ fi
 
 # /aif localization contract regression checks
 AIF_SKILL="$ROOT_DIR/skills/aif/SKILL.md"
+AIF_EXPLORE_SKILL="$ROOT_DIR/skills/aif-explore/SKILL.md"
 AIF_COMMIT_SKILL="$ROOT_DIR/skills/aif-commit/SKILL.md"
 AIF_ARCH_SKILL="$ROOT_DIR/skills/aif-architecture/SKILL.md"
 CONFIG_REFERENCE_DOC="$ROOT_DIR/docs/config-reference.md"
 WORKFLOW_DOC="$ROOT_DIR/docs/workflow.md"
 SKILLS_DOC="$ROOT_DIR/docs/skills.md"
+CONFIGURATION_DOC="$ROOT_DIR/docs/configuration.md"
 MODE1_SECTION="$(awk '
     /^### Mode 1: Analyze Existing Project$/ { capture=1 }
     capture { print }
@@ -493,6 +495,51 @@ if grep -Fq 'After creating DESCRIPTION.md, resolve the project language setting
     fail "late language resolution wording reintroduced in /aif"
 else
     pass "no late language resolution wording in /aif"
+fi
+
+if grep -Fq 'ui_language = language.ui || "en"' "$AIF_EXPLORE_SKILL" \
+   && grep -Fq 'artifact_language = language.artifacts || language.ui || "en"' "$AIF_EXPLORE_SKILL" \
+   && grep -Fq 'technical_terms_policy = language.technical_terms || "keep"' "$AIF_EXPLORE_SKILL"; then
+    pass "/aif-explore resolves language variables"
+else
+    fail "/aif-explore language variable resolution missing"
+fi
+
+if grep -Fq 'All user-facing responses from `/aif-explore` MUST be written in `ui_language`.' "$AIF_EXPLORE_SKILL" \
+   && grep -Fq 'Persisted exploration artifacts under `paths.research` MUST be written in `artifact_language`.' "$AIF_EXPLORE_SKILL"; then
+    pass "/aif-explore separates ui and artifact language"
+else
+    fail "/aif-explore ui/artifact language split missing"
+fi
+
+if grep -Fq 'If `technical_terms_policy` is not one of `keep`, `translate`, or `mixed`, treat it as `keep`.' "$AIF_EXPLORE_SKILL" \
+   && grep -Fq 'Legacy values such as `english` also behave like `keep`.' "$AIF_EXPLORE_SKILL" \
+   && grep -Fq 'commands, paths, identifiers, config keys, API names, package names, branch names, code terms, and raw error messages unchanged' "$AIF_EXPLORE_SKILL"; then
+    pass "/aif-explore technical terms policy is explicit"
+else
+    fail "/aif-explore technical terms policy missing"
+fi
+
+CONFIG_LANGUAGE_ARTIFACTS_ROW="$(grep -F '| `language.artifacts` |' "$CONFIG_REFERENCE_DOC" || true)"
+CONFIG_LANGUAGE_TECH_TERMS_ROW="$(grep -F '| `language.technical_terms` |' "$CONFIG_REFERENCE_DOC" || true)"
+CONFIG_AIF_EXPLORE_ROW="$(grep -F '| `/aif-explore` |' "$CONFIG_REFERENCE_DOC" || true)"
+
+if [[ "$CONFIG_LANGUAGE_ARTIFACTS_ROW" == *"/aif-explore"* ]] \
+   && [[ "$CONFIG_LANGUAGE_TECH_TERMS_ROW" == *"/aif-explore"* ]] \
+   && [[ "$CONFIG_AIF_EXPLORE_ROW" == *'`language.ui`'* ]] \
+   && [[ "$CONFIG_AIF_EXPLORE_ROW" == *'`language.artifacts`'* ]] \
+   && [[ "$CONFIG_AIF_EXPLORE_ROW" == *'`language.technical_terms`'* ]]; then
+    pass "config reference documents /aif-explore language keys"
+else
+    fail "config reference missing /aif-explore language keys"
+fi
+
+if grep -Fq 'Uses `language.ui` for user-facing exploration responses, `language.artifacts` for persisted `paths.research` snapshots, and `language.technical_terms`' "$SKILLS_DOC" \
+   && grep -Fq '`language.artifacts` controls generated or persisted artifacts, including `/aif-explore` research snapshots in `paths.research`.' "$CONFIGURATION_DOC" \
+   && grep -Fq '`language.ui` / `language.artifacts` / `language.technical_terms`' "$ROOT_DIR/AGENTS.md"; then
+    pass "docs summarize /aif-explore language policy"
+else
+    fail "docs missing /aif-explore language policy summary"
 fi
 
 if grep -Fq '[Enhanced, clear description of the project in English]' "$AIF_SKILL"; then

--- a/skills/aif-explore/SKILL.md
+++ b/skills/aif-explore/SKILL.md
@@ -16,7 +16,12 @@ Enter explore mode. Think deeply. Visualize freely. Follow the conversation wher
 
 **FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
 - **Paths:** `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.research`, `paths.plan`, `paths.plans`, and `paths.rules`
-- **Language:** `language.ui` for communication
+- **Language:**
+  - `language.ui` for all user-facing responses: prompts, progress updates, explanations, exploration summaries, and next-step guidance
+  - `language.artifacts` for generated or persisted exploration artifacts, including the resolved `paths.research`
+  - `language.technical_terms` for human-readable technical terminology style in artifacts and summaries
+  - If `language.artifacts` is missing, use `language.ui`
+  - If both are missing, use `en`
 - **Workflow:** `workflow.plan_id_format` (default: `slug`) — used by the optional active-plan-context lookup when explore mode references an existing plan for the current branch.
   Active values: `slug` and `sequential`. When `sequential`, glob
   `<paths.plans>/[0-9]{4}_<branch_stem>.md` first and fall back to
@@ -26,8 +31,26 @@ Enter explore mode. Think deeply. Visualize freely. Follow the conversation wher
 
 If config.yaml doesn't exist, use defaults:
 - Paths: `.ai-factory/` for all artifacts
-- Language: `en` (English)
+- `ui_language`: `en`
+- `artifact_language`: `en`
+- `technical_terms_policy`: `keep`
 - `workflow.plan_id_format`: `slug`
+
+Store:
+- `ui_language = language.ui || "en"`
+- `artifact_language = language.artifacts || language.ui || "en"`
+- `technical_terms_policy = language.technical_terms || "keep"`
+
+If `technical_terms_policy` is not one of `keep`, `translate`, or `mixed`, treat it as `keep`. Legacy values such as `english` also behave like `keep`.
+
+All user-facing responses from `/aif-explore` MUST be written in `ui_language`.
+
+Persisted exploration artifacts under `paths.research` MUST be written in `artifact_language`.
+
+Apply `technical_terms_policy` while writing summaries and persisted artifacts:
+- `keep` - keep commands, paths, identifiers, config keys, API names, package names, branch names, code terms, and raw error messages unchanged
+- `translate` - translate human-readable technical terms where a natural target-language term exists
+- `mixed` - translate ordinary prose terms while keeping code, infrastructure, and ecosystem terms unchanged
 
 **This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
 
@@ -207,6 +230,8 @@ If the conversation is crystallizing (you're about to plan, you want to `/clear`
 
 **Hard rule in explore mode:** If the user chooses to save, you may write/edit **only** the resolved research path (and create its parent directory if missing). Do not write or modify any other project files.
 
+Write the saved research content in `artifact_language`. The skeleton below defines structure, not fixed English output. If `artifact_language` is not `en`, translate human-readable headings, labels, notes, and prose before saving. Preserve markdown markers, paths, commands, config keys, issue URLs, branch names, code identifiers, package names, and raw error messages unchanged.
+
 Ask:
 
 ```
@@ -220,7 +245,7 @@ Options:
 
 If user selects (1) or (2):
 - Ensure the parent directory of the resolved research path exists (`mkdir -p "$(dirname "<resolved research path>")"`)
-- If the resolved research path does not exist, create it with this skeleton:
+- If the resolved research path does not exist, create it with this skeleton, localized to `artifact_language` before saving:
 
 ```markdown
 # Research
@@ -245,7 +270,7 @@ Next step:
 ```
 
 - Update the `Updated:` timestamp
-- Replace only the content inside `aif:active-summary:start/end`
+- Replace only the content inside `aif:active-summary:start/end`, written in `artifact_language`
 - If user selected option (1), append a new session entry just before `<!-- aif:sessions:end -->`:
 
 ```markdown

--- a/skills/aif-fix/SKILL.md
+++ b/skills/aif-fix/SKILL.md
@@ -343,6 +343,8 @@ try {
 
 **ALWAYS suggest covering this case with a test:**
 
+The Step 5 and After Fixing output templates define structure only. Render all human-readable text in these user-facing responses in `ui_language`. Preserve code snippets, commands, file paths, line references, log prefixes such as `[FIX]`, and AskUserQuestion option structure unchanged.
+
 ```
 ## Fix Applied ✅
 

--- a/skills/aif-fix/SKILL.md
+++ b/skills/aif-fix/SKILL.md
@@ -48,7 +48,7 @@ When creating a new FIX_PLAN.md: if there is no existing annotation and no Hando
 **FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
 
 - **Paths:** `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.rules`, `paths.fix_plan`, and `paths.patches`
-- **Language:** `language.ui` for prompts
+- **Language:** `language.ui` for prompts and summaries, `language.artifacts` for `FIX_PLAN.md` and patch artifacts, and `language.technical_terms` for human-readable technical terminology in artifacts
 - **Rules:** `rules.base` plus any named `rules.<area>` entries
 
 If config.yaml doesn't exist, use defaults:
@@ -59,7 +59,22 @@ If config.yaml doesn't exist, use defaults:
 - rules/: `.ai-factory/rules/`
 - FIX_PLAN.md: `.ai-factory/FIX_PLAN.md`
 - patches/: `.ai-factory/patches/`
-- Language: `en` (English)
+- `ui_language`: `en`
+- `artifact_language`: `en`
+- `technical_terms_policy`: `keep`
+
+Resolved language values:
+- `ui_language = language.ui || "en"`
+- `artifact_language = language.artifacts || language.ui || "en"`
+- `technical_terms_policy = language.technical_terms || "keep"`
+
+If `technical_terms_policy` is not one of `keep`, `translate`, or `mixed`, treat it as `keep`. Legacy values such as `english` also behave like `keep`.
+
+All AskUserQuestion prompts, progress updates, fix summaries, test prompts, and next-step guidance MUST be written in `ui_language`.
+
+Generated `FIX_PLAN.md` and self-improvement patch files under `paths.patches` MUST be written in `artifact_language`.
+
+Templates and examples define structure, not fixed English output. If `artifact_language` is not `en`, translate human-readable headings, labels, analysis text, fix steps, risks, prevention notes, and patch prose before saving. Preserve Handoff annotations, markdown structure, checkbox syntax, paths, commands, config keys, code identifiers, package names, API names, raw error messages, code snippets, log prefixes such as `[FIX]`, and patch tags unchanged. Apply `technical_terms_policy` to other human-readable terminology.
 
 ### Step 0.1: Check for Existing Fix Plan
 
@@ -180,6 +195,8 @@ After agents return, synthesize findings to:
 3. Assess impact scope
 
 Then create the resolved fix plan file (default: `.ai-factory/FIX_PLAN.md`).
+
+Write the fix plan in `artifact_language`. The template below is the required structure only; translate human-readable headings, labels, and prose before saving when `artifact_language` is not `en`, while preserving stable technical tokens from Step 0.
 
 **Before writing:** If `HANDOFF_MODE` is `1` and `HANDOFF_TASK_ID` is non-empty, the very first line of the file MUST be `<!-- handoff:task:<HANDOFF_TASK_ID> -->` followed by a blank line, then the plan content below. If in manual mode and a task ID was extracted from an existing annotation, preserve it.
 
@@ -482,6 +499,8 @@ function fixedFunction(input) {
    **Format:** `YYYY-MM-DD-HH.mm.md` (e.g., `2026-02-07-14.30.md`)
 
 3. Use this template:
+
+Write the patch artifact in `artifact_language`. The template below is the required structure only; translate human-readable headings, labels, root-cause text, solution text, and prevention text before saving when `artifact_language` is not `en`, while preserving stable technical tokens from Step 0.
 
 ```markdown
 # [Brief title describing the fix]

--- a/skills/aif-improve/SKILL.md
+++ b/skills/aif-improve/SKILL.md
@@ -26,7 +26,7 @@ enhanced plan with better tasks, correct dependencies, more detail
 
 **FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
 - **Paths:** `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.research`, `paths.description`, and `paths.patches`
-- **Language:** `language.ui` for prompts
+- **Language:** `language.ui` for prompts and summaries, `language.artifacts` for plan artifact updates, and `language.technical_terms` for human-readable technical terminology in plan artifacts
 - **Git:** `git.enabled`, `git.base_branch`, `git.create_branches`
 - **Workflow:** `workflow.plan_id_format` (default: `slug`) — used by branch-based plan discovery.
   Active values: `slug` and `sequential`. When `sequential`, the resolver globs
@@ -42,8 +42,23 @@ If config.yaml doesn't exist, use defaults:
 - research: `.ai-factory/RESEARCH.md`
 - patches/: `.ai-factory/patches/`
 - DESCRIPTION.md: `.ai-factory/DESCRIPTION.md`
-- Language: `en` (English)
+- `ui_language`: `en`
+- `artifact_language`: `en`
+- `technical_terms_policy`: `keep`
 - `workflow.plan_id_format`: `slug`
+
+Resolved language values:
+- `ui_language = language.ui || "en"`
+- `artifact_language = language.artifacts || language.ui || "en"`
+- `technical_terms_policy = language.technical_terms || "keep"`
+
+If `technical_terms_policy` is not one of `keep`, `translate`, or `mixed`, treat it as `keep`. Legacy values such as `english` also behave like `keep`.
+
+All AskUserQuestion prompts, progress updates, refinement reports, summaries, and next-step guidance MUST be written in `ui_language`.
+
+Any generated or updated plan artifact content under `paths.plan`, `paths.plans`, or `paths.fix_plan` MUST be written in `artifact_language`.
+
+Templates and examples define structure, not fixed English output. If `artifact_language` is not `en`, translate human-readable headings, labels, task prose, roadmap rationale, research summaries, improvement notes, and dependency notes before saving. Preserve markdown structure, checkbox syntax, task IDs, numeric prefixes, branch names, commit messages, commands, file paths, config keys, package names, API names, `WARN`/`INFO` labels, and raw errors unchanged. Apply `technical_terms_policy` to other human-readable terminology.
 
 **First parse arguments:**
 
@@ -371,6 +386,8 @@ The difference between the two is the report only. `removals` are dead-weight du
 - Preserve any `- [x]` checkboxes for already completed tasks
 
 Use `Edit` to make surgical changes to the plan file, or `Write` to regenerate it if changes are extensive.
+
+When editing or regenerating the plan file, keep all human-readable artifact content in `artifact_language`; the examples above are structural only. Preserve completed `- [x]` checkboxes exactly.
 
 **Filename invariant:** when the existing plan filename matches the sequential
 pattern `^[0-9]{4}_.*\.md$` (e.g. `0042_feature-user-auth.md`), preserve the

--- a/skills/aif-improve/SKILL.md
+++ b/skills/aif-improve/SKILL.md
@@ -326,6 +326,8 @@ Options:
 
 **If no improvements found:**
 
+The completion templates below define structure only. Render all human-readable text in these user-facing responses in `ui_language`. Preserve command names, paths, task counts, and numeric counts unchanged.
+
 ```
 ## Plan Review Complete
 

--- a/skills/aif-plan/SKILL.md
+++ b/skills/aif-plan/SKILL.md
@@ -87,16 +87,31 @@ Preserve the `<!-- handoff:task:<id> -->` annotation on the first line when rewr
 **FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
 
 - **Paths:** `paths.description`, `paths.architecture`, `paths.roadmap`, `paths.research`, `paths.rules_file`, `paths.plan`, `paths.plans`, `paths.patches`, `paths.evolutions`, `paths.specs`, and `paths.rules`
-- **Language:** `language.ui` for AskUserQuestion prompts
+- **Language:** `language.ui` for AskUserQuestion prompts, `language.artifacts` for generated plan files, and `language.technical_terms` for human-readable technical terminology in plan artifacts
 - **Git:** `git.enabled`, `git.base_branch`, `git.create_branches`, and `git.branch_prefix`
 - **Workflow:** `workflow.plan_id_format` — controls full-mode plan filename shape. Allowed values: `slug` (default), `timestamp`, `uuid`, `sequential`. Only `slug` and `sequential` are active; `timestamp` and `uuid` are **reserved** and currently behave like `slug` (with an `INFO` log). The `sequential` value writes plan files as `<NNNN>_<plan_file_stem>.md` (see Step 1.2 for the canonical stem and the algorithm). Treat any unknown value as `slug` and emit `WARN [aif-plan] unknown workflow.plan_id_format=<value>; falling back to slug`.
 
 If config.yaml doesn't exist, use defaults:
 
 - Paths: `.ai-factory/` for all artifacts
-- Language: `en` (English)
+- `ui_language`: `en`
+- `artifact_language`: `en`
+- `technical_terms_policy`: `keep`
 - Git: `enabled: true`, `base_branch: main`, `create_branches: true`, `branch_prefix: feature/`
 - Workflow: `plan_id_format: slug`
+
+Resolved language values:
+- `ui_language = language.ui || "en"`
+- `artifact_language = language.artifacts || language.ui || "en"`
+- `technical_terms_policy = language.technical_terms || "keep"`
+
+If `technical_terms_policy` is not one of `keep`, `translate`, or `mixed`, treat it as `keep`. Legacy values such as `english` also behave like `keep`.
+
+All AskUserQuestion prompts, progress updates, summaries, and next-step guidance MUST be written in `ui_language`.
+
+Generated plan artifacts under `paths.plan` or `paths.plans` MUST be written in `artifact_language`.
+
+Templates and examples define structure, not fixed English output. If `artifact_language` is not `en`, translate human-readable headings, labels, task prose, roadmap rationale, research summaries, settings explanations, and dependency notes before saving. Preserve markdown structure, checkbox syntax, task IDs, branch names, commit messages, commands, file paths, config keys, package names, API names, `WARN`/`INFO` labels, and raw errors unchanged. Apply `technical_terms_policy` to other human-readable terminology.
 
 **THEN:** Read `.ai-factory/DESCRIPTION.md` (use path from config) if it exists to understand:
 
@@ -610,6 +625,8 @@ If the resolved research path exists:
 - Keep it compact; it should be readable as a one-screen requirements snapshot
 
 Use the canonical template in `references/TASK-FORMAT.md` (Plan File Template).
+
+The canonical template defines the required sections and ordering only. Render all human-readable plan content in `artifact_language` before writing the file, applying `technical_terms_policy` and preserving stable tokens as described in Step 0.
 
 **Commit Plan Rules:**
 

--- a/skills/aif-plan/SKILL.md
+++ b/skills/aif-plan/SKILL.md
@@ -651,6 +651,8 @@ CONTEXT FROM /aif-plan:
 
 **Full mode normal:** STOP after planning. The user reviews the plan and decides when to implement.
 
+The next-step templates below define structure only. Render all human-readable text in these user-facing responses in `ui_language`. Preserve command names, configured paths, task counts, and TaskList references unchanged.
+
 ```
 Plan created with [N] tasks.
 Plan file: <configured plans dir>/<resolved-plan-file>      # see Step 1.2 / Step 5 for the exact stem

--- a/skills/aif-reference/SKILL.md
+++ b/skills/aif-reference/SKILL.md
@@ -21,12 +21,27 @@ Create structured knowledge references from external sources and store them in t
 
 **FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
 - **Paths:** `paths.references` and `paths.rules_file`
-- **Language:** `language.ui` for prompts
+- **Language:** `language.ui` for prompts and summaries, `language.artifacts` for generated reference artifacts, and `language.technical_terms` for human-readable technical terminology in references
 
 If config.yaml doesn't exist, use defaults:
 - references/: `.ai-factory/references/`
 - RULES.md: `.ai-factory/RULES.md`
-- Language: `en` (English)
+- `ui_language`: `en`
+- `artifact_language`: `en`
+- `technical_terms_policy`: `keep`
+
+Resolved language values:
+- `ui_language = language.ui || "en"`
+- `artifact_language = language.artifacts || language.ui || "en"`
+- `technical_terms_policy = language.technical_terms || "keep"`
+
+If `technical_terms_policy` is not one of `keep`, `translate`, or `mixed`, treat it as `keep`. Legacy values such as `english` also behave like `keep`.
+
+All AskUserQuestion prompts, progress updates, summaries, and next-step guidance MUST be written in `ui_language`.
+
+Generated reference files and the reference `INDEX.md` MUST be written in `artifact_language`.
+
+Templates and examples define structure, not fixed English output. If `artifact_language` is not `en`, translate human-readable headings, labels, summaries, concept explanations, best-practice prose, pitfalls, and index descriptions before saving. Preserve source quotations, source titles, URLs, local paths, code examples, API signatures, command names, config keys, package names, version strings, raw errors, and link targets unchanged. Apply `technical_terms_policy` to other human-readable terminology.
 
 ### Project Context
 
@@ -123,6 +138,8 @@ Transform collected material into a structured reference document.
 
 **Reference file format:**
 
+Render this structure in `artifact_language` before saving. The headings below are canonical structure labels, not fixed English output.
+
 ```markdown
 # <Topic> Reference
 
@@ -186,6 +203,8 @@ Transform collected material into a structured reference document.
 
 Check if `<resolved references dir>/INDEX.md` exists. Create or update it:
 
+Write human-readable index headings, topic descriptions, and source summaries in `artifact_language`; keep filenames, links, URLs, and dates unchanged.
+
 ```markdown
 # References Index
 
@@ -241,7 +260,7 @@ To make a skill aware of a specific reference, mention it in the resolved RULES.
 - **Primary ownership:** the resolved references directory (default: `.ai-factory/references/`)
 - **Shared ownership:** the resolved references index file (`INDEX.md` inside that directory)
 - **Read-only:** all other `.ai-factory/` files
-- **Config policy:** config-aware. Use `paths.references` for storage and `paths.rules_file` when pointing other skills at a saved reference.
+- **Config policy:** config-aware. Use `paths.references` for storage, `paths.rules_file` when pointing other skills at a saved reference, `language.ui` for prompts and summaries, `language.artifacts` for generated reference artifacts, and `language.technical_terms` for human-readable terminology policy.
 
 ## Guardrails
 

--- a/skills/aif-rules/SKILL.md
+++ b/skills/aif-rules/SKILL.md
@@ -37,12 +37,27 @@ AI Factory supports a three-level rules hierarchy:
 
 **FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
 - **Paths:** `paths.rules_file` and `paths.rules`
-- **Language:** `language.ui` for prompts
+- **Language:** `language.ui` for prompts and summaries, `language.artifacts` for rules artifacts, and `language.technical_terms` for human-readable technical terminology in rules
 
 If config.yaml doesn't exist, use defaults:
 - RULES.md: `.ai-factory/RULES.md`
 - rules/: `.ai-factory/rules/`
-- Language: `en` (English)
+- `ui_language`: `en`
+- `artifact_language`: `en`
+- `technical_terms_policy`: `keep`
+
+Resolved language values:
+- `ui_language = language.ui || "en"`
+- `artifact_language = language.artifacts || language.ui || "en"`
+- `technical_terms_policy = language.technical_terms || "keep"`
+
+If `technical_terms_policy` is not one of `keep`, `translate`, or `mixed`, treat it as `keep`. Legacy values such as `english` also behave like `keep`.
+
+All AskUserQuestion prompts, progress updates, confirmations, and next-step guidance MUST be written in `ui_language`.
+
+Generated or updated rules artifacts under `paths.rules_file` and `paths.rules/<area>.md` MUST be written in `artifact_language`.
+
+Templates and examples define structure, not fixed English output. If `artifact_language` is not `en`, translate human-readable headings, notes, rule text, labels, and confirmation prose before saving. Preserve markdown structure, paths, commands, config keys such as `rules.<area>`, area names, code identifiers, package names, API names, and raw errors unchanged. Apply `technical_terms_policy` to other human-readable terminology.
 
 ### Step 0.1: Load Skill Context
 
@@ -215,6 +230,7 @@ Use `Edit` to append the new rule as a `- ` list item at the end of the `## Rule
 - No categories, headers, or sub-lists - flat list only
 - No duplicates - if rule already exists (same meaning), tell user and skip
 - If user provides multiple rules at once (separated by newlines or semicolons), add each as a separate line
+- Write generated rule text in `artifact_language`; translate user-provided human-readable rule text when needed so the persisted artifact follows `language.artifacts`, while preserving stable technical tokens from Step 0.
 
 ### Step 4: Confirm
 

--- a/skills/aif-security-checklist/SKILL.md
+++ b/skills/aif-security-checklist/SKILL.md
@@ -28,11 +28,26 @@ Comprehensive security checklist based on OWASP Top 10 (2021) and industry best 
 
 **FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
 - **Paths:** `paths.security`
-- **Language:** `language.ui` for prompts
+- **Language:** `language.ui` for prompts, audit summaries, and next-step guidance; `language.artifacts` for the ignored-item state artifact; `language.technical_terms` for human-readable technical terminology in the ignored-item artifact
 
 If config.yaml doesn't exist, use defaults:
 - SECURITY.md: `.ai-factory/SECURITY.md`
-- Language: `en` (English)
+- `ui_language`: `en`
+- `artifact_language`: `en`
+- `technical_terms_policy`: `keep`
+
+Resolved language values:
+- `ui_language = language.ui || "en"`
+- `artifact_language = language.artifacts || language.ui || "en"`
+- `technical_terms_policy = language.technical_terms || "keep"`
+
+If `technical_terms_policy` is not one of `keep`, `translate`, or `mixed`, treat it as `keep`. Legacy values such as `english` also behave like `keep`.
+
+All AskUserQuestion prompts, audit summaries, ignored-item explanations shown to the user, and next-step guidance MUST be written in `ui_language`.
+
+The persistent `SECURITY.md` ignored-item artifact under `paths.security` MUST be written in `artifact_language`.
+
+Templates and examples define structure, not fixed English output. If `artifact_language` is not `en`, translate human-readable headings, table captions, notes, ignored-item reasons when generated, and review guidance before saving. Preserve item IDs, dates, author handles, commands, paths, config keys, package names, API names, security category IDs, severity/status enum values, raw errors, and the final `aif-gate-result` JSON schema unchanged. Apply `technical_terms_policy` to other human-readable terminology.
 
 ## Ignored Items (SECURITY.md)
 
@@ -57,6 +72,8 @@ Before running any audit, **always read** the resolved SECURITY.md path (default
 3. Non-ignored items are audited as usual
 
 ### SECURITY.md format
+
+Render this structure in `artifact_language` before saving. The headings below are canonical structure labels, not fixed English output; item IDs and table field meanings stay stable.
 
 ```markdown
 # Security: Ignored Items
@@ -589,4 +606,4 @@ grep -rn "innerHTML.*llm\|innerHTML.*response\|innerHTML.*completion" --include=
 
 - Primary ownership: the resolved SECURITY.md artifact (default: `.ai-factory/SECURITY.md`) for ignored-item state created through the `ignore` flow.
 - Write policy: audit findings are normally conversational output; persistent writes are limited to the ignore-state artifact above unless the user explicitly asks for more.
-- Config policy: config-aware. Use `paths.security` for the ignore-state artifact while deriving audit scope from repo evidence and audit commands.
+- Config policy: config-aware. Use `paths.security` for the ignore-state artifact, `language.ui` for prompts and audit summaries, `language.artifacts` for the ignored-item artifact, and `language.technical_terms` for human-readable terminology policy while deriving audit scope from repo evidence and audit commands.

--- a/skills/aif-verify/SKILL.md
+++ b/skills/aif-verify/SKILL.md
@@ -30,6 +30,7 @@ Verify that the completed implementation matches the plan, nothing was missed, a
 - **verify_mode:** default verification strictness (`strict` | `normal` | `lenient`)
 - **Git:** `git.enabled`, `git.base_branch`, `git.create_branches`
 - **Rules hierarchy:** the resolved RULES.md path + `rules.base` + named `rules.<area>` entries
+- **Language:** `language.ui` for prompts, user-visible explanations, verification reports, context-gate summaries, issue remediation prompts, and next-step guidance
 - **Workflow:** `workflow.plan_id_format` (default: `slug`) — used by branch-based plan discovery in Step 0.2.
   Active values: `slug` and `sequential`. When `sequential`, the resolver globs
   `<paths.plans>/[0-9]{4}_<branch_stem>.md` first and falls back to
@@ -46,7 +47,15 @@ If config.yaml doesn't exist, use defaults:
 - Paths: `.ai-factory/` for all artifacts
 - verify_mode: `normal`
 - Rules: RULES.md only
+- `ui_language`: `en`
 - `workflow.plan_id_format`: `slug`
+
+Resolved language value:
+- `ui_language = language.ui || "en"`
+
+All AskUserQuestion prompts, user-visible explanations, verification reports, context-gate summaries, issue remediation prompts, and next-step guidance MUST be written in `ui_language`.
+
+Preserve machine-readable `aif-gate-result` JSON schema fields and enum values (`pass`, `warn`, `fail`) unchanged. Preserve `WARN`/`ERROR` gate labels, commands, paths, config keys, code identifiers, package names, API names, and raw command output unchanged.
 
 ### 0.1 Load Ownership and Gate Contract
 
@@ -362,6 +371,8 @@ Options:
 ## Step 4: Verification Report
 
 ### 4.1 Display Results
+
+Write the human-readable verification report in `ui_language`. The template below defines structure only; keep stable technical tokens and the final `aif-gate-result` JSON schema unchanged.
 
 ```
 ## Verification Report


### PR DESCRIPTION
## Summary
- Fix `/aif-explore` so user-facing output follows `language.ui`, persisted research follows `language.artifacts`, and stable technical tokens remain preserved.
- Broaden the same language-policy contract across workflow artifact skills: plan, improve, fix, rules, reference, security checklist, and verify.
- Update docs/config matrices and add regression checks for the expanded language-policy coverage.

## Linked issue
Fixes #121

## Why
Issue #121 reported that `/aif-explore` ignored the configured UI language. During follow-up review, several adjacent workflow skills had the same incomplete language contract for reports or persisted artifacts.

## Validation
- `npm run build` passed
- `npm run lint` passed
- `git diff --check` passed
- `bash -n scripts/test-skills.sh` passed
- `npm test` ran: 116/122 passed; remaining failures are existing local environment issues (`python3` missing for aif-distillation helper tests and Windows npm resolver smoke failure)