### PR TITLE
Make aif-fix regression-first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,8 @@ Investigates codebase (Glob, Grep, Read)
     ↓
 When a bug needs test/check coverage, creates or identifies a targeted regression test/check and confirms it reproduces the problem
     ↓
+If that check passes unexpectedly before the fix, records the mismatch; Handoff mode proceeds only with a safe likely root cause, while manual mode asks whether to continue or investigate
+    ↓
 Implements fix WITH logging ([FIX] prefix)
     ↓
 Reruns the same regression test/check and suggests any useful extra coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,13 +329,11 @@ If an existing FIX_PLAN.md references `RESEARCH.md`, treats embedded `Research C
     ↓
 Investigates codebase (Glob, Grep, Read)
     ↓
-When a bug needs test/check coverage, creates or identifies a targeted regression test/check and confirms it reproduces the problem
-    ↓
-If that check passes unexpectedly before the fix, records the mismatch; Handoff mode proceeds only with a safe likely root cause, while manual mode asks whether to continue or investigate
+When a bug needs regression coverage, follows the Canonical Regression-First Policy: creates or identifies a regression check, handles no-regression-check or non-reproducible fallbacks, then preserves the same check for verification
     ↓
 Implements fix WITH logging ([FIX] prefix)
     ↓
-Reruns the same regression test/check and suggests any useful extra coverage
+Reruns the same regression check when available and suggests any useful extra coverage
     ↓
 Creates self-improvement patch in configured `paths.patches/`
     ↓

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,7 @@ If an existing FIX_PLAN.md references `RESEARCH.md`, treats embedded `Research C
 Investigates codebase (Glob, Grep, Read)
     ↓
 When a bug needs regression coverage, follows the Canonical Regression-First Policy: creates or identifies a regression check, handles no-regression-check or non-reproducible fallbacks, then preserves the same check for verification
+(`Canonical Regression-First Policy` is defined in `skills/aif-fix/SKILL.md`.)
     ↓
 Implements fix WITH logging ([FIX] prefix)
     ↓

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,9 +329,11 @@ If an existing FIX_PLAN.md references `RESEARCH.md`, treats embedded `Research C
     ↓
 Investigates codebase (Glob, Grep, Read)
     ↓
+When a bug needs test/check coverage, creates or identifies a targeted regression test/check and confirms it reproduces the problem
+    ↓
 Implements fix WITH logging ([FIX] prefix)
     ↓
-Suggests test coverage for the bug
+Reruns the same regression test/check and suggests any useful extra coverage
     ↓
 Creates self-improvement patch in configured `paths.patches/`
     ↓

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -190,10 +190,9 @@ Bug fix with optional plan-first mode:
 - Asks to choose mode: **Fix now** (immediate) or **Plan first** (review before fixing)
 - Reads `.ai-factory/config.yaml` for `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.rules`, `paths.research`, `paths.fix_plan`, `paths.patches`, named `rules.<area>` entries, `language.ui`, `language.artifacts`, and `language.technical_terms`
 - Investigates codebase to find root cause
-- When a bug needs test/check coverage, creates or identifies a targeted regression test/check before implementation and confirms it reproduces the problem
-- If the pre-fix check passes unexpectedly, records the mismatch; Handoff mode continues only with a safe likely root cause, while manual mode asks whether to proceed or investigate further
+- When a bug needs regression coverage, follows the Canonical Regression-First Policy before implementation: create or identify a regression check, handle no-regression-check or non-reproducible fallbacks, then preserve the same check for verification
 - Applies fix WITH logging (`[FIX]` prefix for easy filtering)
-- Reruns the same regression test/check after the fix, then suggests any useful extra coverage
+- Reruns the same regression check after the fix when available, then suggests any useful extra coverage
 - Creates a **self-improvement patch** in `paths.patches` (default: `.ai-factory/patches/`)
 - User-facing fix summaries use `language.ui`; `FIX_PLAN.md` and patch artifacts use `language.artifacts` while preserving `[FIX]`, commands, paths, identifiers, raw errors, and patch tags according to `language.technical_terms`
 
@@ -201,7 +200,7 @@ Bug fix with optional plan-first mode:
 ```
 /aif-fix Something is broken    # Choose "Plan first" when asked
 ```
-- Investigates the codebase, creates `paths.fix_plan` with analysis, fix steps, risks
+- Investigates the codebase, creates `paths.fix_plan` with analysis, fix checklist, risks
 - Includes `Research Context` only when research content influenced the fix plan, records a committed source revision, and checks the live research file only for drift before executing the plan
 - Stops after creating the plan — you review it at your own pace
 - When ready, run without arguments to execute the plan:

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -191,6 +191,7 @@ Bug fix with optional plan-first mode:
 - Reads `.ai-factory/config.yaml` for `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.rules`, `paths.research`, `paths.fix_plan`, `paths.patches`, named `rules.<area>` entries, `language.ui`, `language.artifacts`, and `language.technical_terms`
 - Investigates codebase to find root cause
 - When a bug needs regression coverage, follows the Canonical Regression-First Policy before implementation: create or identify a regression check, handle no-regression-check or non-reproducible fallbacks, then preserve the same check for verification
+- The Canonical Regression-First Policy is defined in `skills/aif-fix/SKILL.md`
 - Applies fix WITH logging (`[FIX]` prefix for easy filtering)
 - Reruns the same regression check after the fix when available, then suggests any useful extra coverage
 - Creates a **self-improvement patch** in `paths.patches` (default: `.ai-factory/patches/`)

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -190,8 +190,9 @@ Bug fix with optional plan-first mode:
 - Asks to choose mode: **Fix now** (immediate) or **Plan first** (review before fixing)
 - Reads `.ai-factory/config.yaml` for `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.rules`, `paths.research`, `paths.fix_plan`, `paths.patches`, named `rules.<area>` entries, `language.ui`, `language.artifacts`, and `language.technical_terms`
 - Investigates codebase to find root cause
+- When a bug needs test/check coverage, creates or identifies a targeted regression test/check before implementation and confirms it reproduces the problem
 - Applies fix WITH logging (`[FIX]` prefix for easy filtering)
-- Suggests test coverage for the bug
+- Reruns the same regression test/check after the fix, then suggests any useful extra coverage
 - Creates a **self-improvement patch** in `paths.patches` (default: `.ai-factory/patches/`)
 - User-facing fix summaries use `language.ui`; `FIX_PLAN.md` and patch artifacts use `language.artifacts` while preserving `[FIX]`, commands, paths, identifiers, raw errors, and patch tags according to `language.technical_terms`
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -191,6 +191,7 @@ Bug fix with optional plan-first mode:
 - Reads `.ai-factory/config.yaml` for `paths.description`, `paths.architecture`, `paths.rules_file`, `paths.rules`, `paths.research`, `paths.fix_plan`, `paths.patches`, named `rules.<area>` entries, `language.ui`, `language.artifacts`, and `language.technical_terms`
 - Investigates codebase to find root cause
 - When a bug needs test/check coverage, creates or identifies a targeted regression test/check before implementation and confirms it reproduces the problem
+- If the pre-fix check passes unexpectedly, records the mismatch; Handoff mode continues only with a safe likely root cause, while manual mode asks whether to proceed or investigate further
 - Applies fix WITH logging (`[FIX]` prefix for easy filtering)
 - Reruns the same regression test/check after the fix, then suggests any useful extra coverage
 - Creates a **self-improvement patch** in `paths.patches` (default: `.ai-factory/patches/`)

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -335,6 +335,8 @@ Two modes — choose when you invoke:
 - **Fix now** — investigates, applies the Canonical Regression-First Policy when needed, fixes with logging, then reruns the same regression check when available
 - **Plan first** – creates `paths.fix_plan` with analysis and fix checklist, then stops for review
 
+The Canonical Regression-First Policy is defined in `skills/aif-fix/SKILL.md`.
+
 When a plan exists, run without arguments to execute:
 ```
 /aif-fix    # reads the configured fix plan → applies fix → deletes plan

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -332,7 +332,7 @@ Creates conventional commits from staged changes and runs read-only architecture
 ```
 
 Two modes — choose when you invoke:
-- **Fix now** — investigates, captures a failing regression test/check when needed, fixes with logging, then reruns the same check
+- **Fix now** — investigates, captures a failing regression test/check when needed, handles non-reproducible checks explicitly, fixes with logging, then reruns the same check
 - **Plan first** – creates `paths.fix_plan` with analysis and fix steps, then stops for review
 
 When a plan exists, run without arguments to execute:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -332,8 +332,8 @@ Creates conventional commits from staged changes and runs read-only architecture
 ```
 
 Two modes — choose when you invoke:
-- **Fix now** — investigates, captures a failing regression test/check when needed, handles non-reproducible checks explicitly, fixes with logging, then reruns the same check
-- **Plan first** – creates `paths.fix_plan` with analysis and fix steps, then stops for review
+- **Fix now** — investigates, applies the Canonical Regression-First Policy when needed, fixes with logging, then reruns the same regression check when available
+- **Plan first** – creates `paths.fix_plan` with analysis and fix checklist, then stops for review
 
 When a plan exists, run without arguments to execute:
 ```

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -332,7 +332,7 @@ Creates conventional commits from staged changes and runs read-only architecture
 ```
 
 Two modes — choose when you invoke:
-- **Fix now** — investigates and fixes immediately with logging
+- **Fix now** — investigates, captures a failing regression test/check when needed, fixes with logging, then reruns the same check
 - **Plan first** – creates `paths.fix_plan` with analysis and fix steps, then stops for review
 
 When a plan exists, run without arguments to execute:

--- a/skills/aif-fix/SKILL.md
+++ b/skills/aif-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aif-fix
-description: Fix a bug or problem. Supports fix-now or plan-first; no args executes FIX_PLAN.md. When tests/checks are needed, reproduce first with a failing regression check, then implement and rerun it. Adds logging and suggests extra coverage.
+description: Fix a bug or problem. Supports fix-now or plan-first; no args executes FIX_PLAN.md. When a regression check is needed, reproduce first, then implement and rerun it. Adds logging and suggests extra coverage.
 argument-hint: <bug description or error message>
 allowed-tools: Read Write Edit Glob Grep Bash AskUserQuestion Questions Task mcp__handoff__handoff_sync_status mcp__handoff__handoff_push_plan mcp__handoff__handoff_get_task mcp__handoff__handoff_list_tasks mcp__handoff__handoff_update_task
 disable-model-invocation: false
@@ -8,9 +8,29 @@ disable-model-invocation: false
 
 # Fix - Bug Fix Workflow
 
-Fix a specific bug or problem in the codebase. Supports two modes: immediate fix or plan-first approach. The default workflow is regression-first whenever a test or executable check is needed: reproduce the problem with a failing regression test/check, confirm the reported behavior, implement the fix, then verify the same test/check passes.
+Fix a specific bug or problem in the codebase. Supports two modes: immediate fix or plan-first approach. The default workflow is regression-first whenever a regression check is needed: reproduce the problem, confirm the reported behavior, implement the fix, then verify the same check passes.
 
 ## Workflow
+
+### Canonical Regression-First Policy
+
+A **regression check** is the smallest useful test, command, fixture, API call, browser scenario, script, or documented manual/runtime reproduction that proves the reported bug or validates the expected behavior.
+
+When a bug needs regression coverage, every workflow path (fix-now, plan-first, and existing-plan execution) follows this policy:
+
+1. Identify the minimal regression check that should reproduce the issue or encode the expected behavior.
+2. Execute the check before implementation and confirm it fails or reproduces the reported problem.
+3. Implement the smallest fix addressing the root cause.
+4. Re-run the exact same check and confirm it passes.
+5. Only after that, run related existing checks when practical and suggest broader coverage if useful.
+
+Fallback behavior:
+
+- If no automated/executable check is available, document the narrowest manual/runtime reproduction and why no executable check exists. Treat that documented reproduction as the regression check for Step 4 when it can be rerun.
+- If no useful regression check exists at all, record the reason before implementation. In `HANDOFF_MODE=1`, continue only when investigation found a plausible root cause that can be fixed safely; otherwise report the task as blocked/unreproducible and stop without changing implementation code. In manual mode, ask whether to proceed with the likely fix, adjust reproduction, or investigate further.
+- If the pre-fix regression check passes unexpectedly, treat it as a reproduction mismatch: record the command/check, inputs, environment assumptions, and observed result. Then use the same `HANDOFF_MODE=1` or manual-mode fallback above.
+
+Do not duplicate or weaken this policy in later workflow sections. Later steps should reference this section and add only local execution details.
 
 ### Step 0 (pre): Detect Handoff Mode
 
@@ -28,7 +48,7 @@ Bash: printenv HANDOFF_SKIP_REVIEW || true
 
 The Handoff coordinator already manages status transitions and DB writes directly. Do NOT call MCP tools. Instead:
 
-- **No interactive questions:** Do not use `AskUserQuestion`. If `$ARGUMENTS` contains `--plan-first`, use "Plan first" mode. Otherwise default to "Fix now" mode. When a test/check is needed for the bug, include a regression-first test/check and logging.
+- **No interactive questions:** Do not use `AskUserQuestion`. If `$ARGUMENTS` contains `--plan-first`, use "Plan first" mode. Otherwise default to "Fix now" mode. When a regression check is needed for the bug, include regression-first handling and logging.
 - **Plan annotation (MANDATORY):** If `HANDOFF_TASK_ID` is non-empty, you MUST insert `<!-- handoff:task:<HANDOFF_TASK_ID> -->` as the very first line of the fix plan file, before the title. **Omitting this annotation when HANDOFF_TASK_ID is set is a bug — verify before completing.** This applies to both Step 1.1 (creating new plan) and any plan rewrite.
 
 #### When `HANDOFF_MODE` is NOT `1` (manual Claude Code session)
@@ -75,7 +95,7 @@ All AskUserQuestion prompts, progress updates, fix summaries, test prompts, and 
 
 Generated `FIX_PLAN.md` and self-improvement patch files under `paths.patches` MUST be written in `artifact_language`.
 
-Templates and examples define structure, not fixed English output. If `artifact_language` is not `en`, translate human-readable headings, labels, analysis text, fix steps, risks, prevention notes, and patch prose before saving. Preserve Handoff annotations, markdown structure, checkbox syntax, paths, commands, config keys, code identifiers, package names, API names, raw error messages, code snippets, log prefixes such as `[FIX]`, and patch tags unchanged. Apply `technical_terms_policy` to other human-readable terminology.
+Templates and examples define structure, not fixed English output. If `artifact_language` is not `en`, translate human-readable headings, labels, analysis text, fix checklist entries, risks, prevention notes, and patch prose before saving. Preserve Handoff annotations, markdown structure, checkbox syntax, paths, commands, config keys, code identifiers, package names, API names, raw error messages, code snippets, log prefixes such as `[FIX]`, and patch tags unchanged. Apply `technical_terms_policy` to other human-readable terminology.
 
 ### Step 0.1: Check for Existing Fix Plan
 
@@ -92,8 +112,8 @@ Templates and examples define structure, not fixed English output. If `artifact_
 - Inform the user: "Found existing fix plan. Executing fix based on the plan."
 - Skip **Step 1** (problem intake/mode choice), but still run **Step 0.2** to load context
 - Then continue to **Step 2: Investigate the Codebase**, using the plan as your guide
-- Run **Step 2.5: Regression Test or Check** before changing implementation code when a test/check is needed for the bug, even if the existing plan did not include that step
-- Follow the plan sequentially, but preserve the default order: confirm the problem with the targeted regression test/check first, implement the fix, then rerun the same test/check
+- Apply the **Canonical Regression-First Policy** before changing implementation code when a regression check is needed for the bug, even if the existing plan did not include that policy
+- Follow the plan sequentially, but preserve the canonical order: confirm the problem first, implement the fix, then rerun the same regression check
 - After the fix is fully applied and verified in Step 4, **delete** the resolved fix plan file:
   ```bash
   rm <resolved fix plan path>
@@ -227,10 +247,10 @@ What was found during investigation:
 
 Checklist entries for implementing the fix:
 
-1. [ ] Add or identify the targeted regression test/check that should fail before the fix, if a test/check is needed
-2. [ ] Run the targeted regression test/check and confirm it reproduces the reported problem
+1. [ ] Apply the Canonical Regression-First Policy: add or identify the minimal regression check, or record why no useful check exists
+2. [ ] Run the regression check and confirm it reproduces the reported problem, or record the fallback outcome from the policy
 3. [ ] Implement the smallest fix for the root cause
-4. [ ] Rerun the same regression test/check and confirm it passes
+4. [ ] Rerun the same regression check and confirm it passes when a rerunnable check exists
 5. [ ] Run the closest related existing checks when practical
 
 ## Files to Modify
@@ -246,9 +266,9 @@ Checklist entries for implementing the fix:
 
 ## Test Coverage
 
-- Targeted regression test/check to confirm the bug before implementation
+- Minimal regression check to confirm the bug before implementation
 - Command/check to run before and after the fix
-- Additional edge cases worth covering after the targeted regression passes
+- Additional edge cases worth covering after the regression check passes
 
 ## Research Context (optional)
 
@@ -315,28 +335,13 @@ Task(subagent_type: Explore, model: sonnet, prompt:
 - Trace the data flow
 - Check for similar patterns elsewhere
 
-### Step 2.5: Capture a Regression Test or Check
+### Step 2.5: Capture a Regression Check
 
-This is the default workflow when a test or executable check is needed to validate the bug. If the change is a non-bug cleanup, purely static correction, investigation-only request, or there is no useful automated/runtime check available, state why and continue with the normal fix workflow.
-
-**Before changing implementation code:**
-
-1. Decide whether this bug needs a targeted regression test/check to prove the fix. Prefer adding one for behavior bugs, parsing/validation bugs, API/data bugs, crashes, and regressions.
-2. Identify the smallest test or executable check that reproduces the reported problem.
-3. Prefer the project's existing test framework and test location conventions.
-4. Add or update a regression test that encodes the expected behavior from the user's report, not the current implementation.
-5. If no test harness exists or the bug needs runtime/manual reproduction, create or document the narrowest reproducible check available: a script, command, fixture, API call, browser scenario, or manual reproduction command.
-6. Run only the targeted regression test/check first and confirm it fails for the reported reason. This confirms the problem before implementation.
-7. If the targeted regression test/check passes unexpectedly before any fix, treat it as a reproduction mismatch: log the exact command/check, inputs, environment assumptions, and observed result.
+Apply the **Canonical Regression-First Policy** before changing implementation code. Prefer a regression check for behavior bugs, parsing/validation bugs, API/data bugs, crashes, and regressions. If the change is a non-bug cleanup, purely static correction, or investigation-only request, record why the policy does not apply and continue with the normal fix workflow.
 
 **Anti-gaming rule:** Do not tailor the test to the implementation you plan to write. The test must describe the externally expected behavior or the reported failure condition. If the test passes before any fix, either the reproduction is wrong, the bug is stale, or the environment differs; investigate and report that before changing implementation code.
 
-**If the bug does not reproduce before the fix:**
-
-- In `HANDOFF_MODE=1`, do not ask the user. Add a note to the fix plan or working notes that the regression check did not reproduce the reported bug, then continue to Step 3 only when investigation found a plausible root cause that can be fixed safely. If no plausible root cause remains, report the mismatch as blocked/unreproducible and stop without changing implementation code.
-- In manual mode, ask the user whether to proceed with the likely fix, adjust the reproduction, or investigate further before changing implementation code.
-
-Record the targeted command/check and the pre-fix result in your working notes so Step 4 can rerun the same check after the fix.
+Record the selected regression check, pre-fix result, and any fallback decision in your working notes so Step 4 can rerun or revisit the same check after the fix.
 
 ### Step 3: Implement the Fix
 
@@ -371,10 +376,10 @@ try {
 ### Step 4: Verify the Fix
 
 - Check the code compiles/runs
-- If Step 2.5 created or identified a targeted regression test/check, rerun the same test/check and confirm it now passes
+- If Step 2.5 created, identified, or documented a regression check, rerun or revisit the same check and confirm the fixed behavior
 - Verify the logic is correct
 - Ensure no regressions introduced
-- When practical, run the closest existing related test suite after the targeted regression passes
+- When practical, run the closest existing related test suite after the regression check passes
 
 ### Step 5: Suggest Additional Test Coverage
 
@@ -399,7 +404,7 @@ Please test and share any logs if issues persist.
 
 ### Recommended: Add More Test Coverage
 
-If the targeted regression test/check was created in Step 2.5, this bug is now covered. Consider adding broader coverage to prevent nearby regressions:
+If a regression check was created or identified in Step 2.5, this bug is now covered. Consider adding broader coverage to prevent nearby regressions:
 
 \`\`\`typescript
 describe('functionName', () => {
@@ -468,9 +473,9 @@ function fixedFunction(input) {
 
 1. Search for UserProfile component/function
 2. Find where `.name` is accessed
-3. Add a targeted regression test/check for the null user case and confirm it fails
+3. Add a regression check for the null user case and confirm it fails
 4. Add null check with logging
-5. Rerun the same regression test/check and confirm it passes
+5. Rerun the same regression check and confirm it passes
 
 ### Example 2: API Returns Wrong Data
 
@@ -481,9 +486,9 @@ function fixedFunction(input) {
 1. Find orders API endpoint
 2. Trace the query logic
 3. Find the bug (e.g., wrong filter)
-4. Add or identify an integration regression test/check for the authenticated user case and confirm it fails
+4. Add or identify an integration regression check for the authenticated user case and confirm it fails
 5. Fix with logging
-6. Rerun the same regression test/check and confirm it passes
+6. Rerun the same regression check and confirm it passes
 
 ### Example 3: Form Validation Not Working
 
@@ -505,9 +510,9 @@ function fixedFunction(input) {
 3. **Execute mode = follow the plan** - When the resolved fix plan exists, follow it step by step, then delete it
 4. **NO reports** - Don't create summary documents (patches are learning artifacts, not reports)
 5. **ALWAYS log** - Every fix must have logging for feedback
-6. **Regression-first when tests are needed** - When a bug needs test/check coverage, write or identify the failing regression test/check before changing implementation code, confirm the problem, then verify the same test/check passes after the fix
+6. **Regression-first when checks are needed** - When a bug needs regression coverage, follow the Canonical Regression-First Policy before changing implementation code, confirm the problem when reproducible, then verify the same regression check after the fix
 7. **Do not fit tests to implementation** - Regression tests encode the reported/expected behavior, not the internal implementation shape
-8. **ALWAYS suggest additional tests** - Help prevent nearby regressions beyond the required targeted regression check
+8. **ALWAYS suggest additional tests** - Help prevent nearby regressions beyond the required regression check
 9. **Root cause** - Fix the actual problem, not symptoms
 10. **Minimal changes** - Don't refactor unrelated code
 11. **One fix at a time** - Don't scope creep
@@ -525,7 +530,7 @@ function fixedFunction(input) {
 **Issue:** [what was broken]
 **Cause:** [why it was broken]
 **Fix:** [what was changed]
-**Regression check:** [targeted test/check command and result]
+**Regression check:** [command/check and result]
 
 **Files modified:**
 - path/to/file.ts (line X)

--- a/skills/aif-fix/SKILL.md
+++ b/skills/aif-fix/SKILL.md
@@ -339,7 +339,7 @@ Task(subagent_type: Explore, model: sonnet, prompt:
 
 Apply the **Canonical Regression-First Policy** before changing implementation code. Prefer a regression check for behavior bugs, parsing/validation bugs, API/data bugs, crashes, and regressions. If the change is a non-bug cleanup, purely static correction, or investigation-only request, record why the policy does not apply and continue with the normal fix workflow.
 
-**Anti-gaming rule:** Do not tailor the test to the implementation you plan to write. The test must describe the externally expected behavior or the reported failure condition. If the test passes before any fix, either the reproduction is wrong, the bug is stale, or the environment differs; investigate and report that before changing implementation code.
+**Anti-gaming rule:** Do not tailor the test to the implementation you plan to write. The test must describe the externally expected behavior or the reported failure condition. If the test passes before any fix, either the reproduction is wrong, the bug is stale, or the environment differs; handle that mismatch through the fallback behavior in the Canonical Regression-First Policy before changing implementation code.
 
 Record the selected regression check, pre-fix result, and any fallback decision in your working notes so Step 4 can rerun or revisit the same check after the fix.
 
@@ -530,7 +530,7 @@ function fixedFunction(input) {
 **Issue:** [what was broken]
 **Cause:** [why it was broken]
 **Fix:** [what was changed]
-**Regression check:** [command/check and result]
+**Regression check:** [command/check and result, manual/runtime reproduction result, or "not available: <reason>"]
 
 **Files modified:**
 - path/to/file.ts (line X)

--- a/skills/aif-fix/SKILL.md
+++ b/skills/aif-fix/SKILL.md
@@ -223,9 +223,9 @@ What was found during investigation:
 - Affected files and functions
 - Impact scope
 
-## Fix Steps
+## Fix Checklist
 
-Step-by-step plan for implementing the fix:
+Checklist entries for implementing the fix:
 
 1. [ ] Add or identify the targeted regression test/check that should fail before the fix, if a test/check is needed
 2. [ ] Run the targeted regression test/check and confirm it reproduces the reported problem
@@ -327,8 +327,14 @@ This is the default workflow when a test or executable check is needed to valida
 4. Add or update a regression test that encodes the expected behavior from the user's report, not the current implementation.
 5. If no test harness exists or the bug needs runtime/manual reproduction, create or document the narrowest reproducible check available: a script, command, fixture, API call, browser scenario, or manual reproduction command.
 6. Run only the targeted regression test/check first and confirm it fails for the reported reason. This confirms the problem before implementation.
+7. If the targeted regression test/check passes unexpectedly before any fix, treat it as a reproduction mismatch: log the exact command/check, inputs, environment assumptions, and observed result.
 
 **Anti-gaming rule:** Do not tailor the test to the implementation you plan to write. The test must describe the externally expected behavior or the reported failure condition. If the test passes before any fix, either the reproduction is wrong, the bug is stale, or the environment differs; investigate and report that before changing implementation code.
+
+**If the bug does not reproduce before the fix:**
+
+- In `HANDOFF_MODE=1`, do not ask the user. Add a note to the fix plan or working notes that the regression check did not reproduce the reported bug, then continue to Step 3 only when investigation found a plausible root cause that can be fixed safely. If no plausible root cause remains, report the mismatch as blocked/unreproducible and stop without changing implementation code.
+- In manual mode, ask the user whether to proceed with the likely fix, adjust the reproduction, or investigate further before changing implementation code.
 
 Record the targeted command/check and the pre-fix result in your working notes so Step 4 can rerun the same check after the fix.
 

--- a/skills/aif-fix/SKILL.md
+++ b/skills/aif-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aif-fix
-description: Fix a specific bug or problem in the codebase. Supports two modes - immediate fix or plan-first. Without arguments executes existing FIX_PLAN.md. Always suggests test coverage and adds logging. Use when user says "fix bug", "debug this", "something is broken", or pastes an error message.
+description: Fix a bug or problem. Supports fix-now or plan-first; no args executes FIX_PLAN.md. When tests/checks are needed, reproduce first with a failing regression check, then implement and rerun it. Adds logging and suggests extra coverage.
 argument-hint: <bug description or error message>
 allowed-tools: Read Write Edit Glob Grep Bash AskUserQuestion Questions Task mcp__handoff__handoff_sync_status mcp__handoff__handoff_push_plan mcp__handoff__handoff_get_task mcp__handoff__handoff_list_tasks mcp__handoff__handoff_update_task
 disable-model-invocation: false
@@ -8,7 +8,7 @@ disable-model-invocation: false
 
 # Fix - Bug Fix Workflow
 
-Fix a specific bug or problem in the codebase. Supports two modes: immediate fix or plan-first approach.
+Fix a specific bug or problem in the codebase. Supports two modes: immediate fix or plan-first approach. The default workflow is regression-first whenever a test or executable check is needed: reproduce the problem with a failing regression test/check, confirm the reported behavior, implement the fix, then verify the same test/check passes.
 
 ## Workflow
 
@@ -28,7 +28,7 @@ Bash: printenv HANDOFF_SKIP_REVIEW || true
 
 The Handoff coordinator already manages status transitions and DB writes directly. Do NOT call MCP tools. Instead:
 
-- **No interactive questions:** Do not use `AskUserQuestion`. If `$ARGUMENTS` contains `--plan-first`, use "Plan first" mode. Otherwise default to "Fix now" mode. Always include tests and logging.
+- **No interactive questions:** Do not use `AskUserQuestion`. If `$ARGUMENTS` contains `--plan-first`, use "Plan first" mode. Otherwise default to "Fix now" mode. When a test/check is needed for the bug, include a regression-first test/check and logging.
 - **Plan annotation (MANDATORY):** If `HANDOFF_TASK_ID` is non-empty, you MUST insert `<!-- handoff:task:<HANDOFF_TASK_ID> -->` as the very first line of the fix plan file, before the title. **Omitting this annotation when HANDOFF_TASK_ID is set is a bug — verify before completing.** This applies to both Step 1.1 (creating new plan) and any plan rewrite.
 
 #### When `HANDOFF_MODE` is NOT `1` (manual Claude Code session)
@@ -92,12 +92,13 @@ Templates and examples define structure, not fixed English output. If `artifact_
 - Inform the user: "Found existing fix plan. Executing fix based on the plan."
 - Skip **Step 1** (problem intake/mode choice), but still run **Step 0.2** to load context
 - Then continue to **Step 2: Investigate the Codebase**, using the plan as your guide
-- Follow each step of the plan sequentially
-- After the fix is fully applied and verified, **delete** the resolved fix plan file:
+- Run **Step 2.5: Regression Test or Check** before changing implementation code when a test/check is needed for the bug, even if the existing plan did not include that step
+- Follow the plan sequentially, but preserve the default order: confirm the problem with the targeted regression test/check first, implement the fix, then rerun the same test/check
+- After the fix is fully applied and verified in Step 4, **delete** the resolved fix plan file:
   ```bash
   rm <resolved fix plan path>
   ```
-- Continue to Step 4 (Verify), Step 5 (Test suggestion), Step 6 (Patch)
+- Continue to Step 5 (Additional Test Coverage) and Step 6 (Patch)
 
 **If the file DOES NOT exist AND `$ARGUMENTS` is empty:**
 
@@ -226,9 +227,11 @@ What was found during investigation:
 
 Step-by-step plan for implementing the fix:
 
-1. [ ] Step one — what to change and why
-2. [ ] Step two — ...
-3. [ ] Step three — ...
+1. [ ] Add or identify the targeted regression test/check that should fail before the fix, if a test/check is needed
+2. [ ] Run the targeted regression test/check and confirm it reproduces the reported problem
+3. [ ] Implement the smallest fix for the root cause
+4. [ ] Rerun the same regression test/check and confirm it passes
+5. [ ] Run the closest related existing checks when practical
 
 ## Files to Modify
 
@@ -243,8 +246,9 @@ Step-by-step plan for implementing the fix:
 
 ## Test Coverage
 
-- What tests should be added
-- What edge cases to cover
+- Targeted regression test/check to confirm the bug before implementation
+- Command/check to run before and after the fix
+- Additional edge cases worth covering after the targeted regression passes
 
 ## Research Context (optional)
 
@@ -311,6 +315,23 @@ Task(subagent_type: Explore, model: sonnet, prompt:
 - Trace the data flow
 - Check for similar patterns elsewhere
 
+### Step 2.5: Capture a Regression Test or Check
+
+This is the default workflow when a test or executable check is needed to validate the bug. If the change is a non-bug cleanup, purely static correction, investigation-only request, or there is no useful automated/runtime check available, state why and continue with the normal fix workflow.
+
+**Before changing implementation code:**
+
+1. Decide whether this bug needs a targeted regression test/check to prove the fix. Prefer adding one for behavior bugs, parsing/validation bugs, API/data bugs, crashes, and regressions.
+2. Identify the smallest test or executable check that reproduces the reported problem.
+3. Prefer the project's existing test framework and test location conventions.
+4. Add or update a regression test that encodes the expected behavior from the user's report, not the current implementation.
+5. If no test harness exists or the bug needs runtime/manual reproduction, create or document the narrowest reproducible check available: a script, command, fixture, API call, browser scenario, or manual reproduction command.
+6. Run only the targeted regression test/check first and confirm it fails for the reported reason. This confirms the problem before implementation.
+
+**Anti-gaming rule:** Do not tailor the test to the implementation you plan to write. The test must describe the externally expected behavior or the reported failure condition. If the test passes before any fix, either the reproduction is wrong, the bug is stale, or the environment differs; investigate and report that before changing implementation code.
+
+Record the targeted command/check and the pre-fix result in your working notes so Step 4 can rerun the same check after the fix.
+
 ### Step 3: Implement the Fix
 
 **Apply the fix with logging:**
@@ -344,17 +365,19 @@ try {
 ### Step 4: Verify the Fix
 
 - Check the code compiles/runs
+- If Step 2.5 created or identified a targeted regression test/check, rerun the same test/check and confirm it now passes
 - Verify the logic is correct
 - Ensure no regressions introduced
+- When practical, run the closest existing related test suite after the targeted regression passes
 
-### Step 5: Suggest Test Coverage
+### Step 5: Suggest Additional Test Coverage
 
 **Handoff sync (manual mode ONLY — skip entirely when `HANDOFF_MODE` is `1`):** If a Handoff task ID is known AND `HANDOFF_MODE` is NOT `1`:
 1. Call `handoff_push_plan` with `{ taskId: <id>, planContent: <fix summary or updated plan> }`.
 2. If `HANDOFF_SKIP_REVIEW` is `1`: call `handoff_sync_status` with `{ taskId: <id>, newStatus: "done", sourceTimestamp: "<current UTC time in ISO 8601 format>", direction: "aif_to_handoff", paused: false }`.
 3. Otherwise: call `handoff_sync_status` with `{ taskId: <id>, newStatus: "review", sourceTimestamp: "<current UTC time in ISO 8601 format>", direction: "aif_to_handoff", paused: true }`.
 
-**ALWAYS suggest covering this case with a test:**
+**ALWAYS suggest additional test coverage:**
 
 The Step 5 and After Fixing output templates define structure only. Render all human-readable text in these user-facing responses in `ui_language`. Preserve code snippets, commands, file paths, line references, log prefixes such as `[FIX]`, and AskUserQuestion option structure unchanged.
 
@@ -368,9 +391,9 @@ Fixed by: [what was changed]
 The fix includes logging with prefix `[FIX]`.
 Please test and share any logs if issues persist.
 
-### Recommended: Add a Test
+### Recommended: Add More Test Coverage
 
-This bug should be covered by a test to prevent regression:
+If the targeted regression test/check was created in Step 2.5, this bug is now covered. Consider adding broader coverage to prevent nearby regressions:
 
 \`\`\`typescript
 describe('functionName', () => {
@@ -387,7 +410,7 @@ describe('functionName', () => {
 });
 \`\`\`
 
-AskUserQuestion: Would you like me to create this test?
+AskUserQuestion: Would you like me to create the additional test coverage?
 
 Options:
 1. Yes, create the test
@@ -398,7 +421,7 @@ Options:
 
 - **If "Yes, create the test":**
   1. Create the test file in the appropriate test directory (follow project conventions)
-  2. Include the suggested test case and any additional edge cases related to the fix
+  2. Include the suggested additional test case and related edge cases
   3. Run the test to verify it passes
   4. Then proceed to **Step 6: Create Self-Improvement Patch**
 
@@ -439,8 +462,9 @@ function fixedFunction(input) {
 
 1. Search for UserProfile component/function
 2. Find where `.name` is accessed
-3. Add null check with logging
-4. Suggest test for null user case
+3. Add a targeted regression test/check for the null user case and confirm it fails
+4. Add null check with logging
+5. Rerun the same regression test/check and confirm it passes
 
 ### Example 2: API Returns Wrong Data
 
@@ -451,8 +475,9 @@ function fixedFunction(input) {
 1. Find orders API endpoint
 2. Trace the query logic
 3. Find the bug (e.g., wrong filter)
-4. Fix with logging
-5. Suggest integration test
+4. Add or identify an integration regression test/check for the authenticated user case and confirm it fails
+5. Fix with logging
+6. Rerun the same regression test/check and confirm it passes
 
 ### Example 3: Form Validation Not Working
 
@@ -462,9 +487,10 @@ function fixedFunction(input) {
 
 1. Find email validation logic
 2. Check regex or validation library usage
-3. Fix the validation
-4. Add logging for validation failures
-5. Suggest unit test with edge cases
+3. Add a unit regression test for the invalid email case and confirm it fails
+4. Fix the validation
+5. Add logging for validation failures
+6. Rerun the same regression test and confirm it passes
 
 ## Important Rules
 
@@ -473,17 +499,19 @@ function fixedFunction(input) {
 3. **Execute mode = follow the plan** - When the resolved fix plan exists, follow it step by step, then delete it
 4. **NO reports** - Don't create summary documents (patches are learning artifacts, not reports)
 5. **ALWAYS log** - Every fix must have logging for feedback
-6. **ALWAYS suggest tests** - Help prevent regressions
-7. **Root cause** - Fix the actual problem, not symptoms
-8. **Minimal changes** - Don't refactor unrelated code
-9. **One fix at a time** - Don't scope creep
-10. **Clean up** - Delete the resolved fix plan file after successful fix execution
-11. **Ownership boundary** - `/aif-fix` owns `paths.fix_plan` and `paths.patches`; treat `.ai-factory/DESCRIPTION.md`, roadmap, rules, and architecture context artifacts as read-only unless the user explicitly requests otherwise
-12. **Logging scope** - Keep `[FIX]` logging requirements for fixes; context-gate outputs in this command should use `WARN`/`ERROR` and must not change global logging policy in other skills
+6. **Regression-first when tests are needed** - When a bug needs test/check coverage, write or identify the failing regression test/check before changing implementation code, confirm the problem, then verify the same test/check passes after the fix
+7. **Do not fit tests to implementation** - Regression tests encode the reported/expected behavior, not the internal implementation shape
+8. **ALWAYS suggest additional tests** - Help prevent nearby regressions beyond the required targeted regression check
+9. **Root cause** - Fix the actual problem, not symptoms
+10. **Minimal changes** - Don't refactor unrelated code
+11. **One fix at a time** - Don't scope creep
+12. **Clean up** - Delete the resolved fix plan file after successful fix execution
+13. **Ownership boundary** - `/aif-fix` owns `paths.fix_plan` and `paths.patches`; treat `.ai-factory/DESCRIPTION.md`, roadmap, rules, and architecture context artifacts as read-only unless the user explicitly requests otherwise
+14. **Logging scope** - Keep `[FIX]` logging requirements for fixes; context-gate outputs in this command should use `WARN`/`ERROR` and must not change global logging policy in other skills
 
 ## After Fixing
 
-**Use this output template in Step 5** (before the AskUserQuestion about tests):
+**Use this output template in Step 5** (before the AskUserQuestion about additional tests):
 
 ```
 ## Fix Applied ✅
@@ -491,6 +519,7 @@ function fixedFunction(input) {
 **Issue:** [what was broken]
 **Cause:** [why it was broken]
 **Fix:** [what was changed]
+**Regression check:** [targeted test/check command and result]
 
 **Files modified:**
 - path/to/file.ts (line X)


### PR DESCRIPTION
## Summary
- Update /aif-fix to use a regression-first workflow when a bug needs test or executable check coverage
- Require confirming the failing regression check before implementation, then rerunning the same check after the fix
- Sync AGENTS.md and user-facing docs with the updated workflow

## Verification
- npm test