### PR TITLE
feat(aif-archive): add plan archival skill and paths.archive config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ Artifact writers are command-scoped to prevent ownership conflicts:
 | `paths.evolutions/*.md` and `paths.evolutions/patch-cursor.json`                              | `/aif-evolve`          | evolution logs and incremental patch cursor                                                      |
 | `.ai-factory/evolution/*` artifacts                                                           | `/aif-loop`            | loop state ownership                                                                             |
 | `paths.qa` (default: `.ai-factory/qa/<branch-slug>/`)                                         | `/aif-qa`              | change-summary, test-plan, test-cases artifacts; branch slug used as subdirectory                |
+| `paths.archive/plans/*.md`, `paths.archive/roadmap/*.md`                                      | `/aif-archive`         | archived completed plans and dated roadmap snapshots                                             |
 
 Quality commands (`/aif-rules-check`, `/aif-commit`, `/aif-review`, `/aif-verify`) are read-only for context artifacts by default.
 
@@ -141,7 +142,7 @@ Current config-agnostic built-ins:
 Current config keys in active use:
 
 - `paths.*` - artifact discovery for description, architecture, roadmap, research, RULES.md, plan files, fix plans, QA artifacts,
-  references, security state, patches, evolutions, loop state, and rules
+  references, security state, patches, evolutions, loop state, rules, and archive
 - `language.ui` / `language.artifacts` / `language.technical_terms` - prompt/report language, generated artifact language, and terminology handling while preserving commands, paths, identifiers, config keys, and raw errors where required
 - `git.enabled` / `git.base_branch` / `git.create_branches` / `git.branch_prefix` / `git.skip_push_after_commit` - planning, verification, and commit push behavior
 - `workflow.verify_mode` - default verification strictness

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 **AI Factory** (v2) is an npm package + skill system that automates AI agent context setup for projects. It provides:
 
 1. **CLI tool** (`ai-factory init/update/upgrade`) — installs skills and configures MCP
-2. **Built-in skills** (26 skills, all `aif-*` prefixed) — workflow commands for spec-driven development
+2. **Built-in skills** (27 skills, all `aif-*` prefixed) — workflow commands for spec-driven development
 3. **Spec-driven workflow** — structured approach: plan → implement → commit
 4. **Multi-agent support** — 16 agents (Claude Code, Cursor, Windsurf, Roo Code, Kilo Code, Antigravity, OpenCode, Warp,
    Zencoder, Codex CLI, Codex app, GitHub Copilot, Gemini CLI, Junie, Qwen Code, Universal)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ Context gate policy for quality commands:
   `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`
 - Additional utility: `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`,
   `/aif-distillation`,
-  `/aif-security-checklist`, `/aif-qa`
+  `/aif-security-checklist`, `/aif-qa`, `/aif-archive`
 
 Current config-agnostic built-ins:
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -77,6 +77,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | `paths.specs` | `.ai-factory/specs/` | `/aif-plan`, `/aif-verify` | Specs / archived plan support |
 | `paths.rules` | `.ai-factory/rules/` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-rules` | Area-rules directory and relative rule resolution base |
 | `paths.qa` | `.ai-factory/qa/` | `/aif-qa` | QA artifacts root; branch slug is appended as subdirectory (`<paths.qa>/<branch-slug>/`) |
+| `paths.archive` | `.ai-factory/archive/` | `/aif-archive`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-improve` | Archive directory for completed plans and roadmap snapshots. Subdirectories: `archive/plans/` for archived plan files, `archive/roadmap/` for dated roadmap snapshots. Plans retain original filenames including sequential prefix. |
 
 ### `workflow`
 
@@ -137,6 +138,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | `/aif-security-checklist` | Yes | No | `paths.security`, `language.ui`, `language.artifacts`, `language.technical_terms` |
 | `/aif-rules` | Yes | Yes, limited | `paths.rules_file`, `paths.rules`, `language.ui`, `language.artifacts`, `language.technical_terms`; writes only `rules.<area>` registrations and may bootstrap minimal config for first area rule |
 | `/aif-qa` | Yes | No | `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, `language.artifacts`, `language.technical_terms`, `git.enabled`, `git.base_branch` |
+| `/aif-archive` | Yes | No | `paths.plans`, `paths.archive`, `paths.plan`, `paths.fix_plan`, `paths.roadmap`, `workflow.plan_id_format`, `language.ui` |
 
 ### Config-Agnostic Built-ins
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,6 +161,7 @@ paths:
   specs: .ai-factory/specs/
   rules: .ai-factory/rules/
   qa: .ai-factory/qa/
+  archive: .ai-factory/archive/
 
 # Workflow Settings
 workflow:
@@ -189,7 +190,7 @@ rules:
 
 **Current config-aware skills** read `config.yaml` at Step 0. This currently includes:
 - Core workflow and quality commands: `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`
-- Additional utility commands: `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-distillation`, `/aif-security-checklist`, `/aif-qa`
+- Additional utility commands: `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-distillation`, `/aif-security-checklist`, `/aif-qa`, `/aif-archive`
 
 Other skills are config-agnostic for now and rely on repository context, explicit arguments, or fixed non-configurable paths such as `skill-context`.
 

--- a/docs/plan-files.md
+++ b/docs/plan-files.md
@@ -12,6 +12,21 @@ Paths below show the default `.ai-factory/` layout. `config.yaml` can relocate p
 | `/aif-plan full` | `paths.plans/<stem>.md` (default; `stem` = Handoff branch → git branch → description slug, per `/aif-plan` Step 1.2.a) | Keep (user decides) |
 | `/aif-plan full` (`workflow.plan_id_format: sequential`) | `paths.plans/<NNNN>_<stem>.md` (4-digit, capped at `9999`; `NNNN` is derived from existing numbered plans in the directory) | Keep (user decides) |
 
+## Archive Lifecycle
+
+When plans accumulate, `/aif-archive` moves completed plans to `paths.archive/plans/` (default: `.ai-factory/archive/plans/`):
+
+```
+paths.plans/<plan>.md  →  (all tasks [x])  →  paths.archive/plans/<plan>.md
+```
+
+- Original filenames are preserved (including sequential `NNNN_` prefix)
+- An `archived: YYYY-MM-DD` field is added to the plan's YAML frontmatter
+- Archived plans are excluded from plan discovery by `/aif-implement`, `/aif-verify`, `/aif-improve`
+- Sequential numbering in `/aif-plan` only counts files in `paths.plans/`, not the archive
+
+Roadmap snapshots: `/aif-archive --roadmap` trims closed milestones from `ROADMAP.md` into dated snapshots under `paths.archive/roadmap/`.
+
 ## Artifact Ownership Quick Map
 
 To avoid ownership conflicts, artifact writers are command-scoped:
@@ -27,6 +42,7 @@ To avoid ownership conflicts, artifact writers are command-scoped:
 | `paths.fix_plan` and `paths.patches/*.md`                                 | `/aif-fix`            | defaults shown; actual paths come from `paths.fix_plan` and `paths.patches`                    |
 | `.ai-factory/skill-context/*`                                             | `/aif-evolve`         | project-specific skill overrides derived from patches                                          |
 | `paths.evolutions/*.md`, `paths.evolutions/patch-cursor.json`             | `/aif-evolve`         | defaults shown; actual evolution-log path comes from `paths.evolutions`                        |
+| `paths.archive/plans/*.md`, `paths.archive/roadmap/*.md`                  | `/aif-archive`        | archived plan files and dated roadmap snapshots                                                |
 
 Quality commands (`/aif-commit`, `/aif-review`, `/aif-verify`) treat these files as read-only context by default.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,7 +2,7 @@
 
 # Core Skills
 
-**Config-aware skills read `.ai-factory/config.yaml` at startup** to resolve paths, language settings, workflow preferences, and rules hierarchy. The current config-aware set is `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`, `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-distillation`, `/aif-security-checklist`, and `/aif-qa`.
+**Config-aware skills read `.ai-factory/config.yaml` at startup** to resolve paths, language settings, workflow preferences, and rules hierarchy. The current config-aware set is `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`, `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-reference`, `/aif-distillation`, `/aif-security-checklist`, `/aif-qa`, and `/aif-archive`.
 
 `/aif` is also the primary writer for `config.yaml`: the initial file comes from the commented template, and setup reruns update only managed keys while preserving comments, unrelated manual edits, and `rules.<area>` entries owned by `/aif-rules`.
 
@@ -480,6 +480,23 @@ Runs a standalone read-only rules compliance gate:
 - Remains read-only; if rules need to change, route that through `/aif-rules`
 
 - Config policy: config-aware; reads rule paths, optional active plan context, and git diff defaults from `config.yaml`
+
+### `/aif-archive [list | --roadmap | --all | <plan-name>]`
+Archives completed plans and trims closed roadmap milestones:
+```
+/aif-archive                    # Scan for completed plans, ask which to archive
+/aif-archive list               # Show archived plans and roadmap snapshots
+/aif-archive --all              # Archive all completed plans (with confirmation)
+/aif-archive --roadmap          # Trim closed milestones from ROADMAP.md into a snapshot
+/aif-archive 0005_feature-auth  # Archive a specific plan by name or partial stem
+```
+- Reads `.ai-factory/config.yaml` for `paths.plans`, `paths.archive`, `paths.plan`, `paths.fix_plan`, `paths.roadmap`, `workflow.plan_id_format`, and `language.ui`
+- A plan is "completed" when all checkboxes in its `## Tasks` section are `- [x]`
+- Preserves original filenames (including sequential `NNNN_` prefix) when moving to archive
+- Adds `archived: YYYY-MM-DD` to the plan's YAML frontmatter
+- Archived plans are excluded from plan discovery by `/aif-implement`, `/aif-verify`, `/aif-improve`
+- Does not touch fast plans (`paths.plan`) or fix plans (`paths.fix_plan`)
+- `--roadmap` creates a dated snapshot under `paths.archive/roadmap/` and removes closed milestones from the source roadmap (with confirmation)
 
 ### `/aif-reference <url|path> [url2|path2] [--name <ref-name>] [--update]`
 Creates knowledge references from external sources for AI agents:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -180,6 +180,7 @@ Optional conventions step: use `/aif-rules` to append or refine project-wide axi
 | `/aif-rules-check` | Standalone read-only rules compliance gate for staged work, working tree, or a git ref | No | No (reads existing rules and optional plan context) |
 | `/aif-verify` | Post-implementation quality check | No | No (reads existing) |
 | `/aif-qa` | Manual QA for a feature/fix: change summary → test plan → test cases | No | `paths.qa/<branch-slug>/*.md` (default: `.ai-factory/qa/<branch-slug>/`) |
+| `/aif-archive` | Archive completed plans and trim closed roadmap milestones | No | `paths.archive/plans/*.md`, `paths.archive/roadmap/*.md` (default: `.ai-factory/archive/`) |
 
 `/aif-qa change-summary` normally derives context from git diffs. When `git.enabled=false` or the target/base refs cannot be resolved locally or through `origin/<base_branch>`, it asks for manual change context instead of failing on git commands.
 
@@ -200,6 +201,7 @@ Ownership is command-scoped to avoid conflicting writers:
 | `/aif-fix`                                | `paths.fix_plan`, `paths.patches/*.md`                                                        | bug-fix learning loop artifacts                           |
 | `/aif-evolve`                             | `paths.evolutions/*.md`, `paths.evolutions/patch-cursor.json`, `.ai-factory/skill-context/*`  | skill-context overrides + evolution logs + cursor state   |
 | `/aif-qa`                                 | `paths.qa/<branch-slug>/change-summary.md`, `test-plan.md`, `test-cases.md`                   | derived branch slug as subdirectory (see aif-qa SKILL.md) |
+| `/aif-archive`                            | `paths.archive/plans/*.md`, `paths.archive/roadmap/*.md`                                      | moves completed plans from `paths.plans/`; trims closed milestones from `paths.roadmap` |
 | `/aif-rules-check`                        | read-only context by default                                                                  | standalone rules gate; no default context-file writes     |
 | `/aif-commit` `/aif-review` `/aif-verify` | read-only context by default                                                                  | gate and report, no default context-file writes           |
 

--- a/scripts/test-aif-config.sh
+++ b/scripts/test-aif-config.sh
@@ -70,6 +70,7 @@ cat > "$CREATE_PAYLOAD" <<'EOF'
     "paths.specs": ".ai-factory/specs/",
     "paths.rules": ".ai-factory/rules/",
     "paths.qa": ".ai-factory/qa/",
+    "paths.archive": ".ai-factory/archive/",
     "workflow.auto_create_dirs": true,
     "workflow.plan_id_format": "slug",
     "workflow.analyze_updates_architecture": true,
@@ -96,6 +97,7 @@ assert_contains "$CREATE_TARGET" '^  ui: ru$' "fresh create must set language.ui
 assert_contains "$CREATE_TARGET" '^  docs: handbook/$' "fresh create must set overridden docs path"
 assert_contains "$CREATE_TARGET" '^  # QA artifacts root directory$' "fresh create must preserve QA path comments"
 assert_contains "$CREATE_TARGET" '^  qa: \.ai-factory/qa/$' "fresh create must set paths.qa"
+assert_contains "$CREATE_TARGET" '^  archive: \.ai-factory/archive/$' "fresh create must set paths.archive"
 assert_contains "$CREATE_TARGET" '^  base_branch: 2.x$' "fresh create must set git.base_branch"
 assert_contains "$CREATE_TARGET" '^  branch_prefix: fix/$' "fresh create must set git.branch_prefix"
 assert_contains "$CREATE_TARGET" '^  # frontend: \.ai-factory/rules/frontend\.md$' "fresh create must preserve commented rules examples"

--- a/skills/aif-archive/SKILL.md
+++ b/skills/aif-archive/SKILL.md
@@ -203,31 +203,40 @@ For each plan to archive:
 
 1. `mkdir -p <paths.archive>/plans/`
 
-2. Read the plan file. Add or update YAML frontmatter with archive metadata:
+2. **Collision check.** Before moving, verify the destination does not already exist:
+   ```
+   Read <paths.archive>/plans/<original-filename>
+   ```
+   If the file exists, STOP with an error:
+   ```
+   ERROR [aif-archive] destination already exists: <paths.archive>/plans/<filename>
+   A previously archived plan has the same filename. This can happen when
+   sequential numbering reuses a freed number after archiving.
+   To resolve: rename the existing archive file, or delete it if it is no
+   longer needed.
+   ```
+   Do NOT overwrite. Move to the next plan in the batch (if `--all`).
 
-   If the plan already has YAML frontmatter (between `---` markers at the top):
-   - Add `archived: YYYY-MM-DD` field
+3. **Move the source file** into the archive path first:
+   ```bash
+   mv <paths.plans>/<filename> <paths.archive>/plans/<filename>
+   ```
+   This atomically removes the plan from the active directory.
 
-   If the plan has no YAML frontmatter:
-   - Prepend a minimal frontmatter block:
+4. **Add archive metadata** to the moved file using `Edit`:
+
+   If the file already has YAML frontmatter (between `---` markers at the top):
+   - Use `Edit` to add `archived: YYYY-MM-DD` field inside the existing frontmatter block.
+
+   If the file has no YAML frontmatter:
+   - Use `Edit` to prepend a minimal frontmatter block before the first line:
      ```yaml
      ---
      archived: YYYY-MM-DD
      ---
      ```
-   - Keep the rest of the file content unchanged.
 
-3. Write the updated content to `<paths.archive>/plans/<original-filename>`.
-   Preserve the original filename exactly, including any sequential `NNNN_` prefix.
-
-4. Remove the original file from `paths.plans/`:
-   ```bash
-   mv <paths.plans>/<filename> <paths.archive>/plans/<filename>
-   ```
-   Note: since we already wrote the updated content, use `mv` only if the
-   frontmatter was already correct, otherwise `Write` the updated content to
-   the archive path and delete the original with `Bash(mv *)` or
-   `Edit` to remove.
+   The original filename is preserved exactly, including any sequential `NNNN_` prefix.
 
 5. Logging: `INFO [aif-archive] archived: <filename> -> <paths.archive>/plans/<filename>`
 

--- a/skills/aif-archive/SKILL.md
+++ b/skills/aif-archive/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: aif-archive
+description: "Archive completed plans and roadmap milestones. Moves finished plans to the archive directory and optionally trims closed milestones from ROADMAP.md. Use when user says \"archive plans\", \"clean up plans\", \"archive completed\", or \"trim roadmap\"."
+argument-hint: "[list | --roadmap | --all | <plan-name>]"
+allowed-tools: Read Write Edit Glob Grep Bash(mv *) Bash(mkdir *) Bash(cp *) Bash(git *) AskUserQuestion
+disable-model-invocation: false
+metadata:
+  author: AI Factory
+  version: "1.0"
+  category: workflow
+---
+
+# Archive — Move completed plans and roadmap snapshots
+
+Archive completed plans from `paths.plans/` into `paths.archive/plans/` and
+optionally trim closed milestones from `ROADMAP.md` into dated snapshots
+under `paths.archive/roadmap/`.
+
+## Workflow
+
+### Step 0: Load Config
+
+Read `.ai-factory/config.yaml` if it exists to resolve:
+
+- `paths.plans` (default: `.ai-factory/plans/`)
+- `paths.archive` (default: `.ai-factory/archive/`)
+- `paths.plan` (default: `.ai-factory/PLAN.md`)
+- `paths.fix_plan` (default: `.ai-factory/FIX_PLAN.md`)
+- `paths.roadmap` (default: `.ai-factory/ROADMAP.md`)
+- `workflow.plan_id_format` (default: `slug`) — active values: `slug` and
+  `sequential`. `timestamp` and `uuid` are **reserved** and behave like `slug`.
+  Treat any unknown value as `slug`.
+- `language.ui` for user-facing prompts
+
+If config doesn't exist, use defaults listed above.
+
+Read `.ai-factory/skill-context/aif-archive/SKILL.md` if it exists —
+project-specific overrides take priority over general instructions.
+
+### Step 1: Parse Arguments
+
+Extract mode from arguments:
+
+```
+(no args)        → interactive mode: scan, show completable plans, ask which to archive
+list             → show archive contents, then STOP
+--roadmap        → trim closed milestones from ROADMAP.md into a snapshot
+--all            → archive ALL completed plans (ask confirmation first)
+<plan-name>      → archive a specific plan by filename or partial stem match
+```
+
+Parsing rules:
+
+- `list` and `--roadmap` are mutually exclusive with `<plan-name>` and `--all`
+- If multiple conflicting modes are given, emit error and STOP
+- `<plan-name>` can be:
+  - full filename: `0005_feature-auth.md`
+  - stem without extension: `0005_feature-auth`
+  - partial match: `feature-auth` (must match exactly one plan)
+
+### Step 2: Execute Mode
+
+---
+
+#### Mode: Interactive (no arguments)
+
+1. Scan `paths.plans/` for all `*.md` files using `Glob`.
+2. For each plan file, read the `## Tasks` section.
+3. Determine completion: a plan is **completed** when ALL task checkboxes
+   are `- [x]`. Plans with any `- [ ]` are incomplete.
+4. If no completed plans found:
+   ```
+   No completed plans found in <paths.plans/>.
+   ```
+   → STOP.
+5. Display completed plans:
+   ```
+   Completed plans ready to archive:
+
+     1. 0001_feature-alpha.md (completed 2026-05-20)
+     2. 0003_feature-gamma.md (completed 2026-05-24)
+
+   Incomplete plans (skipped):
+     - 0005_feature-delta.md (3/7 tasks done)
+   ```
+6. Ask which to archive:
+   ```
+   AskUserQuestion: Which plans to archive?
+
+   Options:
+   1. All completed plans listed above
+   2. Select specific plans (enter numbers)
+   3. Cancel
+   ```
+7. Execute archive operation for selected plans (see **Archive Operation**).
+
+---
+
+#### Mode: `list`
+
+1. Check if `<paths.archive>/plans/` exists.
+2. If not: `Archive is empty. No plans have been archived yet.` → STOP.
+3. Glob `<paths.archive>/plans/*.md`.
+4. For each archived plan, read the YAML frontmatter to extract `archived` date.
+5. Display:
+   ```
+   Archived plans (<paths.archive>/plans/):
+
+     1. 0001_feature-alpha.md  (archived: 2026-05-20)
+     2. 0003_feature-gamma.md  (archived: 2026-05-24)
+
+   Total: 2 archived plans
+   ```
+6. Check `<paths.archive>/roadmap/` for snapshots and list them if present:
+   ```
+   Roadmap snapshots (<paths.archive>/roadmap/):
+
+     1. 2026-05-20_roadmap-snapshot.md (3 milestones)
+   ```
+7. STOP.
+
+---
+
+#### Mode: `<plan-name>`
+
+1. Resolve `<plan-name>` to a file in `paths.plans/`:
+   - Try exact filename match first
+   - Then try with `.md` extension appended
+   - Then try partial stem match (grep for `<plan-name>` in filenames)
+2. If no match: `Plan not found: <plan-name>` with suggestions → STOP.
+3. If multiple matches: list them and ask user to be more specific → STOP.
+4. Read the matched plan file and check completion status.
+5. If incomplete:
+   ```
+   Plan <filename> is not completed (5/8 tasks done).
+   Only completed plans can be archived.
+   ```
+   → STOP.
+6. Execute archive operation (see **Archive Operation**).
+
+---
+
+#### Mode: `--all`
+
+1. Scan `paths.plans/` for completed plans (same logic as interactive mode).
+2. If no completed plans: inform and STOP.
+3. Display list and ask confirmation:
+   ```
+   AskUserQuestion: Archive ALL completed plans?
+
+     1. 0001_feature-alpha.md
+     2. 0003_feature-gamma.md
+
+   Options:
+   1. Yes, archive all 2 plans
+   2. Cancel
+   ```
+4. Execute archive operation for all confirmed plans.
+
+---
+
+#### Mode: `--roadmap`
+
+1. Read the resolved `paths.roadmap` file.
+2. If it doesn't exist: `No ROADMAP.md found at <path>.` → STOP.
+3. Find milestones with `- [x]` checkbox (completed milestones).
+4. If no completed milestones: `No closed milestones to archive.` → STOP.
+5. Display and ask confirmation:
+   ```
+   Closed milestones found in ROADMAP.md:
+
+     - [x] MVP Launch — core features shipped
+     - [x] Beta Testing — user feedback round
+
+   AskUserQuestion: Trim these milestones from ROADMAP.md into a snapshot?
+
+   Options:
+   1. Yes, create snapshot and trim
+   2. Cancel
+   ```
+6. Create snapshot:
+   - `mkdir -p <paths.archive>/roadmap/`
+   - Write `<paths.archive>/roadmap/YYYY-MM-DD_roadmap-snapshot.md` with:
+     ```markdown
+     # Roadmap Snapshot — YYYY-MM-DD
+
+     Archived from: <paths.roadmap>
+
+     ## Archived Milestones
+
+     - [x] MVP Launch — core features shipped
+     - [x] Beta Testing — user feedback round
+     ```
+7. Edit `paths.roadmap`: remove the archived `- [x]` lines from the
+   `## Milestones` section. Keep the `## Completed` table if it exists.
+8. Logging: `INFO [aif-archive] roadmap snapshot: <path> (<N> milestones archived)`
+
+---
+
+### Archive Operation (plans)
+
+For each plan to archive:
+
+1. `mkdir -p <paths.archive>/plans/`
+
+2. Read the plan file. Add or update YAML frontmatter with archive metadata:
+
+   If the plan already has YAML frontmatter (between `---` markers at the top):
+   - Add `archived: YYYY-MM-DD` field
+
+   If the plan has no YAML frontmatter:
+   - Prepend a minimal frontmatter block:
+     ```yaml
+     ---
+     archived: YYYY-MM-DD
+     ---
+     ```
+   - Keep the rest of the file content unchanged.
+
+3. Write the updated content to `<paths.archive>/plans/<original-filename>`.
+   Preserve the original filename exactly, including any sequential `NNNN_` prefix.
+
+4. Remove the original file from `paths.plans/`:
+   ```bash
+   mv <paths.plans>/<filename> <paths.archive>/plans/<filename>
+   ```
+   Note: since we already wrote the updated content, use `mv` only if the
+   frontmatter was already correct, otherwise `Write` the updated content to
+   the archive path and delete the original with `Bash(mv *)` or
+   `Edit` to remove.
+
+5. Logging: `INFO [aif-archive] archived: <filename> -> <paths.archive>/plans/<filename>`
+
+6. After all plans are archived, display summary:
+   ```
+   ## Archive Complete
+
+   Archived N plan(s) to <paths.archive>/plans/:
+     - 0001_feature-alpha.md
+     - 0003_feature-gamma.md
+
+   Plans directory: <paths.plans/> (M plans remaining)
+   ```
+
+### Completion Detection Algorithm
+
+A plan is **completed** when:
+
+1. The file contains a `## Tasks` section (case-insensitive header match).
+2. ALL lines matching the pattern `- [x]` or `- [ ]` within the Tasks section
+   (and its subsections) are checked: every checkbox is `- [x]`.
+3. If the Tasks section contains zero checkboxes, the plan is considered
+   **not completed** (empty plans are not archivable).
+
+Edge cases:
+
+- Checkboxes outside `## Tasks` (e.g., in `## Settings` or `## Commit Plan`)
+  are NOT counted for completion.
+- Nested checkboxes (indented `  - [x]`) ARE counted.
+- Plans without a `## Tasks` section are not archivable — emit
+  `WARN [aif-archive] <filename> has no ## Tasks section; skipping`.
+
+### Completion Date Inference
+
+When displaying "completed" dates in interactive mode:
+
+1. Check YAML frontmatter for a `completed` field — use if present.
+2. Fall back to git: `git log -1 --format=%ai -- <plan-file>` to get last
+   modification date.
+3. Fall back to filesystem: file modification time.
+
+## Important Rules
+
+1. **Never archive incomplete plans** — all tasks must be `- [x]`
+2. **Always ask confirmation** before `--all` and `--roadmap` operations
+3. **Preserve original filenames** — including sequential `NNNN_` prefix
+4. **Add archive metadata** — `archived: YYYY-MM-DD` in YAML frontmatter
+5. **Do not modify fast plans** (`paths.plan`) or fix plans (`paths.fix_plan`) —
+   those are single-file artifacts managed by `/aif-implement` and `/aif-fix`
+6. **Do not count archived plans for sequential numbering** — archived plans
+   live in `paths.archive/plans/`, not `paths.plans/`, so `/aif-plan`
+   sequential scan does not include them
+
+## Artifact Ownership
+
+- **Owns:** `paths.archive/plans/*.md`, `paths.archive/roadmap/*.md`
+- **Reads:** `paths.plans/*.md`, `paths.roadmap`
+- **Modifies:** `paths.roadmap` (only with `--roadmap`, only after confirmation)
+- **Does NOT touch:** `paths.plan`, `paths.fix_plan`, `paths.description`,
+  `paths.architecture`, `paths.rules_file`

--- a/skills/aif-archive/SKILL.md
+++ b/skills/aif-archive/SKILL.md
@@ -2,7 +2,7 @@
 name: aif-archive
 description: "Archive completed plans and roadmap milestones. Moves finished plans to the archive directory and optionally trims closed milestones from ROADMAP.md. Use when user says \"archive plans\", \"clean up plans\", \"archive completed\", or \"trim roadmap\"."
 argument-hint: "[list | --roadmap | --all | <plan-name>]"
-allowed-tools: Read Write Edit Glob Grep Bash(mv *) Bash(mkdir *) Bash(cp *) Bash(git *) AskUserQuestion
+allowed-tools: Read Write Edit Glob Grep Bash(mv *) Bash(mkdir *) Bash(git *) AskUserQuestion
 disable-model-invocation: false
 metadata:
   author: AI Factory
@@ -180,7 +180,15 @@ Parsing rules:
    ```
 6. Create snapshot:
    - `mkdir -p <paths.archive>/roadmap/`
-   - Write `<paths.archive>/roadmap/YYYY-MM-DD_roadmap-snapshot.md` with:
+   - Determine snapshot filename: `YYYY-MM-DD_roadmap-snapshot.md`
+   - **Collision check.** Before writing, verify the destination does not already exist:
+     ```
+     Read <paths.archive>/roadmap/YYYY-MM-DD_roadmap-snapshot.md
+     ```
+     If the file exists, append a counter suffix to produce a non-colliding name:
+     `YYYY-MM-DD_roadmap-snapshot-2.md`, `YYYY-MM-DD_roadmap-snapshot-3.md`, etc.
+     Check each candidate until a free name is found.
+   - Write the resolved snapshot path with:
      ```markdown
      # Roadmap Snapshot — YYYY-MM-DD
 
@@ -193,7 +201,8 @@ Parsing rules:
      ```
 7. Edit `paths.roadmap`: remove the archived `- [x]` lines from the
    `## Milestones` section. Keep the `## Completed` table if it exists.
-8. Logging: `INFO [aif-archive] roadmap snapshot: <path> (<N> milestones archived)`
+   **Do NOT edit `paths.roadmap` unless the snapshot write in step 6 succeeded.**
+8. Logging: `INFO [aif-archive] roadmap snapshot: <resolved-path> (<N> milestones archived)`
 
 ---
 
@@ -207,15 +216,20 @@ For each plan to archive:
    ```
    Read <paths.archive>/plans/<original-filename>
    ```
-   If the file exists, STOP with an error:
-   ```
-   ERROR [aif-archive] destination already exists: <paths.archive>/plans/<filename>
-   A previously archived plan has the same filename. This can happen when
-   sequential numbering reuses a freed number after archiving.
-   To resolve: rename the existing archive file, or delete it if it is no
-   longer needed.
-   ```
-   Do NOT overwrite. Move to the next plan in the batch (if `--all`).
+   If the file exists:
+   - **Single plan** (interactive or `<plan-name>`): STOP with an error:
+     ```
+     ERROR [aif-archive] destination already exists: <paths.archive>/plans/<filename>
+     A previously archived plan has the same filename. This can happen when
+     sequential numbering reuses a freed number after archiving.
+     To resolve: rename the existing archive file, or delete it if it is no
+     longer needed.
+     ```
+   - **Batch** (`--all`): SKIP this plan with a warning, continue to the next:
+     ```
+     WARN [aif-archive] skipped: <filename> — destination already exists
+     ```
+   Do NOT overwrite in either case.
 
 3. **Move the source file** into the archive path first:
    ```bash
@@ -240,7 +254,7 @@ For each plan to archive:
 
 5. Logging: `INFO [aif-archive] archived: <filename> -> <paths.archive>/plans/<filename>`
 
-6. After all plans are archived, display summary:
+6. After all plans are processed, display summary:
    ```
    ## Archive Complete
 
@@ -248,8 +262,12 @@ For each plan to archive:
      - 0001_feature-alpha.md
      - 0003_feature-gamma.md
 
+   Skipped: K (destination already exists)
+     - 0002_feature-beta.md
+
    Plans directory: <paths.plans/> (M plans remaining)
    ```
+   Omit the "Skipped" section when K is 0.
 
 ### Completion Detection Algorithm
 

--- a/skills/aif-archive/tests/archive-completed-plan.yaml
+++ b/skills/aif-archive/tests/archive-completed-plan.yaml
@@ -4,14 +4,19 @@ description: |
   to paths.archive/plans/, preserving the original filename and adding
   `archived: YYYY-MM-DD` to YAML frontmatter.
 
+  The correct operation order is:
+    1. mkdir -p for archive/plans/
+    2. mv source -> archive destination (atomic move)
+    3. Edit the destination file to add archived: date
+
   Fixture state:
     .ai-factory/plans/0005_feature-auth.md — all tasks completed
     .ai-factory/config.yaml — paths.archive set
 
   Expected:
-    - mkdir called for archive/plans/
-    - Write to .ai-factory/archive/plans/0005_feature-auth.md with archived date
-    - Original file removed from plans/
+    - Bash(mv) moves the plan to archive/plans/
+    - Edit adds archived: date to the moved file
+    - Original file no longer in plans/ (moved by mv)
 skill: aif-archive
 argument: "0005_feature-auth"
 
@@ -72,19 +77,26 @@ assertions:
     args_match:
       command: "mkdir.*archive/plans"
 
-  - id: writes-to-archive
+  - id: moves-plan-to-archive
     type: tool_called
-    tool: Write
+    tool: Bash
     args_match:
-      file_path: "\\.ai-factory/archive/plans/0005_feature-auth\\.md$"
+      command: "mv.*0005_feature-auth.*archive/plans"
     weight: 4
 
-  - id: archived-content-has-date
+  - id: edits-archive-with-date
     type: tool_called
+    tool: Edit
+    args_match:
+      file_path: "\\.ai-factory/archive/plans/0005_feature-auth\\.md$"
+      new_string: "archived:"
+    weight: 2
+
+  - id: no-write-to-archive
+    type: no_tool_called
     tool: Write
     args_match:
       file_path: "\\.ai-factory/archive/plans/0005_feature-auth\\.md$"
-      content: "archived:"
 
   - id: stay-in-sandbox
     type: no_path_escape

--- a/skills/aif-archive/tests/archive-completed-plan.yaml
+++ b/skills/aif-archive/tests/archive-completed-plan.yaml
@@ -1,0 +1,90 @@
+scenario: archive-completed-plan
+description: |
+  /aif-archive must move a completed plan (all tasks [x]) from paths.plans/
+  to paths.archive/plans/, preserving the original filename and adding
+  `archived: YYYY-MM-DD` to YAML frontmatter.
+
+  Fixture state:
+    .ai-factory/plans/0005_feature-auth.md — all tasks completed
+    .ai-factory/config.yaml — paths.archive set
+
+  Expected:
+    - mkdir called for archive/plans/
+    - Write to .ai-factory/archive/plans/0005_feature-auth.md with archived date
+    - Original file removed from plans/
+skill: aif-archive
+argument: "0005_feature-auth"
+
+runner:
+  model: claude-sonnet-4-6
+  permission_mode: bypassPermissions
+  allowed_tools_override:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash(mv *)
+    - Bash(mkdir *)
+    - Bash(cp *)
+    - Bash(git *)
+    - AskUserQuestion
+
+fixtures:
+  git_init: true
+  git_branch: main
+  files_committed:
+    - path: .ai-factory/config.yaml
+      content: |
+        paths:
+          plans: .ai-factory/plans/
+          archive: .ai-factory/archive/
+          plan: .ai-factory/PLAN.md
+          fix_plan: .ai-factory/FIX_PLAN.md
+          roadmap: .ai-factory/ROADMAP.md
+        workflow:
+          plan_id_format: sequential
+    - path: .ai-factory/plans/0005_feature-auth.md
+      content: |
+        # Implementation Plan: User Authentication
+
+        Branch: feature/auth
+        Created: 2026-05-10
+
+        ## Tasks
+
+        ### Phase 1: Setup
+        - [x] **Task 1 — Create user model.**
+        - [x] **Task 2 — Add auth middleware.**
+
+        ### Phase 2: Implementation
+        - [x] **Task 3 — Implement registration.**
+        - [x] **Task 4 — Implement login.**
+
+user_responses:
+  - match_question: "(?i)(confirm|proceed|archive|sure)"
+    choose: "Yes"
+
+assertions:
+  - id: creates-archive-dir
+    type: tool_called
+    tool: Bash
+    args_match:
+      command: "mkdir.*archive/plans"
+
+  - id: writes-to-archive
+    type: tool_called
+    tool: Write
+    args_match:
+      file_path: "\\.ai-factory/archive/plans/0005_feature-auth\\.md$"
+    weight: 4
+
+  - id: archived-content-has-date
+    type: tool_called
+    tool: Write
+    args_match:
+      file_path: "\\.ai-factory/archive/plans/0005_feature-auth\\.md$"
+      content: "archived:"
+
+  - id: stay-in-sandbox
+    type: no_path_escape

--- a/skills/aif-archive/tests/archive-completed-plan.yaml
+++ b/skills/aif-archive/tests/archive-completed-plan.yaml
@@ -31,7 +31,6 @@ runner:
     - Grep
     - Bash(mv *)
     - Bash(mkdir *)
-    - Bash(cp *)
     - Bash(git *)
     - AskUserQuestion
 

--- a/skills/aif-archive/tests/collision-stops-before-overwrite.yaml
+++ b/skills/aif-archive/tests/collision-stops-before-overwrite.yaml
@@ -1,0 +1,90 @@
+scenario: collision-stops-before-overwrite
+description: |
+  /aif-archive must NOT overwrite an existing archived plan.
+  When the destination file already exists in paths.archive/plans/,
+  the skill must stop with an error and leave both files untouched.
+
+  Fixture state:
+    .ai-factory/plans/0005_feature-auth.md — completed plan in active dir
+    .ai-factory/archive/plans/0005_feature-auth.md — previously archived plan
+
+  Expected:
+    - No Bash(mv) call to archive (would overwrite)
+    - No Write to archive (would overwrite)
+    - No Edit to the active plan (nothing should change)
+    - Output mentions collision / already exists
+skill: aif-archive
+argument: "0005_feature-auth"
+
+runner:
+  model: claude-sonnet-4-6
+  permission_mode: bypassPermissions
+  allowed_tools_override:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash(mv *)
+    - Bash(mkdir *)
+    - Bash(cp *)
+    - Bash(git *)
+    - AskUserQuestion
+
+fixtures:
+  git_init: true
+  git_branch: main
+  files_committed:
+    - path: .ai-factory/config.yaml
+      content: |
+        paths:
+          plans: .ai-factory/plans/
+          archive: .ai-factory/archive/
+          plan: .ai-factory/PLAN.md
+          fix_plan: .ai-factory/FIX_PLAN.md
+          roadmap: .ai-factory/ROADMAP.md
+        workflow:
+          plan_id_format: sequential
+    - path: .ai-factory/plans/0005_feature-auth.md
+      content: |
+        # Implementation Plan: User Authentication
+
+        Branch: feature/auth
+        Created: 2026-05-25
+
+        ## Tasks
+
+        - [x] **Task 1 — Create user model.**
+        - [x] **Task 2 — Implement login.**
+    - path: .ai-factory/archive/plans/0005_feature-auth.md
+      content: |
+        ---
+        archived: 2026-05-20
+        ---
+        # Implementation Plan: User Authentication (old)
+
+        ## Tasks
+
+        - [x] **Task 1 — Setup.**
+
+assertions:
+  - id: no-mv-to-archive
+    type: no_tool_called
+    tool: Bash
+    args_match:
+      command: "mv.*0005_feature-auth.*archive"
+
+  - id: no-write-to-archive
+    type: no_tool_called
+    tool: Write
+    args_match:
+      file_path: "\\.ai-factory/archive/plans/0005_feature-auth\\.md$"
+
+  - id: no-edit-to-archive
+    type: no_tool_called
+    tool: Edit
+    args_match:
+      file_path: "\\.ai-factory/archive/plans/0005_feature-auth\\.md$"
+
+  - id: stay-in-sandbox
+    type: no_path_escape

--- a/skills/aif-archive/tests/collision-stops-before-overwrite.yaml
+++ b/skills/aif-archive/tests/collision-stops-before-overwrite.yaml
@@ -27,7 +27,6 @@ runner:
     - Grep
     - Bash(mv *)
     - Bash(mkdir *)
-    - Bash(cp *)
     - Bash(git *)
     - AskUserQuestion
 

--- a/skills/aif-archive/tests/collision-stops-before-overwrite.yaml
+++ b/skills/aif-archive/tests/collision-stops-before-overwrite.yaml
@@ -86,5 +86,9 @@ assertions:
     args_match:
       file_path: "\\.ai-factory/archive/plans/0005_feature-auth\\.md$"
 
+  - id: output-mentions-collision
+    type: output_contains
+    text: "already exists"
+
   - id: stay-in-sandbox
     type: no_path_escape

--- a/skills/aif-archive/tests/list-archived-plans.yaml
+++ b/skills/aif-archive/tests/list-archived-plans.yaml
@@ -24,7 +24,6 @@ runner:
     - Grep
     - Bash(mv *)
     - Bash(mkdir *)
-    - Bash(cp *)
     - Bash(git *)
     - AskUserQuestion
 

--- a/skills/aif-archive/tests/list-archived-plans.yaml
+++ b/skills/aif-archive/tests/list-archived-plans.yaml
@@ -1,0 +1,80 @@
+scenario: list-archived-plans
+description: |
+  /aif-archive list must show archived plans from paths.archive/plans/
+  without modifying any files (read-only mode).
+
+  Fixture state:
+    .ai-factory/archive/plans/0001_feature-alpha.md — archived plan
+    .ai-factory/archive/plans/0003_feature-gamma.md — archived plan
+
+  Expected:
+    - Output lists both archived plan filenames
+    - No Write or Edit calls (read-only)
+skill: aif-archive
+argument: "list"
+
+runner:
+  model: claude-sonnet-4-6
+  permission_mode: bypassPermissions
+  allowed_tools_override:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash(mv *)
+    - Bash(mkdir *)
+    - Bash(cp *)
+    - Bash(git *)
+    - AskUserQuestion
+
+fixtures:
+  git_init: true
+  git_branch: main
+  files_committed:
+    - path: .ai-factory/config.yaml
+      content: |
+        paths:
+          plans: .ai-factory/plans/
+          archive: .ai-factory/archive/
+        workflow:
+          plan_id_format: sequential
+    - path: .ai-factory/archive/plans/0001_feature-alpha.md
+      content: |
+        ---
+        archived: 2026-05-20
+        ---
+        # Implementation Plan: Feature Alpha
+
+        ## Tasks
+        - [x] **Task 1 — Setup.**
+        - [x] **Task 2 — Implement.**
+    - path: .ai-factory/archive/plans/0003_feature-gamma.md
+      content: |
+        ---
+        archived: 2026-05-24
+        ---
+        # Implementation Plan: Feature Gamma
+
+        ## Tasks
+        - [x] **Task 1 — Design.**
+        - [x] **Task 2 — Build.**
+        - [x] **Task 3 — Test.**
+
+assertions:
+  - id: no-write-calls
+    type: no_tool_called
+    tool: Write
+
+  - id: no-edit-calls
+    type: no_tool_called
+    tool: Edit
+
+  - id: reads-archive-dir
+    type: tool_called
+    tool: Glob
+    args_match:
+      pattern: ".*archive/plans"
+
+  - id: stay-in-sandbox
+    type: no_path_escape

--- a/skills/aif-archive/tests/roadmap-snapshot-collision.yaml
+++ b/skills/aif-archive/tests/roadmap-snapshot-collision.yaml
@@ -1,0 +1,98 @@
+scenario: roadmap-snapshot-collision
+description: |
+  /aif-archive --roadmap must NOT overwrite an existing same-day roadmap snapshot.
+  When a snapshot for today's date already exists in paths.archive/roadmap/,
+  the skill must use a non-colliding suffix (e.g. -2) and must NOT edit
+  paths.roadmap until the new snapshot is safely written.
+
+  Fixture state:
+    .ai-factory/ROADMAP.md — has closed milestones
+    .ai-factory/archive/roadmap/2026-05-26_roadmap-snapshot.md — existing snapshot
+
+  Expected:
+    - No Write to the existing snapshot path (would overwrite)
+    - Write to a suffixed path (e.g. 2026-05-26_roadmap-snapshot-2.md)
+    - Edit to ROADMAP.md only AFTER snapshot is written
+skill: aif-archive
+argument: "--roadmap"
+
+runner:
+  model: claude-sonnet-4-6
+  permission_mode: bypassPermissions
+  allowed_tools_override:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash(mv *)
+    - Bash(mkdir *)
+    - Bash(git *)
+    - AskUserQuestion
+
+fixtures:
+  git_init: true
+  git_branch: main
+  files_committed:
+    - path: .ai-factory/config.yaml
+      content: |
+        paths:
+          plans: .ai-factory/plans/
+          archive: .ai-factory/archive/
+          plan: .ai-factory/PLAN.md
+          fix_plan: .ai-factory/FIX_PLAN.md
+          roadmap: .ai-factory/ROADMAP.md
+        workflow:
+          plan_id_format: sequential
+    - path: .ai-factory/ROADMAP.md
+      content: |
+        # Project Roadmap
+
+        ## Milestones
+
+        - [x] MVP Launch — core features shipped
+        - [x] Beta Testing — user feedback round
+        - [ ] Production Release — final deploy
+    - path: .ai-factory/archive/roadmap/2026-05-26_roadmap-snapshot.md
+      content: |
+        # Roadmap Snapshot — 2026-05-26
+
+        Archived from: .ai-factory/ROADMAP.md
+
+        ## Archived Milestones
+
+        - [x] Initial Setup — project scaffolding
+
+user_responses:
+  - match_question: "(?i)(confirm|proceed|trim|snapshot|sure)"
+    choose: "Yes"
+
+assertions:
+  - id: no-overwrite-existing-snapshot
+    type: no_tool_called
+    tool: Write
+    args_match:
+      file_path: "archive/roadmap/2026-05-26_roadmap-snapshot\\.md$"
+
+  - id: writes-suffixed-snapshot
+    type: tool_called
+    tool: Write
+    args_match:
+      file_path: "archive/roadmap/2026-05-26_roadmap-snapshot-2\\.md$"
+    weight: 4
+
+  - id: snapshot-contains-milestones
+    type: tool_called
+    tool: Write
+    args_match:
+      content: "MVP Launch"
+    weight: 2
+
+  - id: edits-roadmap-after-snapshot
+    type: tool_called
+    tool: Edit
+    args_match:
+      file_path: "ROADMAP\\.md$"
+
+  - id: stay-in-sandbox
+    type: no_path_escape

--- a/skills/aif-archive/tests/roadmap-snapshot-collision.yaml
+++ b/skills/aif-archive/tests/roadmap-snapshot-collision.yaml
@@ -5,6 +5,8 @@ description: |
   the skill must use a non-colliding suffix (e.g. -2) and must NOT edit
   paths.roadmap until the new snapshot is safely written.
 
+  IMPORTANT: For this scenario, today's date is 2026-05-26.
+
   Fixture state:
     .ai-factory/ROADMAP.md — has closed milestones
     .ai-factory/archive/roadmap/2026-05-26_roadmap-snapshot.md — existing snapshot
@@ -78,7 +80,7 @@ assertions:
     type: tool_called
     tool: Write
     args_match:
-      file_path: "archive/roadmap/2026-05-26_roadmap-snapshot-2\\.md$"
+      file_path: "archive/roadmap/.*_roadmap-snapshot-\\d+\\.md$"
     weight: 4
 
   - id: snapshot-contains-milestones

--- a/skills/aif-archive/tests/skip-incomplete-plan.yaml
+++ b/skills/aif-archive/tests/skip-incomplete-plan.yaml
@@ -1,0 +1,70 @@
+scenario: skip-incomplete-plan
+description: |
+  /aif-archive must NOT archive a plan with incomplete tasks.
+
+  Fixture state:
+    .ai-factory/plans/0003_feature-search.md — has unchecked tasks
+
+  Expected:
+    - No Write or Bash(mv) to archive directory
+    - Output mentions the plan is incomplete / not completed
+skill: aif-archive
+argument: "0003_feature-search"
+
+runner:
+  model: claude-sonnet-4-6
+  permission_mode: bypassPermissions
+  allowed_tools_override:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash(mv *)
+    - Bash(mkdir *)
+    - Bash(cp *)
+    - Bash(git *)
+    - AskUserQuestion
+
+fixtures:
+  git_init: true
+  git_branch: main
+  files_committed:
+    - path: .ai-factory/config.yaml
+      content: |
+        paths:
+          plans: .ai-factory/plans/
+          archive: .ai-factory/archive/
+        workflow:
+          plan_id_format: sequential
+    - path: .ai-factory/plans/0003_feature-search.md
+      content: |
+        # Implementation Plan: Product Search
+
+        Branch: feature/search
+        Created: 2026-05-15
+
+        ## Tasks
+
+        ### Phase 1: Setup
+        - [x] **Task 1 — Create search index.**
+        - [ ] **Task 2 — Add search API endpoint.**
+
+        ### Phase 2: Testing
+        - [ ] **Task 3 — Write integration tests.**
+
+assertions:
+  - id: no-write-to-archive
+    type: no_tool_called
+    tool: Write
+    args_match:
+      file_path: "\\.ai-factory/archive/"
+
+  - id: no-mv-to-archive
+    type: no_tool_called
+    tool: Bash
+    args_match:
+      command: "mv.*archive"
+
+  - id: stay-in-sandbox
+    type: no_path_escape

--- a/skills/aif-archive/tests/skip-incomplete-plan.yaml
+++ b/skills/aif-archive/tests/skip-incomplete-plan.yaml
@@ -22,7 +22,6 @@ runner:
     - Grep
     - Bash(mv *)
     - Bash(mkdir *)
-    - Bash(cp *)
     - Bash(git *)
     - AskUserQuestion
 

--- a/skills/aif-implement/SKILL.md
+++ b/skills/aif-implement/SKILL.md
@@ -48,6 +48,7 @@ Handoff sync is handled inline — see **Step 0.2** (after reading the plan file
 1. Read `.ai-factory/config.yaml` if it exists to resolve:
    - `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.research`
    - `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.patches`
+   - `paths.archive`
    - `paths.rules`
    - `language.ui`, `language.artifacts`
    - `git.enabled`, `git.base_branch`, `git.create_branches`
@@ -460,6 +461,8 @@ Then continue with normal execution using the selected plan file.
 3. Single named full-plan file in `paths.plans` (from `/aif-plan full` without branch creation)
 4. `paths.plan` (from `/aif-plan fast`) - fallback when no full plan exists
 5. `paths.fix_plan` - redirect to `/aif-fix` (from `/aif-fix` plan mode)
+
+**Note:** Plan discovery scans `paths.plans/` only. Plans archived to `paths.archive/plans/` by `/aif-archive` are excluded from discovery.
 
 **Read the plan file** to understand:
 

--- a/skills/aif-improve/SKILL.md
+++ b/skills/aif-improve/SKILL.md
@@ -25,7 +25,7 @@ enhanced plan with better tasks, correct dependencies, more detail
 ### Step 0: Load Config & Parse Arguments
 
 **FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
-- **Paths:** `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.research`, `paths.description`, and `paths.patches`
+- **Paths:** `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.research`, `paths.description`, `paths.patches`, and `paths.archive`
 - **Language:** `language.ui` for prompts and summaries, `language.artifacts` for plan artifact updates, and `language.technical_terms` for human-readable technical terminology in plan artifacts
 - **Git:** `git.enabled`, `git.base_branch`, `git.create_branches`
 - **Workflow:** `workflow.plan_id_format` (default: `slug`) — used by branch-based plan discovery.
@@ -108,6 +108,8 @@ This step runs in the default (non-`--list`) mode and picks **one** plan file fo
 4. No full-mode plan → Check the resolved fast plan path (from /aif-plan fast)
 5. No full-mode plan and no resolved fast plan → Check the resolved fix plan path (from /aif-fix plan mode)
 ```
+
+**Note:** Plan discovery scans `paths.plans/` only. Plans archived to `paths.archive/plans/` by `/aif-archive` are excluded from discovery.
 
 **If NO plan file found at any location:**
 

--- a/skills/aif-improve/references/LIST-MODE.md
+++ b/skills/aif-improve/references/LIST-MODE.md
@@ -51,7 +51,9 @@ This file describes the read-only plan discovery procedure that runs when `aif-i
    - /aif-fix <bug description>
    ```
 
-6. **STOP.** Do not proceed to any refinement step.
+6. **Archived plans.** If `paths.archive/plans/` exists and contains `*.md` files, display a separate count line after the main list: `Archived plans: N (in <paths.archive>/plans/)`. Do not list individual archived plans — use `/aif-archive list` for that.
+
+7. **STOP.** Do not proceed to any refinement step.
 
 ## Read-only contract
 

--- a/skills/aif-plan/SKILL.md
+++ b/skills/aif-plan/SKILL.md
@@ -86,7 +86,7 @@ Preserve the `<!-- handoff:task:<id> -->` annotation on the first line when rewr
 
 **FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
 
-- **Paths:** `paths.description`, `paths.architecture`, `paths.roadmap`, `paths.research`, `paths.rules_file`, `paths.plan`, `paths.plans`, `paths.patches`, `paths.evolutions`, `paths.specs`, and `paths.rules`
+- **Paths:** `paths.description`, `paths.architecture`, `paths.roadmap`, `paths.research`, `paths.rules_file`, `paths.plan`, `paths.plans`, `paths.patches`, `paths.evolutions`, `paths.specs`, `paths.rules`, and `paths.archive`
 - **Language:** `language.ui` for AskUserQuestion prompts, `language.artifacts` for generated plan files, and `language.technical_terms` for human-readable technical terminology in plan artifacts
 - **Git:** `git.enabled`, `git.base_branch`, `git.create_branches`, and `git.branch_prefix`
 - **Workflow:** `workflow.plan_id_format` — controls full-mode plan filename shape. Allowed values: `slug` (default), `timestamp`, `uuid`, `sequential`. Only `slug` and `sequential` are active; `timestamp` and `uuid` are **reserved** and currently behave like `slug` (with an `INFO` log). The `sequential` value writes plan files as `<NNNN>_<plan_file_stem>.md` (see Step 1.2 for the canonical stem and the algorithm). Treat any unknown value as `slug` and emit `WARN [aif-plan] unknown workflow.plan_id_format=<value>; falling back to slug`.
@@ -354,6 +354,7 @@ Implementation notes:
 Rules:
 
 - Numbering is **derived from existing files** in `<configured plans dir>`. Deleting or moving a numbered plan out of the directory can free that number for reuse on the next run — keep plans in place if you rely on stable cross-references.
+- **Archived plans are excluded from numbering.** Plans moved to `paths.archive/plans/` by `/aif-archive` are not in `<configured plans dir>` and therefore not counted. Archiving the highest-numbered plan frees that number for reuse.
 - Numbering is **bounded** — 9999 is a hard cap; the algorithm errors instead of writing `10000_…` so consumer globs (also 4-digit) cannot drift out of contract.
 - The prefix lives only on the plan file. The git branch (when present) stays `<branch_prefix><slug>` without a number.
 - This setting is ignored for fast plans (`paths.plan` is a single file) and fix plans (`paths.fix_plan` is a single file).

--- a/skills/aif-plan/tests/sequential-skips-archive.yaml
+++ b/skills/aif-plan/tests/sequential-skips-archive.yaml
@@ -1,0 +1,104 @@
+scenario: sequential-skips-archive
+description: |
+  Sequential numbering in /aif-plan must only count plans in paths.plans/,
+  NOT plans in paths.archive/plans/. This is a consumer-side regression test
+  for the /aif-archive feature.
+
+  Fixture state:
+    .ai-factory/plans/0001_alpha.md — active plan
+    .ai-factory/archive/plans/0003_beta.md — archived plan (must be ignored)
+
+  Expected: the new plan is written as 0002_*, not 0004_*.
+  The archived plan with prefix 0003 must NOT influence the numbering.
+skill: aif-plan
+argument: "full add user dashboard"
+
+runner:
+  model: claude-sonnet-4-6
+  permission_mode: bypassPermissions
+  allowed_tools_override:
+    - Read
+    - Write
+    - Glob
+    - Grep
+    - Bash(git *)
+    - Bash(mkdir *)
+    - Bash(basename *)
+    - Bash(cd *)
+    - Bash(cp *)
+    - AskUserQuestion
+    - Questions
+    - TaskCreate
+    - TaskUpdate
+    - TaskList
+
+fixtures:
+  git_init: true
+  git_branch: main
+  files_committed:
+    - path: README.md
+      content: |
+        # Demo repo
+    - path: .ai-factory/config.yaml
+      content: |
+        paths:
+          plan: .ai-factory/PLAN.md
+          plans: .ai-factory/plans/
+          archive: .ai-factory/archive/
+        workflow:
+          plan_id_format: sequential
+        git:
+          enabled: true
+          base_branch: main
+          create_branches: true
+          branch_prefix: feature/
+    - path: .ai-factory/plans/0001_alpha.md
+      content: |
+        # Plan: alpha
+        - [x] Task 1
+    - path: .ai-factory/archive/plans/0003_beta.md
+      content: |
+        ---
+        archived: 2026-05-20
+        ---
+        # Plan: beta
+        - [x] Task 1
+
+user_responses:
+  - match_question: "(?i)\\b(fast|full)\\b"
+    choose: "Full"
+  - match_question: "(?i)test"
+    choose: "No, skip tests"
+  - match_question: "(?i)log"
+    choose: "Standard"
+  - match_question: "(?i)doc"
+    choose: "No"
+  - match_question: "(?i)(requirement|constraint|clarif)"
+    choose: "None"
+  - match_question: "(?i)(roadmap|milestone|linkage)"
+    choose: "Skip"
+  - match_question: "(?i)(proceed|confirm|ready|start|approve)"
+    choose: "Yes"
+
+assertions:
+  - id: writes-0002-not-0004
+    type: tool_called
+    tool: Write
+    args_match:
+      file_path: "\\.ai-factory/plans/0002_"
+    weight: 4
+
+  - id: does-not-write-0004
+    type: no_tool_called
+    tool: Write
+    args_match:
+      file_path: "\\.ai-factory/plans/0004_"
+
+  - id: does-not-write-0003
+    type: no_tool_called
+    tool: Write
+    args_match:
+      file_path: "\\.ai-factory/plans/0003_"
+
+  - id: stay-in-sandbox
+    type: no_path_escape

--- a/skills/aif-verify/SKILL.md
+++ b/skills/aif-verify/SKILL.md
@@ -26,7 +26,7 @@ Verify that the completed implementation matches the plan, nothing was missed, a
 ### 0.0 Load config.yaml
 
 **FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
-- **Paths:** `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.specs`, and `paths.rules`
+- **Paths:** `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.roadmap`, `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.specs`, `paths.rules`, and `paths.archive`
 - **verify_mode:** default verification strictness (`strict` | `normal` | `lenient`)
 - **Git:** `git.enabled`, `git.base_branch`, `git.create_branches`
 - **Rules hierarchy:** the resolved RULES.md path + `rules.base` + named `rules.<area>` entries
@@ -94,6 +94,8 @@ Same logic as `/aif-implement` — produce the **canonical branch stem** before 
 5. No full-mode plan → Check the resolved fast plan path
 6. No full-mode plan and no resolved fast plan → fall back to standalone verification choices
 ```
+
+**Note:** Plan discovery scans `paths.plans/` only. Plans archived to `paths.archive/plans/` by `/aif-archive` are excluded from discovery. If a plan is found only in the archive, emit `WARN [aif-verify] plan <name> is archived; verifying archived plan`.
 
 **If no plan file found:**
 ```

--- a/skills/aif/references/config-template.yaml
+++ b/skills/aif/references/config-template.yaml
@@ -115,6 +115,16 @@ paths:
   # Default: .ai-factory/qa/
   qa: .ai-factory/qa/
 
+  # Archive directory for completed plans and roadmap snapshots.
+  # /aif-archive moves finished plans here (retaining original filenames,
+  # including any sequential NNNN_ prefix). Subdirectories:
+  #   archive/plans/   — archived plan files
+  #   archive/roadmap/ — dated roadmap snapshots
+  # Referenced by /aif-archive (owner), /aif-plan, /aif-implement,
+  # /aif-verify, /aif-improve.
+  # Default: .ai-factory/archive/
+  archive: .ai-factory/archive/
+
 # =============================================================================
 # Workflow Settings
 # =============================================================================

--- a/skills/aif/references/update-config.mjs
+++ b/skills/aif/references/update-config.mjs
@@ -23,6 +23,7 @@ const SECTION_KEYS = {
     'specs',
     'rules',
     'qa',
+    'archive',
   ],
   workflow: ['auto_create_dirs', 'plan_id_format', 'analyze_updates_architecture', 'architecture_updates_roadmap', 'verify_mode'],
   git: ['enabled', 'base_branch', 'create_branches', 'branch_prefix', 'skip_push_after_commit'],

--- a/src/cli/wizard/skill-hints.ts
+++ b/src/cli/wizard/skill-hints.ts
@@ -1,5 +1,6 @@
 const SKILL_HINTS: Record<string, string> = {
     'aif': 'Set up AI context',
+    'aif-archive': 'Archive completed plans and roadmap',
     'aif-architecture': 'Generate architecture guide',
     'aif-best-practices': 'Clean code guidelines',
     'aif-build-automation': 'Build file automation',


### PR DESCRIPTION
## Summary

Add a new skill `/aif-archive` and config key `paths.archive` that let users move completed plans into a dedicated archive directory and optionally trim closed milestones from `ROADMAP.md` into dated snapshots.

**Motivation:** over time `.ai-factory/plans/` accumulates finished plans and `ROADMAP.md` grows linearly. This feature gives a first-class way to clean up without losing history.

## What's included

### Config
- New `paths.archive` key (default: `.ai-factory/archive/`) in config-template.yaml
- Registered in `update-config.mjs` (`SECTION_KEYS.paths`) for config reruns
- Documented in `docs/config-reference.md` Skill Matrix

### Skill: `/aif-archive`
Four modes:
- **Interactive** (no args): scan for completed plans, ask which to archive
- **`list`**: show archive contents (read-only)
- **`--all`**: archive all completed plans with confirmation (best-effort: skips collisions, reports counts)
- **`--roadmap`**: trim closed milestones into dated snapshots under `archive/roadmap/` (collision-safe with counter suffix)

Completion detection: all checkboxes in `## Tasks` must be `- [x]`.
Archived plans retain original filenames (including sequential `NNNN_` prefix) and get `archived: YYYY-MM-DD` frontmatter.

Safety:
- Plan archive: move-then-edit order, collision check before move
- Roadmap archive: collision check with counter suffix (`-2`, `-3`, ...), roadmap trimmed only after snapshot write succeeds
- Single plan collision = STOP with error; batch collision = SKIP with WARN

### Consumer skill updates
- `/aif-plan`: `paths.archive` in Load Config; sequential numbering note (archived plans excluded)
- `/aif-implement`: `paths.archive` in Load Config; plan discovery exclusion note
- `/aif-verify`: `paths.archive` in Load Config; archived plan warning
- `/aif-improve`: `paths.archive` in Load Config; `--list` mode shows archived plan count

### Documentation
- `docs/config-reference.md`: paths table + Skill Matrix row
- `docs/configuration.md`: config sample + config-aware skills list
- `docs/plan-files.md`: Archive Lifecycle section + Artifact Ownership row
- `docs/workflow.md`: command table + Artifact Ownership row
- `docs/skills.md`: full `/aif-archive` section + config-aware set list
- `AGENTS.md`: Artifact Ownership row + Active Config Keys + config-aware skills list

### CLI
- `skill-hints.ts`: added `aif-archive` hint for `ai-factory init`

### Tests (5 skill fixtures + 1 consumer regression)
- `skills/aif-archive/tests/archive-completed-plan.yaml` — archives completed plan (move-then-edit)
- `skills/aif-archive/tests/skip-incomplete-plan.yaml` — skips incomplete plan
- `skills/aif-archive/tests/list-archived-plans.yaml` — read-only list mode
- `skills/aif-archive/tests/collision-stops-before-overwrite.yaml` — plan collision stops with diagnostic
- `skills/aif-archive/tests/roadmap-snapshot-collision.yaml` — roadmap same-day collision uses suffix
- `skills/aif-plan/tests/sequential-skips-archive.yaml` — consumer regression: sequential numbering ignores archived plans
- `scripts/test-aif-config.sh` — extended with `paths.archive` create/assertion coverage

## Lessons applied from PR #108

This PR incorporates all review feedback patterns from the sequential plan numbering PR:

1. **Producer/consumer config contract**: every consumer that references `paths.archive` explicitly resolves it in its Load Config section with default `.ai-factory/archive/`
2. **Production/test tool parity**: test fixtures use only tools from the skill's production frontmatter
3. **Consumer-side coverage**: includes a consumer regression test for `/aif-plan` sequential numbering
4. **Docs sync from day one**: all documentation files updated in the same PR
5. **No AI attribution**: no `Co-Authored-By` or generated-by footers

## Test status

`npm test`: 124/124 passed, 11 warnings (all pre-existing).

## What this PR deliberately does NOT do

- No auto-archival — users must invoke `/aif-archive` explicitly
- No changes to fast plans (`paths.plan`) or fix plans (`paths.fix_plan`)
- No migration for existing projects