### PR TITLE
Preserve agent config files and offer new skills on update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-factory",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "type": "module",
   "description": "CLI tool for automating AI agent context setup in projects",
   "main": "dist/cli/index.js",

--- a/scripts/test-init.sh
+++ b/scripts/test-init.sh
@@ -167,6 +167,19 @@ EXPECTED_CODEX_AGENT_FILES="$EXPECTED_CODEX_AGENT_FILES" node -e "const fs=requi
 
 echo "codex init smoke tests passed"
 
+cat >> "$PROJECT_DIR/.codex/config.toml" << 'EOF'
+
+[user]
+keep = true
+EOF
+
+(cd "$PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agents codex --skills aif > "$TMPDIR/init-codex-rerun.log" 2>&1)
+assert_contains "$PROJECT_DIR/.codex/config.toml" "\\[user\\]" "Codex init rerun must preserve tracked local config changes"
+assert_contains "$PROJECT_DIR/.codex/config.toml" "keep = true" "Codex init rerun must preserve tracked local config content"
+EXPECTED_CODEX_AGENT_FILES="$EXPECTED_CODEX_AGENT_FILES" node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];const expected=Number(process.env.EXPECTED_CODEX_AGENT_FILES);if(a.id!=='codex')process.exit(1);if(!Array.isArray(a.installedAgentFiles)||a.installedAgentFiles.length!==expected)process.exit(1);if(!a.installedConfigFiles||a.installedConfigFiles[0]!=='config.toml')process.exit(1);if(!a.managedConfigFiles||!a.managedConfigFiles['config.toml'])process.exit(1);" "$PROJECT_DIR/.ai-factory.json"
+
+echo "codex init rerun preserves config smoke tests passed"
+
 CODEX_USER_CONFIG_INIT_PROJECT_DIR="$TMPDIR/init-smoke-codex-user-config"
 mkdir -p "$CODEX_USER_CONFIG_INIT_PROJECT_DIR/.codex"
 
@@ -184,6 +197,96 @@ assert_not_contains "$CODEX_USER_CONFIG_INIT_PROJECT_DIR/.codex/config.toml" "\\
 EXPECTED_CODEX_AGENT_FILES="$EXPECTED_CODEX_AGENT_FILES" node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];const expected=Number(process.env.EXPECTED_CODEX_AGENT_FILES);if(a.id!=='codex')process.exit(1);if(!Array.isArray(a.installedAgentFiles)||a.installedAgentFiles.length!==expected)process.exit(1);if(!a.configFiles||a.configFiles[0]!=='config.toml')process.exit(1);if(Array.isArray(a.installedConfigFiles)&&a.installedConfigFiles.includes('config.toml'))process.exit(1);if(a.managedConfigFiles&&a.managedConfigFiles['config.toml'])process.exit(1);" "$CODEX_USER_CONFIG_INIT_PROJECT_DIR/.ai-factory.json"
 
 echo "codex user-owned config init smoke tests passed"
+
+CODEX_CLEAN_SOURCE_CHANGE_INIT_PROJECT_DIR="$TMPDIR/init-smoke-codex-clean-source-change"
+mkdir -p "$CODEX_CLEAN_SOURCE_CHANGE_INIT_PROJECT_DIR/.codex"
+
+node - "$CODEX_CLEAN_SOURCE_CHANGE_INIT_PROJECT_DIR" <<'EOF'
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const projectDir = process.argv[2];
+const oldConfig = '[agents]\nmax_threads = 2\n';
+fs.writeFileSync(path.join(projectDir, '.codex/config.toml'), oldConfig);
+
+const hash = crypto.createHash('sha256')
+  .update('path:config.toml\n')
+  .update(Buffer.from(oldConfig))
+  .update('\n')
+  .digest('hex');
+
+fs.writeFileSync(path.join(projectDir, '.ai-factory.json'), JSON.stringify({
+  version: '2.4.0',
+  agents: [{
+    id: 'codex',
+    skillsDir: '.codex/skills',
+    installedSkills: ['aif'],
+    configFiles: ['config.toml'],
+    installedConfigFiles: ['config.toml'],
+    managedConfigFiles: { 'config.toml': { sourceHash: hash, installedHash: hash } },
+    mcp: {
+      github: false,
+      filesystem: false,
+      postgres: false,
+      chromeDevtools: false,
+      playwright: false,
+    },
+  }],
+  extensions: [],
+}, null, 2) + '\n');
+EOF
+
+(cd "$CODEX_CLEAN_SOURCE_CHANGE_INIT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agents codex --skills aif > "$TMPDIR/init-codex-clean-source-change.log" 2>&1)
+assert_contains "$CODEX_CLEAN_SOURCE_CHANGE_INIT_PROJECT_DIR/.codex/config.toml" "max_threads = 6" "Codex init rerun must update clean tracked config when bundled source changed"
+assert_not_contains "$CODEX_CLEAN_SOURCE_CHANGE_INIT_PROJECT_DIR/.codex/config.toml" "max_threads = 2" "Codex init rerun must not freeze clean old config as local customization"
+
+CODEX_LOCAL_SOURCE_CHANGE_INIT_PROJECT_DIR="$TMPDIR/init-smoke-codex-local-source-change"
+mkdir -p "$CODEX_LOCAL_SOURCE_CHANGE_INIT_PROJECT_DIR/.codex"
+
+node - "$CODEX_LOCAL_SOURCE_CHANGE_INIT_PROJECT_DIR" <<'EOF'
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const projectDir = process.argv[2];
+const oldConfig = '[agents]\nmax_threads = 2\n';
+const localConfig = `${oldConfig}\n[user]\nkeep = true\n`;
+fs.writeFileSync(path.join(projectDir, '.codex/config.toml'), localConfig);
+
+const hash = crypto.createHash('sha256')
+  .update('path:config.toml\n')
+  .update(Buffer.from(oldConfig))
+  .update('\n')
+  .digest('hex');
+
+fs.writeFileSync(path.join(projectDir, '.ai-factory.json'), JSON.stringify({
+  version: '2.4.0',
+  agents: [{
+    id: 'codex',
+    skillsDir: '.codex/skills',
+    installedSkills: ['aif'],
+    configFiles: ['config.toml'],
+    installedConfigFiles: ['config.toml'],
+    managedConfigFiles: { 'config.toml': { sourceHash: hash, installedHash: hash } },
+    mcp: {
+      github: false,
+      filesystem: false,
+      postgres: false,
+      chromeDevtools: false,
+      playwright: false,
+    },
+  }],
+  extensions: [],
+}, null, 2) + '\n');
+EOF
+
+(cd "$CODEX_LOCAL_SOURCE_CHANGE_INIT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" init --agents codex --skills aif > "$TMPDIR/init-codex-local-source-change.log" 2>&1)
+assert_contains "$CODEX_LOCAL_SOURCE_CHANGE_INIT_PROJECT_DIR/.codex/config.toml" "\\[user\\]" "Codex init rerun must preserve local config edits when bundled source changed"
+assert_contains "$CODEX_LOCAL_SOURCE_CHANGE_INIT_PROJECT_DIR/.codex/config.toml" "keep = true" "Codex init rerun must preserve local config content when bundled source changed"
+assert_contains "$CODEX_LOCAL_SOURCE_CHANGE_INIT_PROJECT_DIR/.codex/config.toml" "max_threads = 2" "Codex init rerun must not overwrite locally edited old config when bundled source changed"
+
+echo "codex init source-change config smoke tests passed"
 
 PROJECT_DIR="$TMPDIR/init-smoke-claude-codex"
 mkdir -p "$PROJECT_DIR"

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -560,6 +560,105 @@ node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[
 echo "codex user-owned config migration smoke tests passed"
 
 # -------------------------------------------------------------------
+# Package-removed config ownership smoke
+# -------------------------------------------------------------------
+
+CLAUDE_REMOVED_CONFIG_LOCAL_PROJECT_DIR="$TMPDIR/update-smoke-removed-config-local"
+mkdir -p "$CLAUDE_REMOVED_CONFIG_LOCAL_PROJECT_DIR/.claude"
+
+node - "$CLAUDE_REMOVED_CONFIG_LOCAL_PROJECT_DIR" <<'EOF'
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const projectDir = process.argv[2];
+const oldConfig = '[managed]\nkeep = true\n';
+const localConfig = `${oldConfig}\n[user]\nkeep = true\n`;
+fs.writeFileSync(path.join(projectDir, '.claude/config.toml'), localConfig);
+
+const oldHash = crypto.createHash('sha256')
+  .update('path:config.toml\n')
+  .update(Buffer.from(oldConfig))
+  .update('\n')
+  .digest('hex');
+
+fs.writeFileSync(path.join(projectDir, '.ai-factory.json'), JSON.stringify({
+  version: '2.4.0',
+  agents: [{
+    id: 'claude',
+    skillsDir: '.claude/skills',
+    installedSkills: ['aif'],
+    configFiles: ['config.toml'],
+    installedConfigFiles: ['config.toml'],
+    managedConfigFiles: { 'config.toml': { sourceHash: oldHash, installedHash: oldHash } },
+    mcp: {
+      github: false,
+      filesystem: false,
+      postgres: false,
+      chromeDevtools: false,
+      playwright: false,
+    },
+  }],
+  extensions: [],
+}, null, 2) + '\n');
+EOF
+
+CLAUDE_REMOVED_CONFIG_LOCAL_OUTPUT="$TMPDIR/update-removed-config-local.log"
+(cd "$CLAUDE_REMOVED_CONFIG_LOCAL_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update > "$CLAUDE_REMOVED_CONFIG_LOCAL_OUTPUT" 2>&1)
+assert_contains "$CLAUDE_REMOVED_CONFIG_LOCAL_OUTPUT" "removed from the package" "package-removed local config warning must be printed"
+assert_contains "$CLAUDE_REMOVED_CONFIG_LOCAL_OUTPUT" "config\\.toml \(local changes preserved\)" "package-removed local config must be reported as preserved"
+assert_exists "$CLAUDE_REMOVED_CONFIG_LOCAL_PROJECT_DIR/.claude/config.toml" "package-removed local config must remain on disk"
+assert_contains "$CLAUDE_REMOVED_CONFIG_LOCAL_PROJECT_DIR/.claude/config.toml" "\\[user\\]" "package-removed local config must keep user section"
+node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];if(Array.isArray(a.configFiles)&&a.configFiles.length>0)process.exit(1);if(Array.isArray(a.installedConfigFiles)&&a.installedConfigFiles.length>0)process.exit(1);if(a.managedConfigFiles&&Object.keys(a.managedConfigFiles).length>0)process.exit(1);" "$CLAUDE_REMOVED_CONFIG_LOCAL_PROJECT_DIR/.ai-factory.json"
+
+CLAUDE_REMOVED_CONFIG_CLEAN_PROJECT_DIR="$TMPDIR/update-smoke-removed-config-clean"
+mkdir -p "$CLAUDE_REMOVED_CONFIG_CLEAN_PROJECT_DIR/.claude"
+
+node - "$CLAUDE_REMOVED_CONFIG_CLEAN_PROJECT_DIR" <<'EOF'
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const projectDir = process.argv[2];
+const oldConfig = '[managed]\nkeep = true\n';
+fs.writeFileSync(path.join(projectDir, '.claude/config.toml'), oldConfig);
+
+const oldHash = crypto.createHash('sha256')
+  .update('path:config.toml\n')
+  .update(Buffer.from(oldConfig))
+  .update('\n')
+  .digest('hex');
+
+fs.writeFileSync(path.join(projectDir, '.ai-factory.json'), JSON.stringify({
+  version: '2.4.0',
+  agents: [{
+    id: 'claude',
+    skillsDir: '.claude/skills',
+    installedSkills: ['aif'],
+    configFiles: ['config.toml'],
+    installedConfigFiles: ['config.toml'],
+    managedConfigFiles: { 'config.toml': { sourceHash: oldHash, installedHash: oldHash } },
+    mcp: {
+      github: false,
+      filesystem: false,
+      postgres: false,
+      chromeDevtools: false,
+      playwright: false,
+    },
+  }],
+  extensions: [],
+}, null, 2) + '\n');
+EOF
+
+CLAUDE_REMOVED_CONFIG_CLEAN_OUTPUT="$TMPDIR/update-removed-config-clean.log"
+(cd "$CLAUDE_REMOVED_CONFIG_CLEAN_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update > "$CLAUDE_REMOVED_CONFIG_CLEAN_OUTPUT" 2>&1)
+assert_contains "$CLAUDE_REMOVED_CONFIG_CLEAN_OUTPUT" "config\\.toml \(removed from package\)" "package-removed clean config must be reported as removed"
+assert_not_exists "$CLAUDE_REMOVED_CONFIG_CLEAN_PROJECT_DIR/.claude/config.toml" "package-removed clean config must be deleted"
+node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];if(Array.isArray(a.configFiles)&&a.configFiles.length>0)process.exit(1);if(Array.isArray(a.installedConfigFiles)&&a.installedConfigFiles.length>0)process.exit(1);if(a.managedConfigFiles&&Object.keys(a.managedConfigFiles).length>0)process.exit(1);" "$CLAUDE_REMOVED_CONFIG_CLEAN_PROJECT_DIR/.ai-factory.json"
+
+echo "package-removed config ownership smoke tests passed"
+
+# -------------------------------------------------------------------
 # Codex config source+target drift smoke
 # -------------------------------------------------------------------
 

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -121,6 +121,73 @@ assert_contains "$FORCE_OUTPUT" "force reinstall" "force reason should be visibl
 echo "update smoke tests passed"
 
 # -------------------------------------------------------------------
+# New base skills update prompt smoke
+# -------------------------------------------------------------------
+
+NEW_SKILL_PROMPT_PROJECT_DIR="$TMPDIR/update-smoke-new-skill-prompt"
+mkdir -p "$NEW_SKILL_PROMPT_PROJECT_DIR"
+
+cat > "$NEW_SKILL_PROMPT_PROJECT_DIR/.ai-factory.json" << 'EOF'
+{
+  "version": "2.4.0",
+  "agents": [
+    {
+      "id": "universal",
+      "skillsDir": ".agents/skills",
+      "installedSkills": ["aif"],
+      "mcp": {
+        "github": false,
+        "filesystem": false,
+        "postgres": false,
+        "chromeDevtools": false,
+        "playwright": false
+      }
+    }
+  ],
+  "extensions": []
+}
+EOF
+
+NEW_SKILL_PROMPT_OUTPUT="$TMPDIR/update-new-skill-prompt.log"
+AIF_TEST_ROOT_DIR="$ROOT_DIR" AIF_TEST_PROJECT_DIR="$NEW_SKILL_PROMPT_PROJECT_DIR" node --input-type=module > "$NEW_SKILL_PROMPT_OUTPUT" 2>&1 <<'EOF'
+import inquirer from 'inquirer';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+
+const originalPrompt = inquirer.prompt.bind(inquirer);
+inquirer.prompt = async (questions) => {
+  const first = Array.isArray(questions) ? questions[0] : questions;
+  if (first?.name === 'shouldUpdate') {
+    return { shouldUpdate: false };
+  }
+  if (first?.name === 'selectedNewSkills') {
+    return { selectedNewSkills: ['aif-plan'] };
+  }
+  throw new Error(`Unexpected prompt: ${JSON.stringify(questions)}`);
+};
+
+process.chdir(process.env.AIF_TEST_PROJECT_DIR);
+
+const moduleUrl = pathToFileURL(path.join(process.env.AIF_TEST_ROOT_DIR, 'dist/cli/commands/update.js')).href;
+const { updateCommand } = await import(moduleUrl);
+
+try {
+  await updateCommand();
+} finally {
+  inquirer.prompt = originalPrompt;
+}
+EOF
+
+assert_contains "$NEW_SKILL_PROMPT_OUTPUT" "New base skills available:" "update must announce newly available base skills"
+assert_contains "$NEW_SKILL_PROMPT_OUTPUT" "aif-plan \(new in package\)" "accepted new skill must be reported as installed"
+assert_exists "$NEW_SKILL_PROMPT_PROJECT_DIR/.agents/skills/aif-plan/SKILL.md" "accepted new skill must be installed"
+node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];if(!Array.isArray(a.installedSkills)||!a.installedSkills.includes('aif-plan'))process.exit(1);if(!a.managedSkills||!a.managedSkills['aif-plan'])process.exit(1);" "$NEW_SKILL_PROMPT_PROJECT_DIR/.ai-factory.json"
+
+echo "new base skill prompt smoke tests passed"
+
+# -------------------------------------------------------------------
 # Codex app update smoke: repo skills should keep Codex $ invocations,
 # custom skills should be preserved, and incompatible shared repo skills
 # runtime configs should fail before mutation.
@@ -432,8 +499,9 @@ echo "# drift" >> "$CODEX_PROJECT_DIR/.codex/config.toml"
 
 (cd "$CODEX_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update > "$CODEX_SECOND_OUTPUT" 2>&1)
 assert_contains "$CODEX_SECOND_OUTPUT" "Local modifications detected in config file" "Codex config drift warning must be printed"
-assert_contains "$CODEX_SECOND_OUTPUT" "config\\.toml \(local drift\)" "Codex config drift must be repaired on update"
-assert_contains "$CODEX_PROJECT_DIR/.codex/config.toml" "\\[agents\\]" "Codex config content must be restored"
+assert_contains "$CODEX_SECOND_OUTPUT" "config\\.toml \(local changes preserved\)" "Codex config drift must be preserved on update"
+assert_contains "$CODEX_PROJECT_DIR/.codex/config.toml" "\\[agents\\]" "Codex config base content must remain"
+assert_contains "$CODEX_PROJECT_DIR/.codex/config.toml" "# drift" "Codex config local drift must be preserved"
 
 echo "codex assets smoke tests passed"
 
@@ -490,6 +558,61 @@ assert_not_contains "$CODEX_USER_CONFIG_PROJECT_DIR/.codex/config.toml" "\\[agen
 node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];if(a.id!=='codex')process.exit(1);if(!Array.isArray(a.configFiles)||!a.configFiles.includes('config.toml'))process.exit(1);if(Array.isArray(a.installedConfigFiles)&&a.installedConfigFiles.includes('config.toml'))process.exit(1);if(a.managedConfigFiles&&a.managedConfigFiles['config.toml'])process.exit(1);" "$CODEX_USER_CONFIG_PROJECT_DIR/.ai-factory.json"
 
 echo "codex user-owned config migration smoke tests passed"
+
+# -------------------------------------------------------------------
+# Codex config source+target drift smoke
+# -------------------------------------------------------------------
+
+CODEX_CONFIG_SOURCE_TARGET_DRIFT_PROJECT_DIR="$TMPDIR/update-smoke-codex-config-source-target-drift"
+mkdir -p "$CODEX_CONFIG_SOURCE_TARGET_DRIFT_PROJECT_DIR/.codex"
+
+node - "$CODEX_CONFIG_SOURCE_TARGET_DRIFT_PROJECT_DIR" <<'EOF'
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const projectDir = process.argv[2];
+const oldConfig = '[agents]\nmax_threads = 2\n';
+const localConfig = `${oldConfig}\n[user]\nkeep = true\n`;
+fs.writeFileSync(path.join(projectDir, '.codex/config.toml'), localConfig);
+
+const oldHash = crypto.createHash('sha256')
+  .update('path:config.toml\n')
+  .update(Buffer.from(oldConfig))
+  .update('\n')
+  .digest('hex');
+
+fs.writeFileSync(path.join(projectDir, '.ai-factory.json'), JSON.stringify({
+  version: '2.4.0',
+  agents: [{
+    id: 'codex',
+    skillsDir: '.codex/skills',
+    installedSkills: ['aif'],
+    configFiles: ['config.toml'],
+    installedConfigFiles: ['config.toml'],
+    managedConfigFiles: { 'config.toml': { sourceHash: oldHash, installedHash: oldHash } },
+    mcp: {
+      github: false,
+      filesystem: false,
+      postgres: false,
+      chromeDevtools: false,
+      playwright: false,
+    },
+  }],
+  extensions: [],
+}, null, 2) + '\n');
+EOF
+
+CODEX_CONFIG_SOURCE_TARGET_DRIFT_OUTPUT="$TMPDIR/update-codex-config-source-target-drift.log"
+(cd "$CODEX_CONFIG_SOURCE_TARGET_DRIFT_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update > "$CODEX_CONFIG_SOURCE_TARGET_DRIFT_OUTPUT" 2>&1)
+assert_contains "$CODEX_CONFIG_SOURCE_TARGET_DRIFT_OUTPUT" "Local modifications detected in config file" "Codex config source+target drift warning must be printed"
+assert_contains "$CODEX_CONFIG_SOURCE_TARGET_DRIFT_OUTPUT" "config\\.toml \(local changes preserved\)" "Codex config source+target drift must be preserved on update"
+assert_contains "$CODEX_CONFIG_SOURCE_TARGET_DRIFT_PROJECT_DIR/.codex/config.toml" "\\[user\\]" "Codex config source+target drift must keep user section"
+assert_contains "$CODEX_CONFIG_SOURCE_TARGET_DRIFT_PROJECT_DIR/.codex/config.toml" "keep = true" "Codex config source+target drift must keep user content"
+assert_contains "$CODEX_CONFIG_SOURCE_TARGET_DRIFT_PROJECT_DIR/.codex/config.toml" "max_threads = 2" "Codex config source+target drift must keep local old config"
+node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const a=c.agents[0];const state=a.managedConfigFiles&&a.managedConfigFiles['config.toml'];if(!state||state.sourceHash===state.installedHash)process.exit(1);" "$CODEX_CONFIG_SOURCE_TARGET_DRIFT_PROJECT_DIR/.ai-factory.json"
+
+echo "codex config source+target drift smoke tests passed"
 
 # -------------------------------------------------------------------
 # Codex TOML drift smoke

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -482,6 +482,7 @@ EOF
 
 CODEX_FIRST_OUTPUT="$TMPDIR/update-codex-first.log"
 CODEX_SECOND_OUTPUT="$TMPDIR/update-codex-second.log"
+CODEX_FORCE_RECORDED_CUSTOMIZATION_OUTPUT="$TMPDIR/update-codex-force-recorded-customization.log"
 
 (cd "$CODEX_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update > "$CODEX_FIRST_OUTPUT" 2>&1)
 assert_contains "$CODEX_FIRST_OUTPUT" "\[codex\] Agent files:" "codex agent files section must be printed"
@@ -502,6 +503,12 @@ assert_contains "$CODEX_SECOND_OUTPUT" "Local modifications detected in config f
 assert_contains "$CODEX_SECOND_OUTPUT" "config\\.toml \(local changes preserved\)" "Codex config drift must be preserved on update"
 assert_contains "$CODEX_PROJECT_DIR/.codex/config.toml" "\\[agents\\]" "Codex config base content must remain"
 assert_contains "$CODEX_PROJECT_DIR/.codex/config.toml" "# drift" "Codex config local drift must be preserved"
+
+(cd "$CODEX_PROJECT_DIR" && node "$ROOT_DIR/dist/cli/index.js" update --force > "$CODEX_FORCE_RECORDED_CUSTOMIZATION_OUTPUT" 2>&1)
+assert_contains "$CODEX_FORCE_RECORDED_CUSTOMIZATION_OUTPUT" "Force mode enabled" "force update must print force mode for recorded config customization"
+assert_contains "$CODEX_FORCE_RECORDED_CUSTOMIZATION_OUTPUT" "Previously preserved local customization detected in config file" "force update must explain recorded config customization preservation"
+assert_contains "$CODEX_FORCE_RECORDED_CUSTOMIZATION_OUTPUT" "config\\.toml \(--force ignored; local changes preserved\)" "force update must report ignored force for recorded config customization"
+assert_contains "$CODEX_PROJECT_DIR/.codex/config.toml" "# drift" "force update must preserve recorded config customization"
 
 echo "codex assets smoke tests passed"
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -227,6 +227,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
           agentId: agentSelection.id,
           configFiles: agentConfig.configFiles,
           installedConfigFiles: existingAgent?.installedConfigFiles,
+          managedConfigFiles: existingAgent?.managedConfigFiles,
         })
         : [];
 

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -323,6 +323,7 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
       subagentEntriesByAgent.set(agent.id, subagentResult.entries);
 
       const configFileResult = await updateConfigFiles(agent, projectDir, { force });
+      agent.configFiles = configFileResult.configFiles;
       agent.installedConfigFiles = configFileResult.installedConfigFiles;
       configFileEntriesByAgent.set(agent.id, configFileResult.entries);
     }
@@ -443,6 +444,8 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
       agent.managedSkills = await buildManagedSkillsState(projectDir, agent, managedBaseSkills);
       if ((agent.configFiles ?? []).length > 0) {
         agent.managedConfigFiles = await buildManagedConfigFilesState(projectDir, agent, agent.installedConfigFiles ?? []);
+      } else {
+        agent.managedConfigFiles = {};
       }
     }
     await rebuildManagedAgentFilesForAgents(projectDir, config.agents, {

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -45,6 +45,8 @@ function formatReason(reason: string): string {
       return 'local drift';
     case 'local-modifications-preserved':
       return 'local changes preserved';
+    case 'force-ignored-local-modifications-preserved':
+      return '--force ignored; local changes preserved';
     case 'missing-managed-state':
       return 'state missing';
     case 'missing-installed-artifact':

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -43,6 +43,8 @@ function formatReason(reason: string): string {
       return 'source changed';
     case 'installed-hash-drift':
       return 'local drift';
+    case 'local-modifications-preserved':
+      return 'local changes preserved';
     case 'missing-managed-state':
       return 'state missing';
     case 'missing-installed-artifact':
@@ -68,6 +70,39 @@ function formatReason(reason: string): string {
     default:
       return reason;
   }
+}
+
+async function promptForNewSkills(
+  availableSkills: string[],
+  agents: Array<{ installedSkills: string[] }>,
+  excludedSkills: Set<string>,
+): Promise<string[]> {
+  const candidates = availableSkills.filter(skill => {
+    if (excludedSkills.has(skill)) {
+      return false;
+    }
+    return agents.some(agent => !partitionSkills(agent.installedSkills).base.includes(skill));
+  });
+
+  if (candidates.length === 0) {
+    return [];
+  }
+
+  if (!process.stdin.isTTY) {
+    console.log(chalk.dim(`New base skills available but not installed: ${candidates.join(', ')}`));
+    console.log(chalk.dim('Non-interactive mode — skipping new skills. Re-run `ai-factory update` interactively to add them.\n'));
+    return [];
+  }
+
+  console.log(chalk.cyan(`New base skills available: ${candidates.join(', ')}`));
+  const { selectedNewSkills } = await inquirer.prompt([{
+    type: 'checkbox',
+    name: 'selectedNewSkills',
+    message: 'Add new base skills to configured agents?',
+    choices: candidates.map(skill => ({ name: skill, value: skill, checked: true })),
+  }]);
+
+  return Array.isArray(selectedNewSkills) ? selectedNewSkills : [];
 }
 
 function groupAndSortEntriesByStatus<T extends { status: 'changed' | 'unchanged' | 'skipped' | 'removed' }>(
@@ -271,10 +306,13 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
       console.log(chalk.dim(`Skipping replaced skills: ${[...allReplacedSkills].join(', ')}`));
     }
 
+    const selectedNewSkills = await promptForNewSkills(availableSkills, config.agents, allReplacedSkills);
+
     for (const agent of config.agents) {
       const result = await updateSkills(agent, projectDir, {
         excludeSkills: [...allReplacedSkills],
         force,
+        installNewSkills: selectedNewSkills,
       });
       agent.installedSkills = result.installedSkills;
       skillEntriesByAgent.set(agent.id, result.entries);

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -236,6 +236,7 @@ export async function upgradeCommand(): Promise<void> {
         agentId: agent.id,
         configFiles: effectiveConfigFiles,
         installedConfigFiles: agent.installedConfigFiles,
+        managedConfigFiles: agent.managedConfigFiles,
       })
       : [];
 

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -1377,14 +1377,25 @@ export async function updateConfigFiles(
     }
 
     if (hasLocalCustomization) {
-      shouldInstall.set(relPath, { install: false, reason: 'local-modifications-preserved' });
+      if (force) {
+        console.warn(
+          `Warning: Previously preserved local customization detected in config file "${relPath}" — preserving existing file. --force does not overwrite local config changes.`,
+        );
+      }
+      shouldInstall.set(relPath, {
+        install: false,
+        reason: force ? 'force-ignored-local-modifications-preserved' : 'local-modifications-preserved',
+      });
       continue;
     }
 
     if (previousState && installedHash && previousState.installedHash !== installedHash) {
       const forceNote = force ? ' --force does not overwrite local config changes.' : '';
       console.warn(`Warning: Local modifications detected in config file "${relPath}" — preserving existing file.${forceNote}`);
-      shouldInstall.set(relPath, { install: false, reason: 'local-modifications-preserved' });
+      shouldInstall.set(relPath, {
+        install: false,
+        reason: force ? 'force-ignored-local-modifications-preserved' : 'local-modifications-preserved',
+      });
       continue;
     }
 

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -78,6 +78,7 @@ export interface ConfigFileUpdateEntry {
 }
 
 export interface UpdateConfigFilesResult {
+  configFiles: string[];
   installedConfigFiles: string[];
   entries: ConfigFileUpdateEntry[];
 }
@@ -318,14 +319,8 @@ export function resolveManagedConfigFilePaths(projectDir: string, agentId: strin
     throw new Error(`Agent "${agentId}" does not define managed config files.`);
   }
 
-  const targetRoot = path.join(projectDir, agentConfig.configDir);
   const sourceFile = path.join(sourceRoot, relPath);
-  const targetFile = path.join(targetRoot, relPath);
-  ensureTargetWithinRoot(targetRoot, targetFile, {
-    rootLabel: 'Managed config directory',
-    targetLabel: 'Managed config target',
-    rootDescription: 'config directory',
-  });
+  const targetFile = resolveInstalledConfigFileTargetPath(projectDir, agentId, relPath);
   ensureTargetWithinRoot(sourceRoot, sourceFile, {
     rootLabel: 'Managed config source directory',
     targetLabel: 'Managed config source',
@@ -337,6 +332,19 @@ export function resolveManagedConfigFilePaths(projectDir: string, agentId: strin
     targetFile,
     relPath,
   };
+}
+
+function resolveInstalledConfigFileTargetPath(projectDir: string, agentId: string, relPath: string): string {
+  assertSafeManagedRelativePath(relPath);
+  const agentConfig = getAgentConfig(agentId);
+  const targetRoot = path.join(projectDir, agentConfig.configDir);
+  const targetFile = path.join(targetRoot, relPath);
+  ensureTargetWithinRoot(targetRoot, targetFile, {
+    rootLabel: 'Managed config directory',
+    targetLabel: 'Managed config target',
+    rootDescription: 'config directory',
+  });
+  return targetFile;
 }
 
 function getBundledAgentFilesSourceDir(agentId: string): string | null {
@@ -930,7 +938,7 @@ async function removeConfigFilesByName(
 
   for (const relPath of configFiles) {
     try {
-      const { targetFile } = resolveManagedConfigFilePaths(projectDir, agentInstallation.id, relPath);
+      const targetFile = resolveInstalledConfigFileTargetPath(projectDir, agentInstallation.id, relPath);
       await removeFile(targetFile);
       removed.push(relPath);
     } catch {
@@ -1267,13 +1275,7 @@ export async function updateConfigFiles(
   projectDir: string,
   options: UpdateSkillsOptions = {},
 ): Promise<UpdateConfigFilesResult> {
-  const configuredFiles = agentInstallation.configFiles ?? getAgentConfig(agentInstallation.id).configFiles ?? [];
-  if (configuredFiles.length === 0) {
-    return {
-      installedConfigFiles: [],
-      entries: [],
-    };
-  }
+  const configuredFiles = getAgentConfig(agentInstallation.id).configFiles ?? [];
 
   const { force = false } = options;
   const availableSet = new Set(configuredFiles);
@@ -1284,13 +1286,65 @@ export async function updateConfigFiles(
 
   const removedFiles = previousInstalled.filter(file => !availableSet.has(file));
   if (removedFiles.length > 0) {
-    await removeConfigFilesByName(projectDir, agentInstallation, removedFiles);
-    for (const file of removedFiles) {
+    const cleanRemovedFiles: string[] = [];
+
+    for (const relPath of removedFiles) {
+      const previousState = previousManaged[relPath];
+      let installedHash: string | null = null;
+
+      try {
+        const targetFile = resolveInstalledConfigFileTargetPath(projectDir, agentInstallation.id, relPath);
+        installedHash = await hashManagedFile(targetFile, relPath);
+      } catch {
+        console.warn(
+          `Warning: Config file "${relPath}" was removed from the package, but its target path could not be verified — preserving existing file and dropping managed ownership.`,
+        );
+        entries.push({
+          configFile: relPath,
+          status: 'skipped',
+          reason: 'local-modifications-preserved',
+        });
+        continue;
+      }
+
+      if (!installedHash) {
+        entries.push({
+          configFile: relPath,
+          status: 'removed',
+          reason: 'package-removed',
+        });
+        continue;
+      }
+
+      if (previousState && previousState.installedHash === installedHash && previousState.sourceHash === previousState.installedHash) {
+        cleanRemovedFiles.push(relPath);
+        continue;
+      }
+
+      const warningSuffix = previousState
+        ? 'local changes exist'
+        : 'managed state is missing';
+      console.warn(
+        `Warning: Config file "${relPath}" was removed from the package, but ${warningSuffix} — preserving existing file and dropping managed ownership.`,
+      );
       entries.push({
-        configFile: file,
-        status: 'removed',
-        reason: 'package-removed',
+        configFile: relPath,
+        status: 'skipped',
+        reason: 'local-modifications-preserved',
       });
+    }
+
+    if (cleanRemovedFiles.length > 0) {
+      const removed = await removeConfigFilesByName(projectDir, agentInstallation, cleanRemovedFiles);
+      const removedSet = new Set(removed);
+
+      for (const relPath of cleanRemovedFiles) {
+        entries.push({
+          configFile: relPath,
+          status: removedSet.has(relPath) ? 'removed' : 'skipped',
+          reason: removedSet.has(relPath) ? 'package-removed' : 'local-modifications-preserved',
+        });
+      }
     }
   }
 
@@ -1418,6 +1472,7 @@ export async function updateConfigFiles(
   });
 
   return {
+    configFiles: configuredFiles,
     installedConfigFiles: syncedFiles,
     entries,
   };

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -85,6 +85,7 @@ export interface UpdateConfigFilesResult {
 export interface UpdateSkillsOptions {
   excludeSkills?: string[];
   force?: boolean;
+  installNewSkills?: string[];
 }
 
 export interface InstallOptions {
@@ -106,6 +107,7 @@ export interface InstallConfigFilesOptions {
   agentId: string;
   configFiles: string[];
   installedConfigFiles?: string[];
+  managedConfigFiles?: Record<string, ManagedArtifactState>;
 }
 
 interface ResolvedSkillPaths {
@@ -785,14 +787,41 @@ export async function installConfigFiles(options: InstallConfigFilesOptions): Pr
   }
 
   const previousInstalledSet = new Set(options.installedConfigFiles ?? []);
+  const previousManaged = options.managedConfigFiles ?? {};
   const installed: string[] = [];
 
   for (const relPath of configFiles) {
     const paths = resolveManagedConfigFilePaths(projectDir, agentId, relPath);
-    if (!previousInstalledSet.has(relPath) && await fileExists(paths.targetFile)) {
+    const sourceHash = await hashManagedFile(paths.sourceFile, relPath);
+    const installedHash = await hashManagedFile(paths.targetFile, relPath);
+    const previousState = previousManaged[relPath];
+
+    if (!previousInstalledSet.has(relPath) && installedHash) {
       console.warn(
         `Warning: Existing untracked config file "${relPath}" detected — preserving it and skipping managed install.`,
       );
+      continue;
+    }
+
+    if (previousInstalledSet.has(relPath) && !previousState && installedHash) {
+      console.warn(`Warning: Managed config file "${relPath}" has no saved state — preserving existing file.`);
+      installed.push(relPath);
+      continue;
+    }
+
+    if (previousState && installedHash && previousState.installedHash !== installedHash) {
+      console.warn(`Warning: Local modifications detected in config file "${relPath}" — preserving existing file.`);
+      installed.push(relPath);
+      continue;
+    }
+
+    if (previousState && installedHash && previousState.installedHash === installedHash && previousState.installedHash !== previousState.sourceHash) {
+      installed.push(relPath);
+      continue;
+    }
+
+    if (!sourceHash && installedHash) {
+      installed.push(relPath);
       continue;
     }
 
@@ -925,10 +954,11 @@ export async function updateSkills(
   projectDir: string,
   options: UpdateSkillsOptions = {},
 ): Promise<UpdateSkillsResult> {
-  const { excludeSkills = [], force = false } = options;
+  const { excludeSkills = [], force = false, installNewSkills = [] } = options;
   const availableSkills = await getAvailableSkills();
   const availableSet = new Set(availableSkills);
   const excludeSet = new Set(excludeSkills);
+  const installNewSet = new Set(installNewSkills);
 
   const entries: SkillUpdateEntry[] = [];
 
@@ -958,7 +988,28 @@ export async function updateSkills(
   }
 
   const newlyAvailable = availableSkills.filter(s => !previousBaseSet.has(s) && !excludeSet.has(s));
-  for (const skill of newlyAvailable) {
+  const newSkillsToInstall = newlyAvailable.filter(s => installNewSet.has(s));
+  const skippedNewSkills = newlyAvailable.filter(s => !installNewSet.has(s));
+
+  const installedNewSkills = newSkillsToInstall.length > 0
+    ? await installSkills({
+      projectDir,
+      skillsDir: agentInstallation.skillsDir,
+      skills: newSkillsToInstall,
+      agentId: agentInstallation.id,
+    })
+    : [];
+  const installedNewSet = new Set(installedNewSkills);
+
+  for (const skill of newSkillsToInstall) {
+    entries.push({
+      skill,
+      status: installedNewSet.has(skill) ? 'changed' : 'skipped',
+      reason: installedNewSet.has(skill) ? 'new-in-package' : 'install-failed',
+    });
+  }
+
+  for (const skill of skippedNewSkills) {
     entries.push({
       skill,
       status: 'skipped',
@@ -1054,7 +1105,7 @@ export async function updateSkills(
   const retainedBaseSkills = previousBaseSkills.filter(s => (availableSet.has(s) || excludeSet.has(s)) && !removedSkills.includes(s));
 
   return {
-    installedSkills: [...retainedBaseSkills, ...custom],
+    installedSkills: [...retainedBaseSkills, ...installedNewSkills, ...custom],
     entries,
   };
 }
@@ -1250,12 +1301,36 @@ export async function updateConfigFiles(
     const sourceHash = await hashManagedFile(paths.sourceFile, relPath);
     const installedHash = await hashManagedFile(paths.targetFile, relPath);
     const previousState = previousManaged[relPath];
+    const hasLocalCustomization = Boolean(
+      previousState &&
+      installedHash &&
+      previousState.installedHash === installedHash &&
+      previousState.installedHash !== previousState.sourceHash,
+    );
 
     if (!previousInstalledSet.has(relPath) && installedHash) {
       console.warn(
         `Warning: Existing untracked config file "${relPath}" detected — preserving it and skipping managed install.`,
       );
       shouldInstall.set(relPath, { install: false, reason: 'untracked-target-exists' });
+      continue;
+    }
+
+    if (previousInstalledSet.has(relPath) && !previousState && installedHash) {
+      console.warn(`Warning: Managed config file "${relPath}" has no saved state — preserving existing file.`);
+      shouldInstall.set(relPath, { install: false, reason: 'local-modifications-preserved' });
+      continue;
+    }
+
+    if (hasLocalCustomization) {
+      shouldInstall.set(relPath, { install: false, reason: 'local-modifications-preserved' });
+      continue;
+    }
+
+    if (previousState && installedHash && previousState.installedHash !== installedHash) {
+      const forceNote = force ? ' --force does not overwrite local config changes.' : '';
+      console.warn(`Warning: Local modifications detected in config file "${relPath}" — preserving existing file.${forceNote}`);
+      shouldInstall.set(relPath, { install: false, reason: 'local-modifications-preserved' });
       continue;
     }
 
@@ -1286,12 +1361,6 @@ export async function updateConfigFiles(
 
     if (previousState.sourceHash !== sourceHash) {
       shouldInstall.set(relPath, { install: true, reason: 'source-hash-changed' });
-      continue;
-    }
-
-    if (previousState.installedHash !== installedHash) {
-      console.warn(`Warning: Local modifications detected in config file "${relPath}" — will be overwritten by update.`);
-      shouldInstall.set(relPath, { install: true, reason: 'installed-hash-drift' });
       continue;
     }
 


### PR DESCRIPTION
## Summary
- preserve existing managed agent config files during repeated init/update runs instead of overwriting local edits
- keep config files with local drift or missing managed state and report them as local changes preserved
- prompt during interactive `ai-factory update` to install newly available built-in skills, while keeping non-interactive runs safe

## Testing
- `npm run build`
- `npm run test:init`
- `npm run test:update`