### PR TITLE
feat(skills): add session warmup workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 **AI Factory** (v2) is an npm package + skill system that automates AI agent context setup for projects. It provides:
 
 1. **CLI tool** (`ai-factory init/update/upgrade`) — installs skills and configures MCP
-2. **Built-in skills** (29 skills, all `aif-*` prefixed) — workflow commands for spec-driven development
+2. **Built-in skills** (30 skills, all `aif-*` prefixed) — workflow commands for spec-driven development
 3. **Spec-driven workflow** — structured approach: plan → implement → commit
 4. **Multi-agent support** — 16 agents (Claude Code, Cursor, Windsurf, Roo Code, Kilo Code, Antigravity, OpenCode, Warp,
    Zencoder, Codex CLI, Codex app, GitHub Copilot, Gemini CLI, Junie, Qwen Code, Universal)
@@ -35,6 +35,7 @@ ai-factory/
 │   ├── aif-docs/               # Documentation generation & maintenance
 │   ├── aif-evolve/             # Self-improve skills based on context
 │   ├── aif-transfer/           # Reuse anonymized patch experience from another project
+│   ├── aif-warmup/             # Load startup context for a session or fork
 │   ├── aif-explore/            # Explore mode (thinking partner)
 │   ├── aif-fix/                # Quick bug fixes (no plans)
 │   ├── aif-grounded/           # Reliability gate for answers
@@ -137,7 +138,7 @@ Context gate policy for quality commands:
 `config.yaml` is not universal yet. The current config-aware skills are:
 
 - Core workflow and quality: `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`,
-  `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`
+  `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`, `/aif-warmup`
 - Additional utility: `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-transfer`, `/aif-reference`,
   `/aif-distillation`,
   `/aif-security-checklist`, `/aif-qa`, `/aif-qa-check`, `/aif-archive`
@@ -154,6 +155,7 @@ Current config keys in active use:
 - `language.ui` / `language.artifacts` / `language.technical_terms` - prompt/report language, generated artifact language, and terminology handling while preserving commands, paths, identifiers, config keys, and raw errors where required
 - `git.enabled` / `git.base_branch` / `git.create_branches` / `git.branch_prefix` / `git.skip_push_after_commit` - planning, verification, and commit push behavior
 - `workflow.verify_mode` - default verification strictness
+- `warmup.paths` - optional extra files/directories loaded recursively by `/aif-warmup`
 - `rules.base` plus named `rules.<area>` entries - rules hierarchy
 
 Not yet configurable via the current schema:
@@ -230,6 +232,16 @@ Reports standalone verdict:
     - final `aif-gate-result` JSON block → parseable lowercase pass/warn/fail summary
     ↓
 Suggests `/aif-rules` when rules need to be added or clarified
+
+/aif-warmup
+    ↓
+Reads config-aware DESCRIPTION, ARCHITECTURE, ROADMAP, RESEARCH, and rules paths plus applicable AGENTS.md
+    ↓
+Loads optional extra files/directories from `warmup.paths`
+    ↓
+Carries relevant language, git, and workflow preferences into a compact read-only handoff
+    ↓
+Stops without implementation so the warmed session can continue or be forked
 
 /aif-explore [ultra] [topic or plan name]
     ↓

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -42,6 +42,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 |---------|---------|
 | `language` | Prompt language and artifact language |
 | `paths` | Artifact locations under project root |
+| `warmup` | Optional extra session context for `/aif-warmup` |
 | `workflow` | Workflow-level defaults and feature flags |
 | `git` | Git-aware planning / verification behavior |
 | `rules` | Base rules file plus named area-rule files |
@@ -52,20 +53,20 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
-| `language.ui` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-transfer`, `/aif-reference`, `/aif-distillation`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa`, `/aif-qa-check` | UI language for prompts, questions, and summaries; `/aif` resolves it before downstream setup questions |
-| `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-fix`, `/aif-evolve`, `/aif-transfer`, `/aif-reference`, `/aif-distillation`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa`, `/aif-qa-check` | Language for generated or persisted artifacts; `/aif` locks it before the first setup artifact so DESCRIPTION/rules base/AGENTS/ARCHITECTURE stay aligned in one run; workflow artifact writers use it for plans, research, fix plans, patches, references, rules, security ignore state, docs, evolution reports, and QA artifacts, with fallback to `language.ui` |
-| `language.technical_terms` | `keep` | `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-fix`, `/aif-transfer`, `/aif-reference`, `/aif-distillation`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa`, `/aif-qa-check` | Present in schema and template; `/aif` preserves an existing value when present and otherwise writes the default `keep`; artifact-writing skills use it to decide whether human-readable terminology should stay in English, be translated, or use mixed style while preserving commands, paths, identifiers, config keys, package names, API names, machine-readable metadata keys/status values, and raw errors where required |
+| `language.ui` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-evolve`, `/aif-transfer`, `/aif-reference`, `/aif-distillation`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa`, `/aif-qa-check`, `/aif-warmup` | UI language for prompts, questions, and summaries; `/aif` resolves it before downstream setup questions |
+| `language.artifacts` | `en` | `/aif`, `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-improve`, `/aif-loop`, `/aif-docs`, `/aif-fix`, `/aif-evolve`, `/aif-transfer`, `/aif-reference`, `/aif-distillation`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa`, `/aif-qa-check`, `/aif-warmup` | Language for generated or persisted artifacts; `/aif` locks it before the first setup artifact so DESCRIPTION/rules base/AGENTS/ARCHITECTURE stay aligned in one run; workflow artifact writers use it for plans, research, fix plans, patches, references, rules, security ignore state, docs, evolution reports, and QA artifacts, with fallback to `language.ui`; `/aif-warmup` only reports the configured preference |
+| `language.technical_terms` | `keep` | `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-fix`, `/aif-transfer`, `/aif-reference`, `/aif-distillation`, `/aif-rules`, `/aif-security-checklist`, `/aif-qa`, `/aif-qa-check`, `/aif-warmup` | Present in schema and template; `/aif` preserves an existing value when present and otherwise writes the default `keep`; artifact-writing skills use it to decide whether human-readable terminology should stay in English, be translated, or use mixed style while preserving commands, paths, identifiers, config keys, package names, API names, machine-readable metadata keys/status values, and raw errors where required; `/aif-warmup` only reports the configured preference |
 
 ### `paths`
 
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
-| `paths.description` | `.ai-factory/DESCRIPTION.md` | `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-transfer`, `/aif-docs`, `/aif-qa`, `/aif-qa-check` | Core project description artifact |
-| `paths.architecture` | `.ai-factory/ARCHITECTURE.md` | `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-docs`, `/aif-loop`, `/aif-evolve`, `/aif-transfer`, `/aif-qa`, `/aif-qa-check` | Architecture source of truth |
+| `paths.description` | `.ai-factory/DESCRIPTION.md` | `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-transfer`, `/aif-docs`, `/aif-qa`, `/aif-qa-check`, `/aif-warmup` | Core project description artifact |
+| `paths.architecture` | `.ai-factory/ARCHITECTURE.md` | `/aif-architecture`, `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-fix`, `/aif-docs`, `/aif-loop`, `/aif-evolve`, `/aif-transfer`, `/aif-qa`, `/aif-qa-check`, `/aif-warmup` | Architecture source of truth |
 | `paths.docs` | `docs/` | `/aif-docs` | Detailed docs directory; `README.md` stays fixed in project root |
-| `paths.roadmap` | `.ai-factory/ROADMAP.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-loop` | Strategic roadmap artifact |
-| `paths.research` | `.ai-factory/RESEARCH.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-improve`, `/aif-fix` | Regular persisted exploration file; ultra bundles derive `<parent>/research/<english-slug>/` from this path and keep a compatible `RESEARCH.md` inside |
-| `paths.rules_file` | `.ai-factory/RULES.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-transfer`, `/aif-rules`, `/aif-reference`, `/aif-loop` | Top-level rules artifact |
+| `paths.roadmap` | `.ai-factory/ROADMAP.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-commit`, `/aif-loop`, `/aif-warmup` | Strategic roadmap artifact |
+| `paths.research` | `.ai-factory/RESEARCH.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-improve`, `/aif-fix`, `/aif-warmup` | Regular persisted exploration file; ultra bundles derive `<parent>/research/<english-slug>/` from this path and keep a compatible `RESEARCH.md` inside |
+| `paths.rules_file` | `.ai-factory/RULES.md` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-transfer`, `/aif-rules`, `/aif-reference`, `/aif-loop`, `/aif-warmup` | Top-level rules artifact |
 | `paths.plan` | `.ai-factory/PLAN.md` | `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-loop` | Fast-plan path |
 | `paths.plans` | `.ai-factory/plans/` | `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-loop`, `/aif-archive` | Named plans directory: full plans are root `.md` files; ultra plans are direct child directories whose `index.md` contains the stable `<!-- aif:plan-mode:ultra -->` marker plus linked phase files |
 | `paths.fix_plan` | `.ai-factory/FIX_PLAN.md` | `/aif-fix`, `/aif-improve`, `/aif-implement`, `/aif-verify` | Fix-plan path |
@@ -75,36 +76,42 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | `paths.evolutions` | `.ai-factory/evolutions/` | `/aif-plan`, `/aif-evolve`, `/aif-transfer` | Evolution logs and patch cursor; transfer delegates one approved log but never touches the cursor |
 | `paths.evolution` | `.ai-factory/evolution/` | `/aif-loop` | Reflex loop state root |
 | `paths.specs` | `.ai-factory/specs/` | `/aif-plan`, `/aif-verify` | Specs / archived plan support |
-| `paths.rules` | `.ai-factory/rules/` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-transfer`, `/aif-rules` | Area-rules directory and relative rule resolution base |
+| `paths.rules` | `.ai-factory/rules/` | `/aif-plan`, `/aif-explore`, `/aif-roadmap`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-transfer`, `/aif-rules`, `/aif-warmup` | Area-rules directory and relative rule resolution base |
 | `paths.qa` | `.ai-factory/qa/` | `/aif-qa`, `/aif-qa-check` | QA artifacts root; branch slug is appended as subdirectory (`<paths.qa>/<branch-slug>/`). `/aif-qa` writes `change-summary.md`, `test-plan.md`, and `test-cases.md`; `/aif-qa-check` writes revision/worktree/source-bound `qa-check.md` plus root-level `agent-context.md` and `agent-history.md` for reusable non-sensitive automated QA memory. |
 | `paths.archive` | `.ai-factory/archive/` | `/aif-archive`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-improve` | Archive directory for completed plans and roadmap snapshots. `archive/plans/` stores full `.md` plans and ultra bundle directories; `archive/roadmap/` stores dated snapshots. Plan identifiers retain any sequential prefix. |
+
+### `warmup`
+
+| Key | Default | Read by skills | Notes |
+|-----|---------|----------------|-------|
+| `warmup.paths` | `[]` | `/aif-warmup` | Ordered extra files or directories loaded after core context. Entries must remain inside project root; directories are scanned recursively for readable text. Outside-root, missing/unreadable, binary, symlinked, sensitive, generated, or context-limited entries are reported instead of silently ignored. This user-owned option is included in new config templates and preserved on setup reruns; absence in an existing config is equivalent to `[]`. |
 
 ### `workflow`
 
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
 | `workflow.auto_create_dirs` | `true` | No dedicated built-in reader yet | Present in schema/template; reserved for directory-management behavior |
-| `workflow.plan_id_format` | `slug` | `/aif-plan`, `/aif-implement`, `/aif-improve`, `/aif-explore`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-archive` | Active values: `slug` (default), `sequential`; `timestamp` and `uuid` are reserved and fall back to `slug`. Sequential writes a full plan as `paths.plans/<NNNN>_<stem>.md` or an ultra bundle as `paths.plans/<NNNN>_<stem>/index.md`. Allocation counts numbered full files and only directories whose `index.md` has the exact ultra marker, uses max + 1, starts at `0001`, caps at `9999`, ignores unrelated numbered directories, and excludes the archive. Moving/deleting the highest active artifact can free its number. Force-disabled when `HANDOFF_BRANCH_PREPARED=1`. |
+| `workflow.plan_id_format` | `slug` | `/aif-plan`, `/aif-implement`, `/aif-improve`, `/aif-explore`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-archive`, `/aif-warmup` | Active values: `slug` (default), `sequential`; `timestamp` and `uuid` are reserved and fall back to `slug`. Sequential writes a full plan as `paths.plans/<NNNN>_<stem>.md` or an ultra bundle as `paths.plans/<NNNN>_<stem>/index.md`. Allocation counts numbered full files and only directories whose `index.md` has the exact ultra marker, uses max + 1, starts at `0001`, caps at `9999`, ignores unrelated numbered directories, and excludes the archive. Moving/deleting the highest active artifact can free its number. Force-disabled when `HANDOFF_BRANCH_PREPARED=1`. `/aif-warmup` only reports the configured preference. |
 | `workflow.analyze_updates_architecture` | `true` | No dedicated built-in reader yet | Present in schema/template; reserved for setup/update workflow control |
 | `workflow.architecture_updates_roadmap` | `true` | No dedicated built-in reader yet | Present in schema/template; reserved for architecture-to-roadmap automation |
-| `workflow.verify_mode` | `normal` | `/aif-verify` | Default strictness for verification runs |
+| `workflow.verify_mode` | `normal` | `/aif-verify`, `/aif-warmup` | Default strictness for verification runs; `/aif-warmup` only reports the configured preference |
 
 ### `git`
 
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
-| `git.enabled` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-qa`, `/aif-qa-check` | Disables branch/worktree assumptions when false; `/aif-qa` switches to manual change context instead of git diffing |
-| `git.base_branch` | `main` with auto-detect fallback | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-qa` | Target branch for diff, merge, and verification guidance |
-| `git.create_branches` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-commit` | Full and ultra plans still exist when false; they skip automatic branch creation |
-| `git.branch_prefix` | `feature/` | `/aif`, `/aif-plan` | Prefix for auto-created full-plan branches |
-| `git.skip_push_after_commit` | `false` | `/aif-commit` | When true, `/aif-commit` skips push prompt and ends after local commit |
+| `git.enabled` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-qa`, `/aif-qa-check`, `/aif-warmup` | Disables branch/worktree assumptions when false; `/aif-qa` switches to manual change context instead of git diffing; `/aif-warmup` only reports the configured preference |
+| `git.base_branch` | `main` with auto-detect fallback | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-review`, `/aif-rules-check`, `/aif-qa`, `/aif-warmup` | Target branch for diff, merge, and verification guidance; `/aif-warmup` only reports the configured preference |
+| `git.create_branches` | `true` | `/aif`, `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-warmup` | Full and ultra plans still exist when false; they skip automatic branch creation; `/aif-warmup` only reports the configured preference |
+| `git.branch_prefix` | `feature/` | `/aif`, `/aif-plan`, `/aif-warmup` | Prefix for auto-created full-plan branches; `/aif-warmup` only reports the configured preference |
+| `git.skip_push_after_commit` | `false` | `/aif-commit`, `/aif-warmup` | When true, `/aif-commit` skips push prompt and ends after local commit; `/aif-warmup` only reports the configured preference |
 
 ### `rules`
 
 | Key | Default | Read by skills | Notes |
 |-----|---------|----------------|-------|
-| `rules.base` | `.ai-factory/rules/base.md` | `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-transfer` | Base project rule file |
-| `rules.<area>` | none | `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-transfer`; written by `/aif-rules area:<name>` | Named area rule entries like `rules.api`, `rules.frontend`; preserved during `/aif` reruns |
+| `rules.base` | `.ai-factory/rules/base.md` | `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-transfer`, `/aif-warmup` | Base project rule file |
+| `rules.<area>` | none | `/aif-implement`, `/aif-verify`, `/aif-rules-check`, `/aif-commit`, `/aif-fix`, `/aif-evolve`, `/aif-transfer`, `/aif-warmup`; written by `/aif-rules area:<name>` | Named area rule entries like `rules.api`, `rules.frontend`; preserved during `/aif` reruns |
 
 ## Skill Matrix
 
@@ -141,6 +148,7 @@ During setup, `/aif` resolves `language.ui` and `language.artifacts` immediately
 | `/aif-qa` | Yes | No | `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, `language.artifacts`, `language.technical_terms`, `git.enabled`, `git.base_branch` |
 | `/aif-qa-check` | Yes | No | `paths.description`, `paths.architecture`, `paths.qa`, `language.ui`, `language.artifacts`, `language.technical_terms`, `git.enabled` |
 | `/aif-archive` | Yes | No | `paths.plans`, `paths.archive`, `paths.plan`, `paths.fix_plan`, `paths.roadmap`, `workflow.plan_id_format`, `language.ui` |
+| `/aif-warmup` | Yes | No | `paths.description`, `paths.architecture`, `paths.roadmap`, `paths.research`, `paths.rules_file`, `paths.rules`, `rules.base`, `rules.<area>`, `warmup.paths`, `language.ui`, `language.artifacts`, `language.technical_terms`, selected `git.*`, `workflow.plan_id_format`, `workflow.verify_mode` |
 
 ### Config-Agnostic Built-ins
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,6 +163,14 @@ paths:
   qa: .ai-factory/qa/
   archive: .ai-factory/archive/
 
+# Optional extra context for /aif-warmup
+warmup:
+  paths: []
+  # Example:
+  # paths:
+  #   - docs/domain/
+  #   - infrastructure/decisions.md
+
 # Workflow Settings
 workflow:
   auto_create_dirs: true           # Create .ai-factory/ directories when missing
@@ -189,7 +197,7 @@ rules:
 ```
 
 **Current config-aware skills** read `config.yaml` at Step 0. This currently includes:
-- Core workflow and quality commands: `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`
+- Core workflow and quality commands: `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`, `/aif-warmup`
 - Additional utility commands: `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-transfer`, `/aif-reference`, `/aif-distillation`, `/aif-security-checklist`, `/aif-qa`, `/aif-qa-check`, `/aif-archive`
 
 Other skills are config-agnostic for now and rely on repository context, explicit arguments, or fixed non-configurable paths such as `skill-context`.
@@ -214,6 +222,7 @@ Current config-agnostic built-ins include `/aif-best-practices`, `/aif-build-aut
   required, and existing fast/full prompts and artifact shapes remain unchanged.
 - `paths.plan` remains the default fast-plan file. If you prefer fast plans inside `paths.plans/`, change `paths.plan` manually in `config.yaml`.
 - `paths.docs` controls where `/aif-docs` writes the detailed documentation pages. `README.md` remains the landing page in the project root.
+- `warmup.paths` is an ordered list of extra files or directories for `/aif-warmup`. Entries resolve from and must stay inside project root; directories are scanned recursively for readable text files. Missing config is equivalent to an empty list.
 - `paths.qa` controls where `/aif-qa` and `/aif-qa-check` store QA artifacts. A derived branch slug is appended automatically: `<paths.qa>/<branch-slug>/change-summary.md`, `test-plan.md`, `test-cases.md`, and `qa-check.md`. Agent-mode `/aif-qa-check` also uses root-level `<paths.qa>/agent-context.md` and `<paths.qa>/agent-history.md` to reuse non-sensitive cross-QA setup facts and recurring learnings, including stable browser routes/selectors and safe command/test-filter patterns. Run-specific details such as branch names, QA target paths, summary counts, assertion totals, and one-off command transcripts stay in `<paths.qa>/<branch-slug>/qa-check.md`. The slug is a deterministic, filesystem-safe, stable derived value with mandatory 40-character safe-slug truncation and a short hash suffix for collision resistance — see `skills/aif-qa/SKILL.md` for the full algorithm. `/aif-qa-check` binds results to the tested commit plus working tree digest, or to a manual build identifier when git is unavailable, plus deterministic `test-cases.md` and per-case digests.
 
 **Current schema limits:** `config.yaml` still leaves `.ai-factory/skill-context/` fixed by command contract. `README.md` and `docs-html/` remain fixed by current documentation workflow.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,7 +2,7 @@
 
 # Core Skills
 
-**Config-aware skills read `.ai-factory/config.yaml` at startup** to resolve paths, language settings, workflow preferences, and rules hierarchy. The current config-aware set is `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`, `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-transfer`, `/aif-reference`, `/aif-distillation`, `/aif-security-checklist`, `/aif-qa`, `/aif-qa-check`, and `/aif-archive`.
+**Config-aware skills read `.ai-factory/config.yaml` at startup** to resolve paths, language settings, workflow preferences, and rules hierarchy. The current config-aware set is `/aif`, `/aif-plan`, `/aif-implement`, `/aif-verify`, `/aif-commit`, `/aif-review`, `/aif-rules-check`, `/aif-roadmap`, `/aif-explore`, `/aif-loop`, `/aif-rules`, `/aif-architecture`, `/aif-docs`, `/aif-fix`, `/aif-improve`, `/aif-evolve`, `/aif-transfer`, `/aif-reference`, `/aif-distillation`, `/aif-security-checklist`, `/aif-qa`, `/aif-qa-check`, `/aif-archive`, and `/aif-warmup`.
 
 `/aif` is also the primary writer for `config.yaml`: the initial file comes from the commented template, and setup reruns update only managed keys while preserving comments, unrelated manual edits, and `rules.<area>` entries owned by `/aif-rules`.
 
@@ -13,6 +13,17 @@ Other skills are intentionally config-agnostic for now and rely on repository co
 ## Workflow Skills
 
 These skills form the core development loop. See [Development Workflow](workflow.md) for the full diagram and how they connect.
+
+### `/aif-warmup`
+Load the essential project context before starting work:
+```
+/aif-warmup
+```
+- Reads configured DESCRIPTION, ARCHITECTURE, ROADMAP, RESEARCH, and the complete scoped rules hierarchy, plus applicable `AGENTS.md` files
+- Resolves custom paths from project root and carries relevant language, git, and workflow preferences into the handoff
+- Loads extra engineer-selected files or directories from `warmup.paths`; directory scans are recursive and text-only
+- Summarizes active research bundles without loading unrelated supporting artifacts
+- Changes nothing and stops at a self-contained handoff, making the warmed session suitable for continuing or forking
 
 ### `/aif-explore [ultra] [topic or plan name]`
 Explore ideas, constraints, and trade-offs before planning:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -54,6 +54,8 @@ Path examples below show the default `.ai-factory/` locations. `config.yaml` can
 
 Optional discovery step: use `/aif-explore` before planning to investigate ideas, compare options, and clarify requirements.
 
+Session startup: use `/aif-warmup` to load the core project artifacts, applicable instructions, and optional extra files/directories from `warmup.paths` into a compact handoff before choosing the next workflow command. The warmed session can then continue directly or be forked.
+
 Reliability gate: use `/aif-grounded` when the main problem is not discovery but certainty - high-stakes answers, changeable facts, version-sensitive behavior, or any request where the model must refuse to guess.
 
 If you want exploration results to survive `/clear` and feed directly into planning, ask `/aif-explore` to save them to `paths.research` (default: `.ai-factory/RESEARCH.md`). Use explicit `/aif-explore ultra <topic>` for a named bundle with mandatory `INDEX.md` + compatible `RESEARCH.md` and only the C4, ADR, or dependency artifacts justified by the topic. See [Research and System Analysis](research.md).
@@ -171,6 +173,7 @@ Optional conventions step: use `/aif-rules` to append or refine project-wide axi
 
 | Command | Use Case | Creates Branch? | Creates Plan? |
 |---------|----------|-----------------|---------------|
+| `/aif-warmup` | Load essential project context at session start or before a fork | No | No |
 | `/aif-explore` | Discovery, option comparison, and requirements clarification before planning | No | No (optional `paths.research` on request) |
 | `/aif-explore ultra` | Durable system analysis with adaptive C4/ADR/dependency coverage | No | No (creates `<parent(paths.research)>/research/<english-slug>/`) |
 | `/aif-grounded` | Evidence-only answers, strict verification, and high-stakes questions where guessing is unacceptable | No | No |
@@ -215,6 +218,7 @@ Ownership is command-scoped to avoid conflicting writers:
 | `/aif-qa-check`                           | `paths.qa/<branch-slug>/qa-check.md`, `paths.qa/agent-context.md`, `paths.qa/agent-history.md` | executes `/aif-qa` test cases; source QA artifacts stay read-only; agent context/history are reusable automated-QA memory |
 | `/aif-archive`                            | `paths.archive/plans/*`, `paths.archive/roadmap/*.md`                                         | moves completed plan files/bundles from `paths.plans/`; trims closed milestones from `paths.roadmap` |
 | `/aif-rules-check`                        | read-only context by default                                                                  | standalone rules gate; no default context-file writes     |
+| `/aif-warmup`                             | read-only context                                                                             | loads a compact session handoff; writes nothing           |
 | `/aif-commit` `/aif-review` `/aif-verify` | read-only context by default                                                                  | gate and report, no default context-file writes           |
 
 Context-gate defaults for `/aif-commit`, `/aif-review`, `/aif-verify`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-factory",
-  "version": "2.18.1",
+  "version": "2.19.0",
   "type": "module",
   "description": "CLI tool for automating AI agent context setup in projects",
   "main": "dist/cli/index.js",

--- a/scripts/test-aif-config.sh
+++ b/scripts/test-aif-config.sh
@@ -100,6 +100,8 @@ assert_contains "$CREATE_TARGET" '^  # /aif-qa-check stores qa-check\.md here an
 assert_contains "$CREATE_TARGET" '^  # digests\.$' "fresh create must document qa-check source digest binding"
 assert_contains "$CREATE_TARGET" '^  qa: \.ai-factory/qa/$' "fresh create must set paths.qa"
 assert_contains "$CREATE_TARGET" '^  archive: \.ai-factory/archive/$' "fresh create must set paths.archive"
+assert_contains "$CREATE_TARGET" '^warmup:$' "fresh create must include optional warmup config"
+assert_contains "$CREATE_TARGET" '^  paths: \[\]$' "fresh create must default warmup.paths to an empty list"
 assert_contains "$CREATE_TARGET" '^  base_branch: 2.x$' "fresh create must set git.base_branch"
 assert_contains "$CREATE_TARGET" '^  branch_prefix: fix/$' "fresh create must set git.branch_prefix"
 assert_contains "$CREATE_TARGET" '^  # frontend: \.ai-factory/rules/frontend\.md$' "fresh create must preserve commented rules examples"
@@ -123,6 +125,10 @@ git:
 rules:
   base: .ai-factory/rules/base.md
   api: .ai-factory/rules/api.md
+
+warmup:
+  paths:
+    - docs/domain/
 
 custom:
   owner: team
@@ -152,6 +158,7 @@ assert_contains "$MERGE_TARGET" '^  qa: quality/$' "merge must preserve custom p
 assert_contains "$MERGE_TARGET" '^  # keep this comment$' "merge must preserve comments above managed keys"
 assert_contains "$MERGE_TARGET" '^  base_branch: trunk # team-default$' "merge must preserve inline comments while updating the value"
 assert_contains "$MERGE_TARGET" '^  api: \.ai-factory/rules/api\.md$' "merge must preserve existing rules.<area> entries"
+assert_contains "$MERGE_TARGET" '^    - docs/domain/$' "merge must preserve user-owned warmup.paths"
 assert_contains "$MERGE_TARGET" '^custom:$' "merge must preserve unknown sections"
 assert_contains "$MERGE_TARGET" '^  # Branch name prefix for new features$' "merge must backfill missing key comments from template"
 assert_contains "$MERGE_TARGET" '^  branch_prefix: feature/$' "merge must backfill missing managed keys"

--- a/scripts/test-aif-config.sh
+++ b/scripts/test-aif-config.sh
@@ -115,6 +115,11 @@ paths:
   docs: handbook/
   qa: quality/
 
+# keep this warmup comment
+warmup:
+  paths:
+    - docs/domain/
+
 git:
   enabled: true
   # keep this comment
@@ -125,10 +130,6 @@ git:
 rules:
   base: .ai-factory/rules/base.md
   api: .ai-factory/rules/api.md
-
-warmup:
-  paths:
-    - docs/domain/
 
 custom:
   owner: team
@@ -144,6 +145,7 @@ cat > "$MERGE_PAYLOAD" <<'EOF'
   "fillMissing": {
     "paths.docs": "docs/",
     "paths.qa": ".ai-factory/qa/",
+    "workflow.verify_mode": "normal",
     "git.branch_prefix": "feature/",
     "rules.base": ".ai-factory/rules/base.md"
   }
@@ -159,6 +161,7 @@ assert_contains "$MERGE_TARGET" '^  # keep this comment$' "merge must preserve c
 assert_contains "$MERGE_TARGET" '^  base_branch: trunk # team-default$' "merge must preserve inline comments while updating the value"
 assert_contains "$MERGE_TARGET" '^  api: \.ai-factory/rules/api\.md$' "merge must preserve existing rules.<area> entries"
 assert_contains "$MERGE_TARGET" '^    - docs/domain/$' "merge must preserve user-owned warmup.paths"
+node -e "const fs=require('fs');const text=fs.readFileSync(process.argv[1],'utf8');const comment=text.indexOf('# keep this warmup comment');const warmup=text.indexOf('warmup:');const workflow=text.indexOf('workflow:');if(!(comment < warmup && warmup < workflow)){console.error('Assertion failed: warmup must remain an insertion anchor before backfilled workflow');process.exit(1)}" "$MERGE_TARGET"
 assert_contains "$MERGE_TARGET" '^custom:$' "merge must preserve unknown sections"
 assert_contains "$MERGE_TARGET" '^  # Branch name prefix for new features$' "merge must backfill missing key comments from template"
 assert_contains "$MERGE_TARGET" '^  branch_prefix: feature/$' "merge must backfill missing managed keys"

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -727,6 +727,7 @@ AIF_REFERENCE_SKILL="$ROOT_DIR/skills/aif-reference/SKILL.md"
 AIF_SECURITY_SKILL="$ROOT_DIR/skills/aif-security-checklist/SKILL.md"
 AIF_TRANSFER_SKILL="$ROOT_DIR/skills/aif-transfer/SKILL.md"
 AIF_VERIFY_SKILL="$ROOT_DIR/skills/aif-verify/SKILL.md"
+AIF_WARMUP_SKILL="$ROOT_DIR/skills/aif-warmup/SKILL.md"
 SKILL_HINTS="$ROOT_DIR/src/cli/wizard/skill-hints.ts"
 AIF_VERIFY_OWNERSHIP_REF="$ROOT_DIR/skills/aif-verify/references/CONTEXT-GATES-AND-OWNERSHIP.md"
 AIF_ROADMAP_SKILL="$ROOT_DIR/skills/aif-roadmap/SKILL.md"
@@ -754,6 +755,23 @@ if grep -Fq '`.ai-factory/config.yaml` first, when present, to resolve:' "$AIF_T
     pass "aif-transfer preserves config, delegation, and privacy contract"
 else
     fail "aif-transfer config, delegation, or privacy contract missing"
+fi
+
+if grep -Fq 'Resolve relative artifact and rule paths from the project root' "$AIF_WARMUP_SKILL" \
+   && grep -Fq '`warmup.paths` (default `[]`)' "$AIF_WARMUP_SKILL" \
+   && grep -Fq 'inside it. Report and skip absolute paths and `..` escapes.' "$AIF_WARMUP_SKILL" \
+   && grep -Fq 'For a directory, recursively read text files in lexical path order.' "$AIF_WARMUP_SKILL" \
+   && grep -Fq '`language.artifacts` and `language.technical_terms`' "$AIF_WARMUP_SKILL" \
+   && grep -Fq '`git.enabled`, `git.base_branch`, `git.create_branches`' "$AIF_WARMUP_SKILL" \
+   && grep -Fq '`workflow.plan_id_format` and `workflow.verify_mode`' "$AIF_WARMUP_SKILL" \
+   && grep -Fq '`rules.<area>` > `rules.base` > `paths.rules_file`' "$AIF_WARMUP_SKILL" \
+   && grep -Fq "'aif-warmup'," "$ROOT_DIR/src/core/transformer.ts" \
+   && grep -Fq "'aif-warmup':" "$SKILL_HINTS" \
+   && grep -F '| `/aif-warmup` | Yes | No |' "$CONFIG_REFERENCE_DOC" | grep -Fq '`warmup.paths`' \
+   && grep -Fq 'warmup:' "$ROOT_DIR/skills/aif/references/config-template.yaml"; then
+    pass "aif-warmup preserves config-aware fork-ready workflow contract"
+else
+    fail "aif-warmup config, rules, transformer, or docs contract missing"
 fi
 
 MODE1_SECTION="$(awk '

--- a/skills/aif-warmup/SKILL.md
+++ b/skills/aif-warmup/SKILL.md
@@ -64,10 +64,11 @@ Read every resolved file that exists, in this order:
 2. ARCHITECTURE
 3. ROADMAP
 4. RESEARCH
-5. RULES: the top-level rules file, `rules.base`, then every named
-   `rules.<area>` entry. Keep every area rule tied to its configured area;
-   never present it as a global rule. Priority is
-   `rules.<area>` > `rules.base` > `paths.rules_file`.
+5. RULES: load from broadest to most specific: the top-level rules file,
+   `rules.base`, then every named `rules.<area>` entry. Later, more specific
+   rules override earlier ones:
+   `rules.<area>` > `rules.base` > `paths.rules_file`. Keep every area rule
+   tied to its configured area; never present it as a global rule.
 
 Missing artifacts are normal. Record them as missing and continue.
 

--- a/skills/aif-warmup/SKILL.md
+++ b/skills/aif-warmup/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: aif-warmup
+description: Load the essential AI Factory project context before work begins. Reads configured DESCRIPTION, ARCHITECTURE, ROADMAP, RESEARCH, RULES, and applicable AGENTS.md files, then returns a compact session handoff suitable for continuing or forking. Use at the start of a new session or after context loss.
+allowed-tools: Read Glob Grep
+disable-model-invocation: true
+---
+
+# Warm Up the Session
+
+Load project context without changing the repository. Finish with a compact,
+self-contained handoff that can start the next task or a forked session.
+
+## Step 0: Resolve Context Paths
+
+Use the nearest ancestor containing `.ai-factory/` as the project root; otherwise
+use the current working directory. Read `.ai-factory/config.yaml` from that root
+first when it exists. Resolve:
+
+- `paths.description` (default `.ai-factory/DESCRIPTION.md`)
+- `paths.architecture` (default `.ai-factory/ARCHITECTURE.md`)
+- `paths.roadmap` (default `.ai-factory/ROADMAP.md`)
+- `paths.research` (default `.ai-factory/RESEARCH.md`)
+- `paths.rules_file` (default `.ai-factory/RULES.md`)
+- `paths.rules` (default `.ai-factory/rules/`)
+- `rules.base` (default `.ai-factory/rules/base.md`)
+- every named `rules.<area>` entry
+- `warmup.paths` (default `[]`)
+- `language.ui` (default `en`)
+
+Also retain these configured preferences for the handoff because they affect
+later workflow commands, even though warmup does not act on them:
+
+- `language.artifacts` and `language.technical_terms`
+- `git.enabled`, `git.base_branch`, `git.create_branches`,
+  `git.branch_prefix`, and `git.skip_push_after_commit`
+- `workflow.plan_id_format` and `workflow.verify_mode`
+
+Resolve relative artifact and rule paths from the project root; keep absolute
+paths absolute. If config is missing or a required value is missing or empty,
+use its documented default. If config cannot be parsed confidently, report that
+and use defaults; do not modify it or invent semantics for unknown keys.
+
+All user-facing output MUST use `language.ui`.
+
+## Step 1: Read Applicable Instructions
+
+Read, when present:
+
+- the repository-root `AGENTS.md`
+- each `AGENTS.md` between the repository root and current working directory,
+  from broadest to most specific
+- `.ai-factory/skill-context/aif-warmup/SKILL.md`
+
+Nested `AGENTS.md` files outside the current working-directory chain are scoped
+to future work in those directories. Do not load all of them during warmup.
+More specific `AGENTS.md` instructions override broader ones. The warmup
+skill-context file overrides this general skill when they conflict.
+
+## Step 2: Read Core Artifacts
+
+Read every resolved file that exists, in this order:
+
+1. DESCRIPTION
+2. ARCHITECTURE
+3. ROADMAP
+4. RESEARCH
+5. RULES: the top-level rules file, `rules.base`, then every named
+   `rules.<area>` entry. Keep every area rule tied to its configured area;
+   never present it as a global rule. Priority is
+   `rules.<area>` > `rules.base` > `paths.rules_file`.
+
+Missing artifacts are normal. Record them as missing and continue.
+
+For ultra research, derive `research_bundles_dir` as
+`<parent(paths.research)>/research/`. Read marked direct-child `INDEX.md` files
+only when they contain `<!-- aif:research-mode:ultra -->` exactly once. For
+bundles with `Status: active`, load the linked `RESEARCH.md` Active Summary and
+open questions. Do not load C4, ADR, dependency, or session-history details
+until a concrete task needs them.
+
+Do not scan application code, plans, git history, external sources, or unrelated
+artifacts during warmup. The next task can load those on demand.
+
+### Additional Warmup Paths
+
+Process `warmup.paths` in configured order after the core artifacts. Each entry
+may point to a file or directory:
+
+- Require a sequence of non-empty strings. Report and ignore invalid entries;
+  treat entries as literal paths, not glob patterns.
+- Resolve entries from the project root and require the resolved path to remain
+  inside it. Report and skip absolute paths and `..` escapes.
+- Read a file once when it is readable text, even if another entry or core
+  artifact resolves to the same file.
+- For a directory, recursively read text files in lexical path order.
+- Do not follow symlinks. Skip binary files and VCS, dependency, build, cache,
+  and coverage directories unless such a directory is itself the explicit entry.
+- Never load likely secrets, credentials, tokens, or private keys from an extra
+  path. Report the skipped path; an explicitly listed `.env.example` may be read.
+- If an entry is missing, unreadable, or too large to load without crowding out
+  the handoff, report it. For a large directory, inventory it, prioritize its
+  root `README*` and `INDEX*` files, and list what was not loaded instead of
+  silently truncating.
+
+An absent or empty `warmup.paths` means no additional scan.
+
+## Step 3: Produce the Handoff
+
+Return a concise summary with these sections:
+
+- **Configuration** — resolved custom paths and configured language, git, and
+  workflow preferences that can affect the next command, including
+  `warmup.paths`
+- **Project** — purpose, stack, and current state
+- **Architecture** — important boundaries and entry points
+- **Direction** — active roadmap priorities and research conclusions
+- **Rules** — non-negotiable instructions and conventions
+- **Gaps** — missing artifacts, contradictions, or open research questions
+- **Loaded** — exact paths read
+- **Ready** — state that context is loaded and the session can continue or be forked
+
+Prefer facts that will affect later decisions. Do not reproduce whole artifacts.
+When two sources conflict, name both sources and the conflict instead of silently
+choosing one.
+
+## Artifact Ownership
+
+- Primary ownership: none.
+- All project files and AI Factory artifacts are read-only.
+
+## Boundaries
+
+- Read-only: never create or modify files, code, branches, plans, or config.
+- Do not start implementation in the same invocation.
+- Do not ask setup questions unless the project root itself cannot be identified.
+- Stop after the handoff so it remains a clean session fork point.

--- a/skills/aif/SKILL.md
+++ b/skills/aif/SKILL.md
@@ -237,6 +237,9 @@ node ~/{{skills_dir}}/aif/references/update-config.mjs \
   - `git.branch_prefix`
   - `git.skip_push_after_commit`
   - `rules.base`
+- `warmup.paths` is user-owned optional configuration: the template includes
+  `warmup.paths: []` on initial create, but reruns must not set or backfill it.
+  Preserve any existing list unchanged; absence is equivalent to an empty list.
 - Never normalize or overwrite `rules.<area>` entries. Those belong to `/aif-rules`.
 - The helper must preserve comments, blank lines, section order, inline comments, unknown sections, custom user values outside targeted keys, and the commented `rules.*` examples from the template.
 - If the helper reports an unsafe structure or invalid payload, STOP. Do **not** fall back to free-form YAML generation.

--- a/skills/aif/references/config-template.yaml
+++ b/skills/aif/references/config-template.yaml
@@ -136,6 +136,20 @@ paths:
   archive: .ai-factory/archive/
 
 # =============================================================================
+# Session Warmup
+# =============================================================================
+# Optional extra context loaded by /aif-warmup after the core artifacts.
+# Entries may be files or directories and must stay inside project root.
+# Directories are scanned recursively for readable text files.
+
+warmup:
+  paths: []
+  # Example:
+  # paths:
+  #   - docs/domain/
+  #   - infrastructure/decisions.md
+
+# =============================================================================
 # Workflow Settings
 # =============================================================================
 # Controls AI Factory workflow behavior.

--- a/skills/aif/references/update-config.mjs
+++ b/skills/aif/references/update-config.mjs
@@ -25,6 +25,7 @@ const SECTION_KEYS = {
     'qa',
     'archive',
   ],
+  warmup: [],
   workflow: ['auto_create_dirs', 'plan_id_format', 'analyze_updates_architecture', 'architecture_updates_roadmap', 'verify_mode'],
   git: ['enabled', 'base_branch', 'create_branches', 'branch_prefix', 'skip_push_after_commit'],
   rules: ['base'],

--- a/src/cli/wizard/skill-hints.ts
+++ b/src/cli/wizard/skill-hints.ts
@@ -28,6 +28,7 @@ const SKILL_HINTS: Record<string, string> = {
     'aif-skill-generator': 'Generate new agent skills',
     'aif-transfer': 'Transfer anonymized project experience',
     'aif-verify': 'Verify implementation completeness',
+    'aif-warmup': 'Load project context for a new session',
 };
 
 const DEFAULT_SKILL_HINT = 'Additional custom skill';

--- a/src/core/transformer.ts
+++ b/src/core/transformer.ts
@@ -39,6 +39,7 @@ export const WORKFLOW_SKILLS = new Set([
   'aif-plan',
   'aif-rules-check',
   'aif-verify',
+  'aif-warmup',
 ]);
 
 export function sanitizeName(name: string): string {

--- a/src/core/transformers/antigravity.ts
+++ b/src/core/transformers/antigravity.ts
@@ -38,6 +38,7 @@ export class AntigravityTransformer implements AgentTransformer {
 ## Skill Usage
 
 - Use \`/aif-explore\` to think through ideas before planning — no implementation, just exploration
+- Use \`/aif-warmup\` to load project context at session start or before a fork
 - Use \`/aif-plan\` for new features — creates branch, plan, and tasks
 - Use \`/aif-fix\` for bug fixes — analyzes, fixes, suggests tests
 - Use \`/aif-commit\` for commits — follows conventional commits
@@ -66,6 +67,7 @@ Action-oriented skills that execute specific tasks:
 - \`aif-implement.md\` — Execute plans step by step
 - \`aif-commit.md\` — Create conventional commits
 - \`aif-rules-check.md\` — Run a standalone rules compliance gate
+- \`aif-warmup.md\` — Load startup context for a session or fork
 - \`aif-review.md\` — Code review checklist
 - \`aif-ci.md\` — CI/CD pipeline setup
 


### PR DESCRIPTION
## Summary

- add `/aif-warmup` to load the core AI Factory artifacts and `AGENTS.md` into a compact, fork-ready session handoff
- add the user-owned `warmup.paths` configuration for extra project-root files and directories, with safe text-only traversal and clear skip reporting
- register the skill as a workflow across supported transformers and document and test the new configuration contract

## Testing

- `npm run build`
- `npm test` (147 passed)
- `bash scripts/test-aif-config.sh`
- transformer output checks for Antigravity and KiloCode