### PR TITLE
fix(skills): honor language settings in aif-improve outputs

### DIFF
--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -406,11 +406,44 @@ cat > "$DISTILL_SRC/docs/.ai-factory/config.yaml" << 'EOF'
 language:
   ui: en
 EOF
-ln -s ../.env "$DISTILL_SRC/docs/symlink-env.md"
-ln -s ../.ssh/id_rsa "$DISTILL_SRC/docs/symlink-ssh.md"
-ln -s ../outside.md "$DISTILL_SRC/docs/symlink-outside.md"
-ln -s ../.ssh "$DISTILL_SRC/docs/symlink-ssh-dir"
-ln -s .env.md "$DISTILL_SRC/docs/symlink-hidden-sensitive.md"
+create_distill_symlink() {
+    local target="$1"
+    local link="$2"
+    local target_is_dir="${3:-0}"
+    "${PYTHON_CMD[@]}" -c '
+import os
+import pathlib
+import sys
+
+target, link, target_is_dir = sys.argv[1], sys.argv[2], sys.argv[3] == "1"
+try:
+    os.symlink(target, link, target_is_directory=target_is_dir)
+except (OSError, NotImplementedError):
+    raise SystemExit(1)
+raise SystemExit(0 if pathlib.Path(link).is_symlink() else 1)
+' "$target" "$link" "$target_is_dir"
+}
+
+cleanup_distill_symlinks() {
+    rm -f \
+        "$DISTILL_SRC/docs/symlink-env.md" \
+        "$DISTILL_SRC/docs/symlink-ssh.md" \
+        "$DISTILL_SRC/docs/symlink-outside.md" \
+        "$DISTILL_SRC/docs/symlink-hidden-sensitive.md" \
+        "$DISTILL_SRC/docs/symlink-ssh-dir"
+}
+
+DISTILL_SYMLINKS_SUPPORTED=0
+cleanup_distill_symlinks
+if create_distill_symlink "$DISTILL_SRC/.env" "$DISTILL_SRC/docs/symlink-env.md" \
+    && create_distill_symlink "$DISTILL_SRC/.ssh/id_rsa" "$DISTILL_SRC/docs/symlink-ssh.md" \
+    && create_distill_symlink "$DISTILL_SRC/outside.md" "$DISTILL_SRC/docs/symlink-outside.md" \
+    && create_distill_symlink "$DISTILL_SRC/.ssh" "$DISTILL_SRC/docs/symlink-ssh-dir" 1 \
+    && create_distill_symlink "$DISTILL_SRC/docs/.env.md" "$DISTILL_SRC/docs/symlink-hidden-sensitive.md"; then
+    DISTILL_SYMLINKS_SUPPORTED=1
+else
+    cleanup_distill_symlinks
+fi
 
 DISTILL_OUT="$TMPDIR/distillation-out"
 if "${PYTHON_CMD[@]}" "$DISTILL_HELPER" "$DISTILL_SRC/docs" --out "$DISTILL_OUT" --chunk-chars 200 > "$TMPDIR/distillation-helper.log" 2>&1; then
@@ -447,20 +480,147 @@ else
 fi
 
 DISTILL_SYMLINK_OUT="$TMPDIR/distillation-symlink-out"
-if "${PYTHON_CMD[@]}" "$DISTILL_HELPER" "$DISTILL_SRC/docs" --out "$DISTILL_SYMLINK_OUT" --include-symlinks --include-hidden --include-sensitive --chunk-chars 200 > "$TMPDIR/distillation-symlink.log" 2>&1; then
-    if grep -q "symlink-hidden-sensitive.md" "$DISTILL_SYMLINK_OUT/source-index.md" \
-        && ! grep -q "symlink-env.md" "$DISTILL_SYMLINK_OUT/source-index.md" \
-        && ! grep -q "symlink-ssh.md" "$DISTILL_SYMLINK_OUT/source-index.md" \
-        && ! grep -q "symlink-outside.md" "$DISTILL_SYMLINK_OUT/source-index.md" \
-        && ! grep -q "symlink-ssh-dir" "$DISTILL_SYMLINK_OUT/source-index.md"; then
-        pass "aif-distillation helper allows only in-root symlink files with all required opt-ins"
+if [[ "$DISTILL_SYMLINKS_SUPPORTED" -eq 1 ]]; then
+    if "${PYTHON_CMD[@]}" "$DISTILL_HELPER" "$DISTILL_SRC/docs" --out "$DISTILL_SYMLINK_OUT" --include-symlinks --include-hidden --include-sensitive --chunk-chars 200 > "$TMPDIR/distillation-symlink.log" 2>&1; then
+        if grep -q "symlink-hidden-sensitive.md" "$DISTILL_SYMLINK_OUT/source-index.md" \
+            && ! grep -q "symlink-env.md" "$DISTILL_SYMLINK_OUT/source-index.md" \
+            && ! grep -q "symlink-ssh.md" "$DISTILL_SYMLINK_OUT/source-index.md" \
+            && ! grep -q "symlink-outside.md" "$DISTILL_SYMLINK_OUT/source-index.md" \
+            && ! grep -q "symlink-ssh-dir" "$DISTILL_SYMLINK_OUT/source-index.md"; then
+            pass "aif-distillation helper allows only in-root symlink files with all required opt-ins"
+        else
+            fail "aif-distillation helper symlink opt-in should keep source-root and hidden/sensitive boundaries"
+            cat "$DISTILL_SYMLINK_OUT/source-index.md"
+        fi
     else
-        fail "aif-distillation helper symlink opt-in should keep source-root and hidden/sensitive boundaries"
-        cat "$DISTILL_SYMLINK_OUT/source-index.md"
+        fail "aif-distillation helper should process folder with explicit symlink opt-ins"
+        cat "$TMPDIR/distillation-symlink.log"
     fi
 else
-    fail "aif-distillation helper should process folder with explicit symlink opt-ins"
-    cat "$TMPDIR/distillation-symlink.log"
+    if "${PYTHON_CMD[@]}" - "$DISTILL_HELPER" > "$TMPDIR/distillation-symlink-boundary-unit.log" 2>&1 << 'PY'
+import importlib.util
+import sys
+
+helper_path = sys.argv[1]
+spec = importlib.util.spec_from_file_location("material_prep", helper_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+class FakePath:
+    def __init__(self, value, *, symlink=False, resolved=None, file=True):
+        self.parts = tuple(part for part in value.strip("/").split("/") if part)
+        self._symlink = symlink
+        self._resolved = resolved
+        self._file = file
+
+    @property
+    def name(self):
+        return self.parts[-1] if self.parts else ""
+
+    def relative_to(self, root):
+        if self.parts[: len(root.parts)] != root.parts:
+            raise ValueError(f"{self} is not under {root}")
+        return FakePath("/".join(self.parts[len(root.parts) :]))
+
+    def is_symlink(self):
+        return self._symlink
+
+    def resolve(self):
+        return self._resolved or self
+
+    def is_file(self):
+        return self._file
+
+    def __str__(self):
+        return "/" + "/".join(self.parts)
+
+
+root = FakePath("/src/docs")
+inside_hidden_sensitive = FakePath(
+    "/src/docs/symlink-hidden-sensitive.md",
+    symlink=True,
+    resolved=FakePath("/src/docs/.env.md"),
+)
+outside_env = FakePath(
+    "/src/docs/symlink-env.md",
+    symlink=True,
+    resolved=FakePath("/src/.env"),
+)
+outside_ssh_file = FakePath(
+    "/src/docs/symlink-ssh.md",
+    symlink=True,
+    resolved=FakePath("/src/.ssh/id_rsa"),
+)
+inside_dir = FakePath(
+    "/src/docs/symlink-ssh-dir",
+    symlink=True,
+    resolved=FakePath("/src/docs/.ssh", file=False),
+)
+
+cases = [
+    (
+        "requires --include-symlinks",
+        inside_hidden_sensitive,
+        {"include_hidden": True, "include_sensitive": True, "include_symlinks": False},
+        False,
+    ),
+    (
+        "allows in-root hidden sensitive symlink when all opt-ins are set",
+        inside_hidden_sensitive,
+        {"include_hidden": True, "include_sensitive": True, "include_symlinks": True},
+        True,
+    ),
+    (
+        "requires hidden opt-in for resolved hidden target",
+        inside_hidden_sensitive,
+        {"include_hidden": False, "include_sensitive": True, "include_symlinks": True},
+        False,
+    ),
+    (
+        "requires sensitive opt-in for resolved sensitive target",
+        inside_hidden_sensitive,
+        {"include_hidden": True, "include_sensitive": False, "include_symlinks": True},
+        False,
+    ),
+    (
+        "rejects symlink target outside selected root",
+        outside_env,
+        {"include_hidden": True, "include_sensitive": True, "include_symlinks": True},
+        False,
+    ),
+    (
+        "rejects outside ssh target",
+        outside_ssh_file,
+        {"include_hidden": True, "include_sensitive": True, "include_symlinks": True},
+        False,
+    ),
+    (
+        "rejects symlink directory target",
+        inside_dir,
+        {"include_hidden": True, "include_sensitive": True, "include_symlinks": True},
+        False,
+    ),
+]
+
+failures = []
+for name, path, kwargs, expected in cases:
+    actual = module.is_allowed_folder_file(path, root, **kwargs)
+    if actual != expected:
+        failures.append(f"{name}: expected {expected}, got {actual}")
+
+if failures:
+    print("\n".join(failures))
+    raise SystemExit(1)
+PY
+    then
+        pass "aif-distillation helper symlink boundary logic handles hidden/sensitive/root filters without native symlinks"
+    else
+        fail "aif-distillation helper symlink boundary logic should pass without native symlinks"
+        cat "$TMPDIR/distillation-symlink-boundary-unit.log"
+    fi
 fi
 
 DISTILL_EXISTING_OUT="$TMPDIR/distillation-existing-out"
@@ -554,6 +714,9 @@ AIF_SKILL="$ROOT_DIR/skills/aif/SKILL.md"
 AIF_EXPLORE_SKILL="$ROOT_DIR/skills/aif-explore/SKILL.md"
 AIF_PLAN_SKILL="$ROOT_DIR/skills/aif-plan/SKILL.md"
 AIF_IMPROVE_SKILL="$ROOT_DIR/skills/aif-improve/SKILL.md"
+AIF_IMPROVE_CHECK_REF="$ROOT_DIR/skills/aif-improve/references/CHECK-MODE.md"
+AIF_IMPROVE_EXAMPLES_REF="$ROOT_DIR/skills/aif-improve/references/EXAMPLES.md"
+AIF_IMPROVE_LIST_REF="$ROOT_DIR/skills/aif-improve/references/LIST-MODE.md"
 AIF_FIX_SKILL="$ROOT_DIR/skills/aif-fix/SKILL.md"
 AIF_RULES_SKILL="$ROOT_DIR/skills/aif-rules/SKILL.md"
 AIF_REFERENCE_SKILL="$ROOT_DIR/skills/aif-reference/SKILL.md"
@@ -751,6 +914,27 @@ if grep -Fq 'The next-step templates below define structure only. Render all hum
     pass "workflow user-facing templates use ui_language"
 else
     fail "workflow user-facing templates missing ui_language structure-only contract"
+fi
+
+AIF_IMPROVE_STEP5_SECTION="$(awk '
+    /^### Step 5: Present Improvements$/ { capture=1 }
+    capture { print }
+    /^\*\*Based on choice:\*\*$/ { exit }
+' "$AIF_IMPROVE_SKILL")"
+AIF_IMPROVE_STEP66_SECTION="$(awk '
+    /^\*\*6\.6: Confirm completion\*\*$/ { capture=1 }
+    capture { print }
+    /^### Context Cleanup$/ { exit }
+' "$AIF_IMPROVE_SKILL")"
+AIF_IMPROVE_REF_LANGUAGE_DIRECTIVE='The examples and output shapes in this reference define structure only. Render user-facing human-readable text in resolved `ui_language`.'
+if printf '%s\n' "$AIF_IMPROVE_STEP5_SECTION" | grep -Fq 'The Step 5 report template below defines structure only. Render all human-readable text in this user-facing response in `ui_language`.' \
+   && printf '%s\n' "$AIF_IMPROVE_STEP66_SECTION" | grep -Fq 'The Step 6.6 completion template below defines structure only. Render all human-readable text in this user-facing response in `ui_language`.' \
+   && grep -Fq "$AIF_IMPROVE_REF_LANGUAGE_DIRECTIVE" "$AIF_IMPROVE_CHECK_REF" \
+   && grep -Fq "$AIF_IMPROVE_REF_LANGUAGE_DIRECTIVE" "$AIF_IMPROVE_EXAMPLES_REF" \
+   && grep -Fq "$AIF_IMPROVE_REF_LANGUAGE_DIRECTIVE" "$AIF_IMPROVE_LIST_REF"; then
+    pass "/aif-improve concrete output templates use ui_language"
+else
+    fail "/aif-improve concrete output templates missing ui_language structure-only contract"
 fi
 
 if grep -Fq 'Preserve markdown structure, checkbox syntax, task IDs, branch names, commit messages, commands, file paths, config keys, package names, API names, `WARN`/`INFO` labels, and raw errors unchanged.' "$AIF_PLAN_SKILL" \

--- a/skills/aif-improve/SKILL.md
+++ b/skills/aif-improve/SKILL.md
@@ -281,6 +281,8 @@ Show the user what you found in a clear format. The emoji-grouped sections are k
 
 The "🔗 Dependency Fixes" group is **not** restated in this shape — it is always computed after the four other groups (and after `+check` filtering when the flag is set, see `references/CHECK-MODE.md`) and uses the short legacy form: `Task #X should depend on Task #Y. Reason: …`. The dependency entries reference only tasks that survived filtering.
 
+The Step 5 report template below defines structure only. Render all human-readable text in this user-facing response in `ui_language`. Preserve command names, paths, task IDs, section structure, option structure, task counts, numeric counts, `WARN`/`INFO` labels, and raw errors unchanged.
+
 ```
 ## Plan Refinement Report
 
@@ -400,6 +402,8 @@ the prefix is permanent and must survive any regeneration. Write back to the
 same absolute path you read from.
 
 **6.6: Confirm completion**
+
+The Step 6.6 completion template below defines structure only. Render all human-readable text in this user-facing response in `ui_language`. Preserve command names, paths, task counts, and numeric counts unchanged.
 
 ```
 ## Plan Refined

--- a/skills/aif-improve/references/CHECK-MODE.md
+++ b/skills/aif-improve/references/CHECK-MODE.md
@@ -2,6 +2,8 @@
 
 This file describes the optional findings-validation pass that runs when `aif-improve` is invoked with the `+check` flag. The parent skill defers to this document so the main `SKILL.md` stays focused on the default refinement workflow; `+check` is opt-in and most invocations do not need it.
 
+The examples and output shapes in this reference define structure only. Render user-facing human-readable text in resolved `ui_language`.
+
 ## When this runs
 
 `aif-improve` is invoked with `+check` and **without** `--list`. The pass executes between Step 4 (Identify Improvements) and Step 5 (Present Improvements). Without `+check`, skip this procedure entirely — there are no validator-related lines in the output and the Step 5 Summary block stays in its default shape without the two `+check` counter rows.

--- a/skills/aif-improve/references/EXAMPLES.md
+++ b/skills/aif-improve/references/EXAMPLES.md
@@ -2,6 +2,8 @@
 
 This file collects the worked examples that previously lived inline in `SKILL.md`. The parent skill defers to this document so the main file stays under the soft skill-size budget; the examples themselves are non-normative and exist as a reading aid.
 
+The examples and output shapes in this reference define structure only. Render user-facing human-readable text in resolved `ui_language`.
+
 The `--list` mode example lives in `references/LIST-MODE.md`. The `+check` mode example lives in `references/CHECK-MODE.md` — these two are not duplicated here.
 
 ## Example 1: Auto-review (no arguments)

--- a/skills/aif-improve/references/LIST-MODE.md
+++ b/skills/aif-improve/references/LIST-MODE.md
@@ -2,6 +2,8 @@
 
 This file describes the read-only plan discovery procedure that runs when `aif-improve` is invoked with the `--list` flag. The parent skill defers to this document instead of inlining the procedure, because `--list` is a conditional branch and keeps the main `SKILL.md` body within the size limit.
 
+The examples and output shapes in this reference define structure only. Render user-facing human-readable text in resolved `ui_language`.
+
 ## When this runs
 
 `aif-improve --list` is invoked. The flag may appear anywhere in `$ARGUMENTS`. When `--list` is present, this procedure runs to completion and the skill stops — no refinement is performed even if other tokens (`+check`, `@path`, free-form prompt) are also passed. Those tokens are silently ignored in `--list` mode.


### PR DESCRIPTION
## Summary

- Add explicit `ui_language` structure-only directives to `/aif-improve` Step 5 report and Step 6.6 completion templates.
- Add matching language directives to `CHECK-MODE.md`, `EXAMPLES.md`, and `LIST-MODE.md`.
- Extend regression coverage for `/aif-improve` language directives.
- Keep `aif-distillation` symlink boundary checks deterministic on Windows when native symlinks are unavailable.

## Verification

- `npm test`
- `npm run build`
- `git diff --check`

Closes #130