### PR TITLE
docs: add Implementation Notes to Community Extensions

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -574,6 +574,7 @@ Extensions built by the community. To add yours, submit a PR to this file.
 |-----------|-------------|---------|
 | [Remote Skills](https://github.com/dealenx/ai-factory-extension-remote-skills) | Install and manage skills from GitHub repositories. Supports branch selection, interactive removal, and sync with active agents. | `ai-factory extension add https://github.com/dealenx/ai-factory-extension-remote-skills.git` |
 | [AIF Extension Creator](https://github.com/dealenx/ai-factory-extension-aif-extension-creator-skill) |An AI Factory extension that provides an interactive skill for scaffolding new AI Factory extensions. | `ai-factory extension add https://github.com/dealenx/ai-factory-extension-aif-extension-creator-skill.git` |
+| [Implementation Notes](https://github.com/sattva2020/aif-ext-implementation-notes) | Append-only decision journal for `/aif-implement` — records decisions, deviations, tradeoffs, surprises and open questions (markdown canon + auto-generated HTML view). Feeds notes into `/aif-commit` bodies, adds a WARN-only coverage gate to `/aif-verify`, and archives the journal with the plan via `/aif-archive`. | `ai-factory extension add https://github.com/sattva2020/aif-ext-implementation-notes.git` |
 
 ## See Also
 


### PR DESCRIPTION
Adds [aif-ext-implementation-notes](https://github.com/sattva2020/aif-ext-implementation-notes) to the Community Extensions table in `docs/extensions.md`.

Built in response to #116 (you suggested keeping it as an extension rather than in-core).

**What it does:** append-only decision journal during `/aif-implement` — records decisions, deviations, tradeoffs, surprises and open questions (markdown canon + auto-generated HTML view with category filters). Via append-injections it wires into:
- `/aif-implement` — maintains the journal
- `/aif-commit` — pulls notes into the commit body
- `/aif-verify` — WARN-only coverage gate
- `/aif-archive` — archives the journal alongside the plan

Plus an `ai-factory notes` CLI and an `/aif-notes` skill. Pure injection-based, so it survives `ai-factory update`. Tested on 2.15.0.

Single-line docs change only.