### PR TITLE
feat(agents): add zcode agent support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@
 1. **CLI tool** (`ai-factory init/update/upgrade`) — installs skills and configures MCP
 2. **Built-in skills** (29 skills, all `aif-*` prefixed) — workflow commands for spec-driven development
 3. **Spec-driven workflow** — structured approach: plan → implement → commit
-4. **Multi-agent support** — 16 agents (Claude Code, Cursor, Windsurf, Roo Code, Kilo Code, Antigravity, OpenCode, Warp,
-   Zencoder, Codex CLI, Codex app, GitHub Copilot, Gemini CLI, Junie, Qwen Code, Universal)
+4. **Multi-agent support** — 17 agents (Claude Code, Cursor, Windsurf, Roo Code, Kilo Code, Antigravity, OpenCode, Warp,
+   Zencoder, ZCode, Codex CLI, Codex app, GitHub Copilot, Gemini CLI, Junie, Qwen Code, Universal)
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ai-factory init
 - **Spec-driven development** — AI follows plans, not random exploration. Predictable, resumable, reviewable
 - **Community skills** — leverage [skills.sh](https://skills.sh) ecosystem or generate custom skills
 - **Stack-agnostic** — works with any language, framework, or platform
-- **Multi-agent support** — Claude Code, Cursor, Windsurf, Roo Code, Kilo Code, Antigravity, OpenCode, Warp, Zencoder, Codex CLI, Codex app, GitHub Copilot, Gemini CLI, Junie, Qwen Code, or [any agent](docs/getting-started.md#supported-agents)
+- **Multi-agent support** — Claude Code, Cursor, Windsurf, Roo Code, Kilo Code, Antigravity, OpenCode, Warp, Zencoder, ZCode, Codex CLI, Codex app, GitHub Copilot, Gemini CLI, Junie, Qwen Code, or [any agent](docs/getting-started.md#supported-agents)
 
 ---
 
@@ -154,6 +154,7 @@ npx skills add lee-to/ai-factory --skill '*'
 - [Claude Code](https://claude.ai/code) - Anthropic's AI coding agent
 - [Cursor](https://cursor.com) - AI-powered code editor
 - [OpenCode](https://opencode.ai) - Open-source AI coding agent
+- [ZCode](https://zcode.ai) - AI coding agent
 - [Roo Code](https://roocode.com) - AI coding agent for VS Code
 - [Kilo Code](https://kilo.ai) - Open-source agentic coding platform
 - [Windsurf](https://windsurf.com) - AI-powered code editor by Codeium

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -250,7 +250,7 @@ AI Factory can configure these MCP servers:
 | Chrome Devtools | Browser inspection, debugging, performance | - |
 | Playwright | Browser automation, web testing | - |
 
-Configuration saved to agent's settings file (e.g. `.mcp.json` for Claude Code and Universal / Other, `.cursor/mcp.json` for Cursor, `.vscode/mcp.json` for GitHub Copilot, `.roo/mcp.json` for Roo Code, `.kilocode/mcp.json` for Kilo Code, `opencode.json` for OpenCode, `.codex/config.toml` for Codex app).
+Configuration saved to agent's settings file (e.g. `.mcp.json` for Claude Code and Universal / Other, `.cursor/mcp.json` for Cursor, `.vscode/mcp.json` for GitHub Copilot, `.roo/mcp.json` for Roo Code, `.kilocode/mcp.json` for Kilo Code, `opencode.json` for OpenCode, `.zcode/config.json` for ZCode, `.codex/config.toml` for Codex app).
 
 ### Runtime Format Contract
 
@@ -260,6 +260,7 @@ Source of truth for runtime MCP shapes and wrapper examples:
 Quick key mapping:
 - Standard MCP runtimes use `mcpServers.<server>`
 - OpenCode uses `mcp.<server>`
+- ZCode uses `mcp.servers.<server>` in `.zcode/config.json`
 - GitHub Copilot uses `servers.<server>`
 - Codex app uses TOML tables under `mcp_servers.<server>`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,6 +24,7 @@ AI Factory works with any AI coding agent. During `ai-factory init`, you choose 
 | Kilo Code | `.kilocode/` | `.kilocode/skills/`, `.kilocode/workflows/` |
 | Antigravity | `.agent/` | `.agent/skills/`, `.agent/workflows/` |
 | OpenCode | `.opencode/` | `.opencode/skills/` |
+| ZCode | `.zcode/` | `.zcode/skills/`, `.zcode/commands/` |
 | Warp | `.warp/` | `.warp/skills/` |
 | Zencoder | `.zencoder/` | `.zencoder/skills/` |
 | Codex CLI | `.codex/` | `.codex/skills/` |
@@ -38,7 +39,7 @@ When Claude Code is selected, AI Factory installs bundled Claude agent files int
 
 Codex CLI and Codex app receive Codex-style skill content and use `$aif-*` invocations. Slash-command runtimes keep `/aif-*` examples. Because Codex app and Universal both write to `.agents/skills/` with different invocation styles, select one of those runtimes per project.
 
-MCP server configuration is supported for Claude Code, Cursor, GitHub Copilot, Roo Code, Kilo Code, OpenCode, Qwen Code, Codex app, and Universal / Other. Universal writes standard MCP settings to `.mcp.json`. Other agents get skills installed with correct paths but without MCP auto-configuration.
+MCP server configuration is supported for Claude Code, Cursor, GitHub Copilot, Roo Code, Kilo Code, OpenCode, ZCode, Qwen Code, Codex app, and Universal / Other. Universal writes standard MCP settings to `.mcp.json`, ZCode writes to `.zcode/config.json` under `mcp.servers`. Other agents get skills installed with correct paths but without MCP auto-configuration.
 
 ## Your First Project
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-factory",
-  "version": "2.11.0",
+  "version": "2.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-factory",
-      "version": "2.11.0",
+      "version": "2.18.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "codex",
     "codex-app",
     "opencode",
+    "zcode",
     "kilocode",
     "windsurf",
     "warp",

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -529,6 +529,7 @@ AI Factory writes MCP config to `{{settings_file}}`, but the outer settings shap
 |---------|-------------|-------------|
 | Standard MCP runtimes (Claude Code, Cursor, Roo Code, Kilo Code, Qwen Code, Universal / Other) | `mcpServers.<server>` | `{ "command": "...", "args": [...], "env": {...} }` |
 | OpenCode | `mcp.<server>` | `{ "type": "local", "command": ["...", "..."], "environment": {...} }` |
+| ZCode | `mcp.servers.<server>` in `.zcode/config.json` | `{ "type": "stdio", "command": "...", "args": [...], "env": {...} }` |
 | GitHub Copilot | `servers.<server>` | `{ "type": "stdio", "command": "...", "args": [...], "env": {...} }` |
 | Codex app | `[mcp_servers.<server>]` in `.codex/config.toml` | `command = "..."`, optional `args = [...]`, credential placeholders as `env_vars = ["VAR"]`, literal values under `[mcp_servers.<server>.env]` |
 
@@ -623,6 +624,22 @@ GitHub Copilot (`servers` + `type: "stdio"`):
       "type": "stdio",
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    }
+  }
+}
+```
+
+ZCode (`.zcode/config.json`, `mcp.servers` + `type: "stdio"`):
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "filesystem": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+      }
     }
   }
 }

--- a/src/core/agents.ts
+++ b/src/core/agents.ts
@@ -200,6 +200,16 @@ const BUILTIN_AGENT_REGISTRY: Record<string, AgentConfig> = {
     skillsCliAgent: 'opencode',
     source: 'builtin',
   },
+  zcode: {
+    id: 'zcode',
+    displayName: 'ZCode',
+    configDir: '.zcode',
+    skillsDir: '.zcode/skills',
+    settingsFile: '.zcode/config.json',
+    supportsMcp: true,
+    skillsCliAgent: null,
+    source: 'builtin',
+  },
   universal: {
     id: 'universal',
     displayName: 'Universal / Other',

--- a/src/core/mcp.ts
+++ b/src/core/mcp.ts
@@ -59,7 +59,7 @@ export interface McpOptions {
   playwright: boolean;
 }
 
-type McpSettingsFormat = 'standard' | 'opencode' | 'vscode' | 'codex-toml';
+type McpSettingsFormat = 'standard' | 'opencode' | 'vscode' | 'zcode' | 'codex-toml';
 
 interface McpServerDefinition {
   key: keyof McpOptions;
@@ -158,6 +158,9 @@ function resolveMcpSettingsFormat(agentId: string): McpSettingsFormat {
   if (agentId === 'opencode') {
     return 'opencode';
   }
+  if (agentId === 'zcode') {
+    return 'zcode';
+  }
   if (agentId === 'copilot') {
     return 'vscode';
   }
@@ -169,6 +172,9 @@ function getContainerKey(format: McpSettingsFormat): 'mcp' | 'mcpServers' | 'ser
     throw new Error('Codex TOML MCP settings do not use a JSON container key');
   }
   if (format === 'opencode') {
+    return 'mcp';
+  }
+  if (format === 'zcode') {
     return 'mcp';
   }
   if (format === 'vscode') {
@@ -189,6 +195,12 @@ function applyServerConfig(
 
   if (format === 'opencode') {
     ensureNestedRecord(settings, 'mcp')[key] = toOpenCodeFormat(template);
+    return;
+  }
+
+  if (format === 'zcode') {
+    const servers = ensureNestedRecord(ensureNestedRecord(settings, 'mcp'), 'servers');
+    servers[key] = { type: 'stdio', ...template };
     return;
   }
 
@@ -336,8 +348,14 @@ export async function removeExtensionMcpServers(
   }
 
   const settings = await loadSettings(settingsPath);
-  const containerKey = getContainerKey(format);
-  const container = settings[containerKey];
+
+  let container: Record<string, unknown> | undefined;
+  if (format === 'zcode') {
+    const mcp = settings.mcp;
+    container = isRecord(mcp) ? mcp.servers as Record<string, unknown> | undefined : undefined;
+  } else {
+    container = settings[getContainerKey(format)] as Record<string, unknown> | undefined;
+  }
 
   if (!isRecord(container)) return;
 

--- a/src/core/transformer.ts
+++ b/src/core/transformer.ts
@@ -3,6 +3,7 @@ import { KiloCodeTransformer } from './transformers/kilocode.js';
 import { AntigravityTransformer } from './transformers/antigravity.js';
 import { CodexTransformer } from './transformers/codex.js';
 import { QwenTransformer } from './transformers/qwen.js';
+import { ZCodeTransformer } from './transformers/zcode.js';
 
 export interface TransformResult {
   targetDir: string;
@@ -110,6 +111,10 @@ const registry: Record<string, TransformerRegistration> = {
   antigravity: {
     create: () => new AntigravityTransformer(),
     identity: 'antigravity',
+  },
+  zcode: {
+    create: () => new ZCodeTransformer(),
+    identity: 'zcode',
   },
 };
 

--- a/src/core/transformers/zcode.ts
+++ b/src/core/transformers/zcode.ts
@@ -1,0 +1,98 @@
+import path from 'path';
+import { DefaultTransformer } from './default.js';
+import { extractFrontmatterName } from '../transformer.js';
+import { ensureDir, listDirectories, listFilesRecursive, readTextFile, writeTextFile, removeFile, fileExists } from '../../utils/fs.js';
+
+const COMMAND_MARKER = '<!-- aif:zcode-command -->';
+
+function extractFrontmatterDescription(content: string): string | null {
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) return null;
+  const descMatch = fmMatch[1].match(/^description:\s*(.+)$/m);
+  return descMatch ? descMatch[1].trim() : null;
+}
+
+function buildCommandStub(skillName: string, description: string | null): string {
+  const desc = description ?? `AI Factory ${skillName} skill`;
+  return [
+    '---',
+    `description: ${desc}`,
+    `skills: ${skillName}`,
+    'argument-hint: [arguments]',
+    '---',
+    COMMAND_MARKER,
+    '',
+    `Execute the "${skillName}" skill (loaded via the skills frontmatter above) with these arguments: $ARGUMENTS`,
+    '',
+  ].join('\n');
+}
+
+export class ZCodeTransformer extends DefaultTransformer {
+  async postInstall(projectDir: string): Promise<void> {
+    const skillsDir = path.join(projectDir, '.zcode', 'skills');
+    const commandsDir = path.join(projectDir, '.zcode', 'commands');
+
+    if (!(await fileExists(skillsDir))) {
+      return;
+    }
+
+    await ensureDir(commandsDir);
+    const installedSkills = await listDirectories(skillsDir);
+
+    for (const skillName of installedSkills) {
+      const skillMd = await readTextFile(path.join(skillsDir, skillName, 'SKILL.md'));
+      if (!skillMd) {
+        continue;
+      }
+
+      // ZCode command files must be named after the command; the skill name
+      // in frontmatter may differ from the directory after sanitization.
+      const frontmatterName = extractFrontmatterName(skillMd) ?? skillName;
+      const description = extractFrontmatterDescription(skillMd);
+      await writeTextFile(
+        path.join(commandsDir, `${skillName}.md`),
+        buildCommandStub(frontmatterName, description),
+      );
+    }
+
+    // Prune managed stubs whose skill no longer exists (e.g. package-removed skills).
+    const installedSet = new Set(installedSkills);
+    for (const filePath of await listFilesRecursive(commandsDir)) {
+      if (!filePath.endsWith('.md')) continue;
+      const content = await readTextFile(filePath);
+      if (!content?.includes(COMMAND_MARKER)) continue;
+      const skillName = path.basename(filePath).replace(/\.md$/, '');
+      if (!installedSet.has(skillName)) {
+        await removeFile(filePath);
+      }
+    }
+  }
+
+  async cleanup(projectDir: string): Promise<void> {
+    const commandsDir = path.join(projectDir, '.zcode', 'commands');
+    if (!(await fileExists(commandsDir))) {
+      return;
+    }
+
+    for (const filePath of await listFilesRecursive(commandsDir)) {
+      if (!filePath.endsWith('.md')) continue;
+      const content = await readTextFile(filePath);
+      if (content?.includes(COMMAND_MARKER)) {
+        await removeFile(filePath);
+      }
+    }
+  }
+
+  getWelcomeMessage(): string[] {
+    return [
+      '1. Open ZCode in this directory',
+      '2. Skills installed to .zcode/skills/ and exposed as /aif-* commands via .zcode/commands/',
+      '3. MCP servers configured in .zcode/config.json under mcp.servers (if selected)',
+      '4. Run /aif to analyze project and use /aif-plan, /aif-commit for daily workflow',
+    ];
+  }
+
+  getInvocationHint(): string {
+    return 'ZCode: /aif, /aif-plan, /aif-commit';
+  }
+}


### PR DESCRIPTION
Add ZCode as a built-in runtime with full skill and MCP support:

- Register zcode agent (configDir .zcode, skillsDir .zcode/skills)
- Write MCP servers to .zcode/config.json under mcp.servers using the strict stdio schema ({ type, command, args, env }) and remove them from the nested container on extension cleanup
- Add ZCodeTransformer: skills install unchanged into .zcode/skills/ and postInstall generates /aif-* slash-command stubs in .zcode/commands/ (skills: frontmatter auto-mounts the skill, $ARGUMENTS passes invocation arguments); managed stubs are marked and pruned when their skill disappears
- Document the ZCode runtime contract in the aif skill MCP matrix
- Update docs (getting-started, configuration), README, AGENTS.md (16 -> 17 agents), and package.json keywords

Verified: npm test 145/145; live ai-factory init --agents zcode run installs 29 skills, 29 command stubs, and a working .zcode/config.json; /aif appears in the ZCode / menu after session restart.