### PR TITLE
feat(skills): add requirements reconciliation gates

### DIFF
--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -1119,6 +1119,46 @@ else
     fail "research-backed plan revision/drift contract missing"
 fi
 
+if grep -Fq 'Resolve citations to the selected research source against the embedded' "$AIF_IMPLEMENT_SKILL" \
+   && grep -Fq 'research-backed citations against the embedded `## Research Context`' "$AIF_IMPROVE_SKILL" \
+   && grep -Fq 'live research source is only a drift signal unless the user explicitly asks' "$AIF_IMPROVE_SKILL" \
+   && grep -Fq 'live research file remains drift-only unless the user explicitly rebases' "$AIF_VERIFY_SKILL"; then
+    pass "requirements reconciliation preserves committed research snapshots"
+else
+    fail "requirements reconciliation may replace committed research snapshots"
+fi
+
+if grep -Fq '`handoff_outcome: blocked_external`' "$AIF_PLAN_SKILL" \
+   && grep -Fq '`handoff_outcome: blocked_external`' "$AIF_IMPLEMENT_SKILL" \
+   && grep -Fq '`status: blocked_external` and `blocker: requirement-conflict`' "$PLAN_POLISHER" \
+   && grep -Fq '`status: blocked_external`' "$ROOT_DIR/subagents/claude/agents/plan-coordinator.md" \
+   && grep -Fq '`status: blocked_external`' "$CODEX_PLAN_POLISHER" \
+   && grep -Fq '`status: blocked_external`' "$ROOT_DIR/subagents/codex/agents/plan-coordinator.toml" \
+   && grep -Fq '`handoff_outcome: blocked_external`' "$ROOT_DIR/subagents/claude/agents/implement-coordinator.md" \
+   && grep -Fq '`handoff_outcome: blocked_external`' "$ROOT_DIR/subagents/codex/agents/implement-coordinator.toml"; then
+    pass "autonomous requirement conflicts return a deterministic Handoff blocker"
+else
+    fail "autonomous requirement conflict Handoff contract is incomplete"
+fi
+
+if grep -Fxq '## Requirements Reconciliation' "$AIF_PLAN_FORMAT_REF" \
+   && grep -Fq 'REQUIREMENT EVIDENCE (when the Requirements Reconciliation Gate applies)' "$AIF_PLAN_FORMAT_REF" \
+   && grep -Fxq '## Requirements Reconciliation' "$AIF_PLAN_ULTRA_REF" \
+   && grep -Fq '### Requirement Evidence (when reconciliation applies)' "$AIF_PLAN_ULTRA_REF"; then
+    pass "full and ultra templates preserve requirements reconciliation"
+else
+    fail "full or ultra requirements reconciliation template is incomplete"
+fi
+
+if grep -Fq '`paths.architecture`, `paths.roadmap`, `paths.rules_file`, `paths.rules`' "$AIF_IMPROVE_SKILL" \
+   && grep -Fq 'Read the resolved architecture and roadmap artifacts when present.' "$AIF_IMPROVE_SKILL" \
+   && grep -Fq 'Read the resolved rules hierarchy when present:' "$AIF_PLAN_SKILL" \
+   && grep -Fq '`ERROR [requirement-ambiguity]` in strict mode' "$AIF_VERIFY_SKILL"; then
+    pass "requirements gates load authoritative context and block strict ambiguity"
+else
+    fail "requirements gate context loading or strict verdict is incomplete"
+fi
+
 AIF_PLAN_ALLOWED_TOOLS_LINE=$(grep -m1 '^allowed-tools:' "$AIF_PLAN_SKILL" || true)
 AIF_IMPROVE_ALLOWED_TOOLS_LINE=$(grep -m1 '^allowed-tools:' "$AIF_IMPROVE_SKILL" || true)
 AIF_FIX_ALLOWED_TOOLS_LINE=$(grep -m1 '^allowed-tools:' "$AIF_FIX_SKILL" || true)

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -1141,6 +1141,39 @@ else
     fail "autonomous requirement conflict Handoff contract is incomplete"
 fi
 
+PLAN_BLOCKED_LINE=$(grep -nF 'if result.status == blocked_external:' "$ROOT_DIR/subagents/claude/agents/plan-coordinator.md" | head -1 | cut -d: -f1 || true)
+PLAN_PATH_LINE=$(grep -nF 'extract plan_path, needs_further_refinement, issues list' "$ROOT_DIR/subagents/claude/agents/plan-coordinator.md" | head -1 | cut -d: -f1 || true)
+if [[ -n "$PLAN_BLOCKED_LINE" && -n "$PLAN_PATH_LINE" && "$PLAN_BLOCKED_LINE" -lt "$PLAN_PATH_LINE" ]] \
+   && grep -Fq 'do not extract or validate plan_path' "$ROOT_DIR/subagents/claude/agents/plan-coordinator.md" \
+   && grep -Fq 'skip the final artifact read, `handoff_push_plan`, and `plan_ready` sync' "$ROOT_DIR/subagents/claude/agents/plan-coordinator.md" \
+   && grep -Fq 'Blocker: requirement-conflict' "$ROOT_DIR/subagents/claude/agents/plan-coordinator.md"; then
+    pass "first-pass planning conflict bypasses missing-artifact processing"
+else
+    fail "first-pass planning conflict can enter normal plan-result processing"
+fi
+
+CLAUDE_BLOCKED_LAYER_LINE=$(grep -nF 'if any result has handoff_outcome: blocked_external:' "$ROOT_DIR/subagents/claude/agents/implement-coordinator.md" | head -1 | cut -d: -f1 || true)
+CLAUDE_FAILURE_LINE=$(grep -nF 'if any worker failed:' "$ROOT_DIR/subagents/claude/agents/implement-coordinator.md" | head -1 | cut -d: -f1 || true)
+if [[ -n "$CLAUDE_BLOCKED_LAYER_LINE" && -n "$CLAUDE_FAILURE_LINE" && "$CLAUDE_BLOCKED_LAYER_LINE" -lt "$CLAUDE_FAILURE_LINE" ]] \
+   && grep -Fq 'restore every unmerged task in this layer to pending' "$ROOT_DIR/subagents/claude/agents/implement-coordinator.md" \
+   && grep -Fq 'do not merge or commit the layer' "$ROOT_DIR/subagents/claude/agents/implement-coordinator.md" \
+   && grep -Fq 'Status: complete | partial | failed | blocked_external' "$ROOT_DIR/subagents/claude/agents/implement-coordinator.md"; then
+    pass "parallel implementation blocker stays pending and bypasses failure/merge"
+else
+    fail "parallel implementation blocker can be failed, merged, or committed"
+fi
+
+if grep -Fq 'Before editing, run the requirement consistency gate:' "$ROOT_DIR/subagents/codex/agents/implement-worker.toml" \
+   && grep -Fq 'embedded `## Research Context`' "$ROOT_DIR/subagents/codex/agents/implement-worker.toml" \
+   && grep -Fq 'return exactly `handoff_outcome: blocked_external` and' "$ROOT_DIR/subagents/codex/agents/implement-worker.toml" \
+   && grep -Fq 'check for `handoff_outcome: blocked_external`' "$ROOT_DIR/subagents/codex/agents/implement-coordinator.toml" \
+   && grep -Fq 'do not merge or commit any' "$ROOT_DIR/subagents/codex/agents/implement-coordinator.toml" \
+   && grep -Fq 'and `Blocker: requirement-conflict`' "$ROOT_DIR/subagents/codex/agents/implement-coordinator.toml"; then
+    pass "delegated Codex conflicts run the gate and return a first-class blocker"
+else
+    fail "delegated Codex conflicts can implement or enter normal completion"
+fi
+
 if grep -Fxq '## Requirements Reconciliation' "$AIF_PLAN_FORMAT_REF" \
    && grep -Fq 'REQUIREMENT EVIDENCE (when the Requirements Reconciliation Gate applies)' "$AIF_PLAN_FORMAT_REF" \
    && grep -Fxq '## Requirements Reconciliation' "$AIF_PLAN_ULTRA_REF" \

--- a/skills/aif-implement/SKILL.md
+++ b/skills/aif-implement/SKILL.md
@@ -28,7 +28,9 @@ Bash: printenv HANDOFF_SKIP_REVIEW || true
 The Handoff coordinator already manages status transitions and DB writes directly. Do NOT call MCP tools. Instead:
 
 - **No interactive questions:** Do not use `AskUserQuestion` — use sensible defaults (auto-commit at checkpoints, skip pause prompts).
-- **No pause/resume prompts:** Execute all tasks sequentially without stopping.
+- **No pause/resume prompts:** Execute all tasks sequentially without stopping
+  for confirmation. Blocking integrity, safety, or requirement conflicts still
+  stop with their defined non-interactive outcome.
 
 #### When `HANDOFF_MODE` is NOT `1` (manual Claude Code session)
 
@@ -576,15 +578,21 @@ silently make the architectural choice that ultra was meant to pre-plan.
 
 Before marking a behavior-changing task in progress:
 
-1. Read the plan's `## Requirements Reconciliation` section when present and
-   re-read the cited passages relevant to the current task.
+1. Read the plan's `## Requirements Reconciliation` section when present.
+   Resolve citations to the selected research source against the embedded
+   `## Research Context`, which remains the committed requirements snapshot.
+   Use the live research file only for the Step 0.2 drift warning; never use it
+   to change task requirements without an explicit rebase. Re-read relevant
+   passages from other cited authoritative sources.
 2. Apply a source-priority hierarchy only when it is declared by the user or
    project. Treat roadmap text as scope rather than a detailed contract unless
    explicitly declared otherwise.
 3. Compare the task's proposed behavior with the cited requirements. If they
    clearly conflict, emit `ERROR [requirement-conflict]`, leave the task pending,
-   and STOP for clarification. Do not implement first and rewrite a requirement
-   artifact afterwards.
+   and STOP. In manual mode, ask for clarification. In `HANDOFF_MODE=1`, do not
+   prompt; return `handoff_outcome: blocked_external` so the coordinator can
+   route the task, and do not signal implementation completion or review.
+   Do not implement first and rewrite a requirement artifact afterwards.
 4. If behavior depends on independent selectors, states, modes, or input shapes,
    confirm that the task covers each applicable supported combination across
    validation, persistence, output/transition, and side effects. Do not infer a
@@ -592,8 +600,8 @@ Before marking a behavior-changing task in progress:
 
 If an old plan lacks `## Requirements Reconciliation`, perform this gate from
 the task, Original Request, committed Research Context, project rules, and any
-authoritative sources they explicitly reference. Do not expand into unrelated
-research.
+authoritative sources they explicitly reference. The embedded Research Context
+still wins over its live drift source. Do not expand into unrelated research.
 
 **3.2: Mark as in_progress**
 

--- a/skills/aif-implement/SKILL.md
+++ b/skills/aif-implement/SKILL.md
@@ -572,6 +572,29 @@ merely because TaskGet contains a shorter summary. If phase instructions conflic
 with current code or project context, stop and report the concrete drift; do not
 silently make the architectural choice that ultra was meant to pre-plan.
 
+**3.1.1: Run the requirement consistency gate**
+
+Before marking a behavior-changing task in progress:
+
+1. Read the plan's `## Requirements Reconciliation` section when present and
+   re-read the cited passages relevant to the current task.
+2. Apply a source-priority hierarchy only when it is declared by the user or
+   project. Treat roadmap text as scope rather than a detailed contract unless
+   explicitly declared otherwise.
+3. Compare the task's proposed behavior with the cited requirements. If they
+   clearly conflict, emit `ERROR [requirement-conflict]`, leave the task pending,
+   and STOP for clarification. Do not implement first and rewrite a requirement
+   artifact afterwards.
+4. If behavior depends on independent selectors, states, modes, or input shapes,
+   confirm that the task covers each applicable supported combination across
+   validation, persistence, output/transition, and side effects. Do not infer a
+   restriction on one dimension from a rule about another.
+
+If an old plan lacks `## Requirements Reconciliation`, perform this gate from
+the task, Original Request, committed Research Context, project rules, and any
+authoritative sources they explicitly reference. Do not expand into unrelated
+research.
+
 **3.2: Mark as in_progress**
 
 ```
@@ -585,12 +608,20 @@ TaskUpdate(taskId, status: "in_progress")
 - Follow existing code patterns
 - **NO tests unless plan includes test tasks**
 - **NO reports or summaries**
+- Treat requirement, research, roadmap, rules, and architecture artifacts as
+  read-only unless the active task explicitly requires changing the owning
+  artifact. This does not block the factual context maintenance explicitly
+  allowed later in this workflow, but those updates must not change behavioral
+  requirements merely to match the implementation.
 
 **3.4: Verify implementation**
 
 - Check code compiles/runs
 - Verify functionality works
 - Fix any immediate issues
+- Run the verification scenarios assigned to the task. When a representative
+  repository artifact defines the contract, exercise that artifact through the
+  primary path rather than relying only on synthetic fixtures.
 
 **3.5: Mark as completed**
 

--- a/skills/aif-improve/SKILL.md
+++ b/skills/aif-improve/SKILL.md
@@ -63,7 +63,7 @@ Any generated or updated plan artifact content under `paths.plan`, `paths.plans`
 
 Exception: an existing `## Original Request` section is raw source input, not generated artifact prose. Preserve its heading and body exactly as read from the plan file on every edit or regeneration, even when `artifact_language` differs. Do not translate, summarize, normalize, trim, or rewrite it.
 
-Templates and examples define structure, not fixed English output. If `artifact_language` is not `en`, translate human-readable headings, labels, task prose, roadmap rationale, research summaries, improvement notes, and dependency notes before saving. Preserve markdown structure, checkbox syntax, task IDs, numeric prefixes, branch names, commit messages, commands, file paths, config keys, package names, API names, `WARN`/`INFO` labels, and raw errors unchanged. Keep `## Research Context`, `Source:`, `Active Summary`, `Updated:`, and `SHA256:` exact because downstream research drift checks parse them as compatibility tokens. Apply `technical_terms_policy` to other human-readable terminology.
+Templates and examples define structure, not fixed English output. If `artifact_language` is not `en`, translate human-readable headings, labels, task prose, roadmap rationale, research summaries, improvement notes, and dependency notes before saving. Preserve markdown structure, checkbox syntax, task IDs, numeric prefixes, branch names, commit messages, commands, file paths, config keys, package names, API names, `WARN`/`INFO` labels, and raw errors unchanged. Keep `## Research Context`, `Source:`, `Active Summary`, `Updated:`, and `SHA256:` exact because downstream research drift checks parse them as compatibility tokens. Keep `## Requirements Reconciliation` exact because downstream workflow checks parse it as a compatibility token. Apply `technical_terms_policy` to other human-readable terminology.
 
 **First parse arguments:**
 
@@ -256,6 +256,23 @@ Based on the tech stack and codebase:
 - Rate limiting, caching considerations
 - Data validation at boundaries
 
+**3.4: Reconcile requirements and behavior combinations**
+
+- Read any `## Requirements Reconciliation` section in the plan and verify its
+  cited source passages against the current authoritative context.
+- Follow a source-priority hierarchy only when the user or project declares it.
+  If conflicting sources have no declared authority, report the ambiguity
+  instead of choosing silently.
+- Treat roadmap items as scope indicators rather than detailed behavioral
+  contracts unless the project explicitly says otherwise.
+- When behavior depends on independent selectors, states, modes, or input
+  shapes, check the supported combinations across input validation, persistence,
+  output/transition, and side effects. Look for combinations that were described
+  separately but never verified together.
+- When real repository data, configuration, fixtures, schemas, or content define
+  the contract, check that the plan exercises a representative existing artifact
+  through the primary integration path.
+
 ### Step 4: Identify Improvements
 
 Compare the plan against what you found. Use `## Original Request` as the original intent / scope anchor when it exists, together with the current task list and any committed `## Research Context`. A proposed refinement is in scope only when it supports that original request or an explicitly approved user refinement prompt; otherwise route it to 4.6 (`out_of_scope`) instead of adding it to the active plan. Categorize issues:
@@ -269,6 +286,11 @@ Compare the plan against what you found. Use `## Original Request` as the origin
 - Missing logging requirements
 - Missing error handling details
 - Incorrect file paths
+- Missing or incorrect requirement citations, unresolved source conflicts, or a
+  missing `## Requirements Reconciliation` section when Step 3.4 requires one
+- Missing verification of a supported behavior combination or representative
+  real artifact. Respect the plan's testing setting: add a test only when testing
+  is enabled; otherwise add a runnable/manual verification step.
 
 **4.3: Dependency issues**
 - Wrong task order (task A depends on B but B comes after A)
@@ -424,6 +446,9 @@ The difference between the two is the report only. `removals` are dead-weight du
 - Preserve any `- [x]` checkboxes for already completed tasks
 - Preserve existing `## Original Request` exactly, including heading, body text, whitespace, and line breaks. Do not translate, summarize, normalize, trim, or rewrite it; this section is raw source input and is exempt from `artifact_language` rewriting.
 - Preserve existing `## Research Context` and its `Source:` / revision marker exactly on any rewrite, unless the user explicitly asks to rebase the plan to current research
+- Preserve or update `## Requirements Reconciliation` from current evidence;
+  keep the exact heading, declared authority, citations, applicable combination
+  table, and verification scenarios synchronized with the refined tasks
 - If an unlinked plan is refined using current research, add `## Research Context` by copying the relevant Active Summary and write ``Source: `<selected research path>` (Active Summary, Updated: <research Updated timestamp>, SHA256: <sha256 of copied Active Summary>)``
 - Compute that hash with the canonical drift normalization: remove HTML comment blocks, preserve line order and leading whitespace, trim trailing spaces from every line, use LF line endings, and end with exactly one final newline. Feed the normalized text to `shasum -a 256` or `sha256sum` through stdin / inline shell input, never through a temp file, and copy the first output field.
 - If a linked plan has research drift, keep the committed Research Context and source revision in the plan and include `WARN [research-drift]` in the refinement report
@@ -489,6 +514,9 @@ Suggest the user to free up context space if needed: `/clear` (full reset) or `/
 7. **User approves first** — never apply changes without user confirmation
 8. **Keep plan file in sync** — the plan file MUST match the task list after improvements
 9. **Original Request is immutable** — when present, use `## Original Request` to judge scope and preserve it verbatim on every plan edit or regeneration
+10. **Requirements remain external evidence** — never rewrite requirement,
+    research, roadmap, rules, or architecture artifacts to make the plan look
+    consistent; refine the plan or report the conflict.
 
 ## Examples
 

--- a/skills/aif-improve/SKILL.md
+++ b/skills/aif-improve/SKILL.md
@@ -25,7 +25,7 @@ enhanced plan with better tasks, correct dependencies, more detail
 ### Step 0: Load Config & Parse Arguments
 
 **FIRST:** Read `.ai-factory/config.yaml` if it exists to resolve:
-- **Paths:** `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.research`, `paths.description`, `paths.patches`, and `paths.archive`; derive `research_bundles_dir = <parent directory of paths.research>/research/`
+- **Paths:** `paths.plan`, `paths.plans`, `paths.fix_plan`, `paths.research`, `paths.description`, `paths.architecture`, `paths.roadmap`, `paths.rules_file`, `paths.rules`, `paths.patches`, and `paths.archive`; derive `research_bundles_dir = <parent directory of paths.research>/research/`
 - **Language:** `language.ui` for prompts and summaries, `language.artifacts` for plan artifact updates, and `language.technical_terms` for human-readable technical terminology in plan artifacts
 - **Git:** `git.enabled`, `git.base_branch`, `git.create_branches`
 - **Workflow:** `workflow.plan_id_format` (default: `slug`) — used by branch-based plan discovery.
@@ -45,6 +45,10 @@ If config.yaml doesn't exist, use defaults:
 - research: `.ai-factory/RESEARCH.md`
 - patches/: `.ai-factory/patches/`
 - DESCRIPTION.md: `.ai-factory/DESCRIPTION.md`
+- architecture: `.ai-factory/ARCHITECTURE.md`
+- roadmap: `.ai-factory/ROADMAP.md`
+- rules file: `.ai-factory/RULES.md`
+- rules directory: `.ai-factory/rules/`
 - `ui_language`: `en`
 - `artifact_language`: `en`
 - `technical_terms_policy`: `keep`
@@ -169,6 +173,12 @@ Read `.ai-factory/DESCRIPTION.md` (use path from config) if it exists:
 - Conventions
 - Non-functional requirements
 
+Read the resolved architecture and roadmap artifacts when present. Read the
+resolved rules hierarchy in order: `paths.rules_file`, `rules.base`, then named
+`rules.<area>` entries relevant to the plan. More-specific rules override
+general ones. Treat roadmap text as scope unless the project explicitly declares
+it authoritative for detailed behavior.
+
 If the plan contains `## Research Context`, treat its embedded copy as the committed requirements snapshot. Parse the first `Source:` / `Reference:` line with canonical `^(?:Source|Reference):\s+\x60([^\x60]+)\x60\s+\(` syntax; for older bare-path lines, fall back to `^(?:Source|Reference):\s+(.+?)\s+\(`. Fall back to configured `paths.research` only when neither form identifies a usable path.
 
 If the parsed source is inside `research_bundles_dir`, require its sibling `INDEX.md` to contain `<!-- aif:research-mode:ultra -->` exactly once and link that `RESEARCH.md` from `## Artifact Index`; otherwise emit `WARN [research-drift]`. Valid sibling C4/ADR/dependency artifacts are rationale only and must not expand plan scope.
@@ -258,8 +268,11 @@ Based on the tech stack and codebase:
 
 **3.4: Reconcile requirements and behavior combinations**
 
-- Read any `## Requirements Reconciliation` section in the plan and verify its
-  cited source passages against the current authoritative context.
+- Read any `## Requirements Reconciliation` section in the plan. Resolve
+  research-backed citations against the embedded `## Research Context`; the
+  live research source is only a drift signal unless the user explicitly asks
+  to rebase. Verify other cited passages against the current authoritative
+  context.
 - Follow a source-priority hierarchy only when the user or project declares it.
   If conflicting sources have no declared authority, report the ambiguity
   instead of choosing silently.
@@ -446,9 +459,12 @@ The difference between the two is the report only. `removals` are dead-weight du
 - Preserve any `- [x]` checkboxes for already completed tasks
 - Preserve existing `## Original Request` exactly, including heading, body text, whitespace, and line breaks. Do not translate, summarize, normalize, trim, or rewrite it; this section is raw source input and is exempt from `artifact_language` rewriting.
 - Preserve existing `## Research Context` and its `Source:` / revision marker exactly on any rewrite, unless the user explicitly asks to rebase the plan to current research
-- Preserve or update `## Requirements Reconciliation` from current evidence;
-  keep the exact heading, declared authority, citations, applicable combination
-  table, and verification scenarios synchronized with the refined tasks
+- Preserve or update `## Requirements Reconciliation` from the plan's committed
+  evidence; keep the exact heading, declared authority, citations, applicable
+  combination table, and verification scenarios synchronized with the refined
+  tasks. When linked research has drifted, preserve its research-backed
+  decisions until the user explicitly requests a rebase; only that rebase may
+  update them from the live research source
 - If an unlinked plan is refined using current research, add `## Research Context` by copying the relevant Active Summary and write ``Source: `<selected research path>` (Active Summary, Updated: <research Updated timestamp>, SHA256: <sha256 of copied Active Summary>)``
 - Compute that hash with the canonical drift normalization: remove HTML comment blocks, preserve line order and leading whitespace, trim trailing spaces from every line, use LF line endings, and end with exactly one final newline. Feed the normalized text to `shasum -a 256` or `sha256sum` through stdin / inline shell input, never through a temp file, and copy the first output field.
 - If a linked plan has research drift, keep the committed Research Context and source revision in the plan and include `WARN [research-drift]` in the refinement report

--- a/skills/aif-plan/SKILL.md
+++ b/skills/aif-plan/SKILL.md
@@ -142,6 +142,15 @@ Use this context when:
 - Planning file structure (follow project conventions)
 - **Follow architecture guidelines from the resolved architecture artifact when planning file structure and task organization**
 
+**ALSO:** Read the resolved rules hierarchy when present:
+
+1. `paths.rules_file` — project-wide axioms
+2. `rules.base` — base project conventions
+3. named `rules.<area>` entries relevant to the requested work
+
+Treat explicit rules as authoritative requirements. More-specific area rules
+override base rules, which override project-wide axioms.
+
 **Read `.ai-factory/skill-context/aif-plan/SKILL.md`** — MANDATORY if the file exists.
 
 This file contains project-specific rules accumulated by `/aif-evolve` from patches,
@@ -631,8 +640,12 @@ implementation:
    If no hierarchy exists, do not silently choose between conflicting sources.
 3. Record each material behavioral rule with its source path/section. When two
    sources overlap, state whether they agree, one refines the other, or they
-   conflict. Ask the user and STOP when an unresolved conflict would change the
-   implementation.
+   conflict. When an unresolved conflict would change the implementation:
+   - manual mode → ask the user and STOP;
+   - `HANDOFF_MODE=1` → do not prompt. Emit
+     `ERROR [requirement-conflict]`, return
+     `handoff_outcome: blocked_external`, and STOP without publishing or
+     signaling `plan_ready`.
 4. Do not edit source requirements while creating the plan. Report stale or
    contradictory artifacts and route them to their owner command or the user.
 

--- a/skills/aif-plan/SKILL.md
+++ b/skills/aif-plan/SKILL.md
@@ -117,7 +117,7 @@ All AskUserQuestion prompts, progress updates, summaries, and next-step guidance
 Generated plan artifacts under `paths.plan` or `paths.plans` MUST be written in `artifact_language`.
 For ultra this applies to `index.md` and every linked phase file.
 
-Templates and examples define structure, not fixed English output. If `artifact_language` is not `en`, translate human-readable headings, labels, task prose, roadmap rationale, research summaries, settings explanations, and dependency notes before saving. Preserve markdown structure, checkbox syntax, task IDs, branch names, commit messages, commands, file paths, config keys, package names, API names, `WARN`/`INFO` labels, raw errors, and the exact ultra marker `<!-- aif:plan-mode:ultra -->` unchanged. Keep `## Research Context`, `Source:`, `Active Summary`, `Updated:`, and `SHA256:` exact because downstream research drift checks parse them as compatibility tokens. Apply `technical_terms_policy` to other human-readable terminology.
+Templates and examples define structure, not fixed English output. If `artifact_language` is not `en`, translate human-readable headings, labels, task prose, roadmap rationale, research summaries, settings explanations, and dependency notes before saving. Preserve markdown structure, checkbox syntax, task IDs, branch names, commit messages, commands, file paths, config keys, package names, API names, `WARN`/`INFO` labels, raw errors, and the exact ultra marker `<!-- aif:plan-mode:ultra -->` unchanged. Keep `## Research Context`, `Source:`, `Active Summary`, `Updated:`, and `SHA256:` exact because downstream research drift checks parse them as compatibility tokens. Keep `## Requirements Reconciliation` exact because downstream workflow checks parse it as a compatibility token. Apply `technical_terms_policy` to other human-readable terminology.
 
 Exception: the section heading and body of `## Original Request` are fixed raw-source structure and must not be translated, summarized, normalized, or rewritten.
 
@@ -620,6 +620,45 @@ I need a few clarifications before creating the plan:
 2. [Question about approach]
 ```
 
+#### Requirements Reconciliation Gate
+
+For work governed by existing requirements, reconcile them before exploring an
+implementation:
+
+1. Treat roadmap items and task summaries as scope indicators, not detailed
+   behavioral contracts, unless the project explicitly declares otherwise.
+2. Follow any source-priority hierarchy declared by the user or project context.
+   If no hierarchy exists, do not silently choose between conflicting sources.
+3. Record each material behavioral rule with its source path/section. When two
+   sources overlap, state whether they agree, one refines the other, or they
+   conflict. Ask the user and STOP when an unresolved conflict would change the
+   implementation.
+4. Do not edit source requirements while creating the plan. Report stale or
+   contradictory artifacts and route them to their owner command or the user.
+
+When behavior depends on two or more independent selectors, states, modes, or
+input shapes, enumerate the supported combinations before writing tasks. Cover
+only combinations allowed by the requirements, not a speculative Cartesian
+product. For each material combination specify:
+
+- accepted input and validation;
+- persisted state;
+- returned output or next transition;
+- side effects and invariants;
+- one verification scenario. If testing is enabled, make it a test; otherwise
+  provide a runnable/manual verification step without adding a test task.
+
+When repository data, configuration, fixtures, schemas, or content define the
+real contract, include at least one representative existing artifact in an
+end-to-end verification path instead of validating only synthetic fixtures.
+
+Add an exact `## Requirements Reconciliation` section to the plan entrypoint
+when multiple authoritative sources materially constrain the work, a conflict
+was resolved, independent behavior dimensions exist, or a representative real
+artifact is required. Keep it compact: declared authority, cited decisions,
+applicable combination table, and verification evidence. Omit it for simple
+work where none of these signals applies.
+
 ### Step 3: Explore Codebase
 
 Before planning, understand the existing code through **parallel exploration**.
@@ -727,6 +766,7 @@ For ultra also create the resolved bundle directory before writing its files.
 - `Settings` section (Testing, Logging, Docs)
 - `Roadmap Linkage` section (optional, only if the resolved roadmap artifact exists)
 - `Research Context` section (optional, only if research content influenced this plan)
+- `Requirements Reconciliation` section (conditional, when required by the gate in Step 2)
 - `Tasks` section grouped by phases; in ultra this is the only task-checkbox source
 - `Commit Plan` section when there are 5+ tasks
 
@@ -874,6 +914,8 @@ Every `TaskCreate` item MUST include:
 - File paths to change/create
 - Logging requirements (what to log, where, and levels)
 - Dependency notes when applicable
+- Requirement source anchors and applicable behavior combinations when the
+  Requirements Reconciliation Gate applies
 
 **Never create tasks without logging instructions.**
 
@@ -898,6 +940,9 @@ Use canonical examples in `references/TASK-FORMAT.md`:
    sequential prefix from Step 1.2; `timestamp` and `uuid` fall back to `slug`.
 9. **Ownership boundary** – This command owns plan artifacts only (the resolved fast plan path and full/ultra artifacts under `paths.plans`). Use owner commands (`/aif-roadmap`, `/aif-rules`, `/aif-explore`) for their artifacts.
 10. **Roadmap linkage (when available)** — If the resolved roadmap artifact exists, include a `## Roadmap Linkage` section in the plan (or explicitly state it was skipped).
+11. **Reconcile before planning** — Do not let a roadmap summary, lower-priority
+    source, or internally consistent implementation override an unresolved
+    behavioral requirement.
 
 ## Plan File Handling
 

--- a/skills/aif-plan/references/TASK-FORMAT.md
+++ b/skills/aif-plan/references/TASK-FORMAT.md
@@ -55,6 +55,14 @@ Constraints:
 Decisions:
 Open questions:
 
+## Requirements Reconciliation
+<!-- Include when multiple authoritative sources constrain behavior, a conflict was resolved, independent behavior dimensions exist, or a representative repository artifact is required. Keep this exact heading. -->
+Authority: [declared source priority, or "none declared"]
+
+| Decision / supported combination | Source path and section | Verification evidence |
+|----------------------------------|-------------------------|-----------------------|
+| [material rule or combination] | `[path]` — [section] | [test, command, or manual check] |
+
 ## Commit Plan
 <!-- For plans with 5+ tasks, define commit checkpoints -->
 - **Commit 1** (after tasks 1-3): "feat: add base models and types"
@@ -97,6 +105,11 @@ TaskCreate:
     - Use log levels (DEBUG/INFO/WARN/ERROR)
 
     Files: src/api/auth/login.ts, src/services/auth.ts
+
+    REQUIREMENT EVIDENCE (when the Requirements Reconciliation Gate applies):
+    - Source: `docs/auth.md` — Login contract
+    - Supported combinations: valid/invalid credentials × active/disabled user
+    - Verification: exercise each supported combination through POST /api/auth/login
   activeForm: "Implementing login endpoint"
 ```
 

--- a/skills/aif-plan/references/ULTRA-FORMAT.md
+++ b/skills/aif-plan/references/ULTRA-FORMAT.md
@@ -70,6 +70,13 @@ Rationale: [one sentence]
 Source: `.ai-factory/RESEARCH.md` (Active Summary, Updated: ..., SHA256: ...)
 [committed Active Summary copy]
 
+## Requirements Reconciliation
+Authority: [declared source priority, or "none declared"]
+
+| Decision / supported combination | Source path and section | Verification evidence |
+|----------------------------------|-------------------------|-----------------------|
+| [material rule or combination] | `[path]` — [section] | [test, command, or manual check] |
+
 ## Architecture and Decisions
 - [Cross-phase boundary, contract, or implementation decision]
 
@@ -148,6 +155,10 @@ Depends on: none | Phase N / Task N
 - Compatibility requirements and invariants.
 - Include concise pseudocode when prose leaves meaningful ambiguity.
 
+### Requirement Evidence (when reconciliation applies)
+- Source anchors for each material behavioral rule.
+- Applicable supported combinations and their verification scenarios.
+
 ### Error Handling and Logging
 - Failure modes and expected behavior.
 - Log events, levels, safe fields, and sensitive fields that must not be logged.
@@ -186,7 +197,9 @@ Before saving an ultra bundle, verify every task has all of the following:
 5. Tests and commands when testing is enabled; an explicit no-test statement
    when testing is disabled.
 6. Observable acceptance criteria and verification commands/checks.
-7. No unresolved implementation choice hidden behind words such as "handle",
+7. Requirement source anchors and applicable supported combinations when the
+   Requirements Reconciliation Gate applies.
+8. No unresolved implementation choice hidden behind words such as "handle",
    "support", "wire up", "as needed", or "etc." If a decision truly cannot be
    made during planning, record it as a blocking open question in `index.md`
    instead of delegating the guess to the implementer.

--- a/skills/aif-verify/SKILL.md
+++ b/skills/aif-verify/SKILL.md
@@ -289,13 +289,17 @@ Only lint the changed files to keep output focused.
 Verify the full chain `authoritative requirements → plan → implementation →
 verification evidence`, not only plan-to-code agreement.
 
-1. If the plan contains `## Requirements Reconciliation`, re-read its cited
-   source passages. Otherwise use the Original Request, committed Research
-   Context, project rules, and authoritative sources they explicitly reference.
+1. If the plan contains `## Requirements Reconciliation`, resolve citations to
+   the selected research source against the embedded `## Research Context`; the
+   live research file remains drift-only unless the user explicitly rebases the
+   plan. Re-read other cited source passages. Otherwise use the Original Request,
+   committed Research Context, project rules, and authoritative sources they
+   explicitly reference.
 2. Follow a source-priority hierarchy only when declared by the user or project.
    Treat roadmap text as scope rather than a detailed behavioral contract unless
    explicitly declared otherwise. If sources conflict without declared
-   authority, emit `WARN [requirement-ambiguity]` instead of guessing.
+   authority, do not guess: emit `WARN [requirement-ambiguity]` in normal or
+   lenient mode, and `ERROR [requirement-ambiguity]` in strict mode.
 3. A clear contradiction between the implementation and a higher-priority
    requirement is `ERROR [requirement-conflict]` and blocks verification even
    when the plan, code, and tests agree with one another.
@@ -585,7 +589,8 @@ When invoked with `--strict`:
 - **Rules gate must pass** — fail on clear rule violations
 - **Roadmap gate must pass** — fail on clear roadmap mismatch
 - **Requirements consistency gate must pass** — fail on clear requirement
-  conflicts or missing evidence for material supported combinations
+  conflicts, unresolved source ambiguity, or missing evidence for material
+  supported combinations
 - Missing milestone linkage for `feat`/`fix`/`perf` is a warning even in strict mode
 - Do not fail strict verification solely because milestone linkage is missing
 

--- a/skills/aif-verify/SKILL.md
+++ b/skills/aif-verify/SKILL.md
@@ -284,6 +284,33 @@ Only lint the changed files to keep output focused.
 
 ## Step 3: Consistency Checks
 
+### 3.0 Requirements Provenance and Semantic Consistency
+
+Verify the full chain `authoritative requirements → plan → implementation →
+verification evidence`, not only plan-to-code agreement.
+
+1. If the plan contains `## Requirements Reconciliation`, re-read its cited
+   source passages. Otherwise use the Original Request, committed Research
+   Context, project rules, and authoritative sources they explicitly reference.
+2. Follow a source-priority hierarchy only when declared by the user or project.
+   Treat roadmap text as scope rather than a detailed behavioral contract unless
+   explicitly declared otherwise. If sources conflict without declared
+   authority, emit `WARN [requirement-ambiguity]` instead of guessing.
+3. A clear contradiction between the implementation and a higher-priority
+   requirement is `ERROR [requirement-conflict]` and blocks verification even
+   when the plan, code, and tests agree with one another.
+4. When behavior depends on independent selectors, states, modes, or input
+   shapes, enumerate only the supported combinations and verify each material
+   combination across validation, persistence, output/transition, and side
+   effects. Separate tests for each dimension do not prove their interaction.
+5. When repository data, configuration, fixtures, schemas, or content define the
+   contract, verify at least one representative existing artifact through the
+   primary integration path when such an artifact is available and relevant.
+
+Respect the plan's testing setting. If tests were intentionally skipped, use
+static inspection plus the plan's runnable/manual verification evidence; report
+missing evidence as a warning in normal mode and a failure in strict mode.
+
 ### 3.1 Plan vs Code Drift
 
 Check for discrepancies between what the plan says and what was built:
@@ -421,6 +448,11 @@ Write the human-readable verification report in `ui_language`. The template belo
 - Tests: ✅ 42 passed, 0 failed
 - Lint: ⚠️ 2 warnings in src/api/auth/reset.ts
 
+### Requirements Consistency
+- Source reconciliation: ✅ Passes
+- Supported combinations: ✅ Covered
+- Representative artifact path: ✅ Verified / ⏭️ Not applicable
+
 ### Issues Found
 1. **Task #3 incomplete** — Password reset endpoint created but email sending not implemented (SendGrid integration missing)
 2. **Task #8 not done** — API documentation not updated despite plan requirement
@@ -552,6 +584,8 @@ When invoked with `--strict`:
 - **Architecture gate must pass** — fail on clear boundary/dependency violations
 - **Rules gate must pass** — fail on clear rule violations
 - **Roadmap gate must pass** — fail on clear roadmap mismatch
+- **Requirements consistency gate must pass** — fail on clear requirement
+  conflicts or missing evidence for material supported combinations
 - Missing milestone linkage for `feat`/`fix`/`perf` is a warning even in strict mode
 - Do not fail strict verification solely because milestone linkage is missing
 

--- a/subagents/claude/agents/implement-coordinator.md
+++ b/subagents/claude/agents/implement-coordinator.md
@@ -42,6 +42,9 @@ Bash: printenv HANDOFF_SKIP_REVIEW || true
 **When `HANDOFF_MODE` is `1`** (autonomous Handoff agent):
 
 The Handoff coordinator already manages status transitions and DB writes directly. Do NOT call MCP tools. Skip all interactive prompts and use defaults.
+If requirement reconciliation returns `handoff_outcome: blocked_external`, stop
+dispatch, propagate `blocker: requirement-conflict`, and never signal `review`
+or `done`.
 
 **When `HANDOFF_MODE` is NOT `1`** (manual Claude Code session):
 

--- a/subagents/claude/agents/implement-coordinator.md
+++ b/subagents/claude/agents/implement-coordinator.md
@@ -43,8 +43,9 @@ Bash: printenv HANDOFF_SKIP_REVIEW || true
 
 The Handoff coordinator already manages status transitions and DB writes directly. Do NOT call MCP tools. Skip all interactive prompts and use defaults.
 If requirement reconciliation returns `handoff_outcome: blocked_external`, stop
-dispatch, propagate `blocker: requirement-conflict`, and never signal `review`
-or `done`.
+dispatch, propagate `blocker: requirement-conflict`, leave or restore the task
+to pending, and never signal `review` or `done`. Treat this separately from a
+worker failure: do not mark the task failed or merge or commit its layer.
 
 **When `HANDOFF_MODE` is NOT `1`** (manual Claude Code session):
 
@@ -152,6 +153,10 @@ When dispatching a task to a worker, change its checkbox from `[ ]` to `[~]` and
 ### Timing
 
 - Write parallelism markers once after plan parsing, before the first dispatch.
+- Run the `aif-implement` requirement consistency gate for every ready task
+  before changing `[ ]` to `[~]` or dispatching it. On an autonomous conflict,
+  leave the task pending and return `handoff_outcome: blocked_external` with
+  `blocker: requirement-conflict`.
 - Update task status in the plan entrypoint immediately before dispatching each layer and immediately after collecting results.
 - This ensures the progress source (`index.md` for ultra) always reflects the current state — if the session crashes, the user sees exactly which tasks were in flight.
 
@@ -163,12 +168,20 @@ while remaining is not empty:
     ready = tasks in remaining whose dependencies are all completed
     if len(ready) == 0:
         ERROR: circular dependency or missing prerequisite — stop and report
+    run requirement consistency preflight for every ready task before status changes
+    if any preflight returns handoff_outcome: blocked_external:
+        leave every blocked task pending and stop with blocker: requirement-conflict
+    mark ready tasks in progress
     if len(ready) == 1:
         implement the task directly (see "Single-task execution" below)
     if len(ready) > 1:
         launch `implement-worker` for EACH ready task in parallel
     wait for all workers to finish
     collect results: successes, failures, warnings
+    if any result has handoff_outcome: blocked_external:
+        restore every unmerged task in this layer to pending
+        do not merge or commit the layer
+        stop with Status: blocked_external and Blocker: requirement-conflict
     if any worker failed:
         stop and report — do not advance to next layer
     mark completed tasks
@@ -186,15 +199,17 @@ Repo-specific rules:
 
 Workflow for single-task execution:
 1. Identify the single target task.
-2. Implement the target task using direct tool calls (Read, Write, Edit, Glob, Grep, Bash).
-3. Run one `aif-verify`-compatible verification pass scoped to the changed files.
-4. Launch read-only quality sidecars in background on the changed scope:
+2. Run the injected `aif-implement` requirement consistency gate. Do not mark
+   the task in progress or edit files until it passes.
+3. Implement the target task using direct tool calls (Read, Write, Edit, Glob, Grep, Bash).
+4. Run one `aif-verify`-compatible verification pass scoped to the changed files.
+5. Launch read-only quality sidecars in background on the changed scope:
     - `review-sidecar` — correctness, regression, performance risks — **skip if `HANDOFF_SKIP_REVIEW=1`**
     - `security-sidecar` — security audit — **skip if `HANDOFF_SKIP_REVIEW=1`**
     - `rules-sidecar` — project rules compliance check — **skip if `HANDOFF_SKIP_REVIEW=1`; this is intentional because Handoff uses that flag as a broad review-family bypass**
     - `best-practices-sidecar` — maintainability problems
-5. Near completion, also launch `docs-auditor` and `commit-preparer` to assess follow-ups.
-6. Feed only material findings back into the next refinement round:
+6. Near completion, also launch `docs-auditor` and `commit-preparer` to assess follow-ups.
+7. Feed only material findings back into the next refinement round:
     - verification failures
     - build/test/lint failures
     - security issues
@@ -202,8 +217,8 @@ Workflow for single-task execution:
     - clear architecture/rules violations
     - concrete best-practice problems in changed code
     - any verdict-style sidecar result with `Verdict: FAIL`; treat `Verdict: WARN` as non-blocking unless it identifies an explicit hard blocker
-7. If a material blocker remains, fix and re-verify (max 2 refinement rounds).
-8. Do not loop forever on cosmetic advice alone.
+8. If a material blocker remains, fix and re-verify (max 2 refinement rounds).
+9. Do not loop forever on cosmetic advice alone.
 
 ## Parallel dispatch rules
 
@@ -218,10 +233,14 @@ Workflow for single-task execution:
 ## Merge strategy
 
 After parallel workers complete:
-1. Review each worker's summary for conflicts (overlapping files modified).
-2. If no conflicts: merge worktree branches sequentially into the working branch.
-3. If conflicts detected: stop, report the conflict, and ask the user how to proceed.
-4. Run a single verification pass (`/aif-verify` equivalent) on the merged result.
+1. Check every worker result for `handoff_outcome: blocked_external` before
+   normal failure or conflict handling. If present, restore all unmerged layer
+   tasks to `[ ]`, do not merge or commit any branch from that layer, and return
+   `blocker: requirement-conflict` unchanged.
+2. Review each worker's summary for conflicts (overlapping files modified).
+3. If no conflicts: merge worktree branches sequentially into the working branch.
+4. If conflicts detected: stop, report the conflict, and ask the user how to proceed.
+5. Run a single verification pass (`/aif-verify` equivalent) on the merged result.
 
 ## Commit handling
 
@@ -272,7 +291,7 @@ Completed: N
 Failed: N
 Layers executed: N (M parallel, K sequential)
 Commits created: N
-Status: complete | partial | failed
+Status: complete | partial | failed | blocked_external
 Remaining tasks: [list if any]
 
 ⏎ This agent session is complete. Please close it (Ctrl+C or /exit)
@@ -280,3 +299,7 @@ Remaining tasks: [list if any]
   Do NOT use /clear — it resets context but keeps the agent session alive,
   which wastes tokens and may cause confusion.
 ```
+
+For `blocked_external`, also emit `Blocker: requirement-conflict`. Do not run
+post-implementation gates, final commits, plan pushes, or `review` / `done`
+status transitions for that blocked layer.

--- a/subagents/claude/agents/plan-coordinator.md
+++ b/subagents/claude/agents/plan-coordinator.md
@@ -49,7 +49,7 @@ Do this even though `HANDOFF_MODE` stays unset or non-`1` in manual sessions. Th
 If a task ID IS found in the plan annotation, sync with Handoff via MCP tools:
 
 - **On start (before first plan-polisher):** Call `handoff_sync_status` with `{ taskId: <extracted-id>, newStatus: "planning", sourceTimestamp: "<current UTC time in ISO 8601 format>", direction: "aif_to_handoff", paused: true }`.
-- **On completion (after final iteration):** Read the final plan artifact, then call `handoff_push_plan`. For fast/full, `planContent` is the file text. For ultra, serialize `index.md` followed by every Phase Index file in order, each prefixed with `<!-- ultra-phase:<relative-path> -->`. Then call `handoff_sync_status` with `{ taskId: <extracted-id>, newStatus: "plan_ready", sourceTimestamp: "<current UTC time in ISO 8601 format>", direction: "aif_to_handoff", paused: true }`.
+- **On successful completion (after final iteration):** Read the final plan artifact, then call `handoff_push_plan`. For fast/full, `planContent` is the file text. For ultra, serialize `index.md` followed by every Phase Index file in order, each prefixed with `<!-- ultra-phase:<relative-path> -->`. Then call `handoff_sync_status` with `{ taskId: <extracted-id>, newStatus: "plan_ready", sourceTimestamp: "<current UTC time in ISO 8601 format>", direction: "aif_to_handoff", paused: true }`. If any polisher result is `status: blocked_external`, skip the final artifact read, `handoff_push_plan`, and `plan_ready` sync.
 
 **CRITICAL:** Always pass `paused: true` with every `handoff_sync_status` call except `done`. This prevents the autonomous Handoff agent from picking up the task while you work manually. Only `done` passes `paused: false`.
 
@@ -82,7 +82,10 @@ iteration = 0
 
 # First pass: create the plan
 launch plan-polisher with the user's original request
-collect result → extract plan_path, needs_further_refinement, issues list
+collect result
+if result.status == blocked_external:
+    preserve result.blocker unchanged and go directly to Blocked output
+extract plan_path, needs_further_refinement, issues list
 verify plan artifact exists on disk; before normalizing an existing directory or
 explicit index.md as ultra, read index.md and require exactly one
 <!-- aif:plan-mode:ultra --> marker — otherwise stop with a plan-integrity error
@@ -94,11 +97,19 @@ while needs_further_refinement == yes AND iteration < max_iterations:
         "Critique and improve the existing plan at {plan_path}.
          Focus on these remaining issues: {issues list from previous iteration}.
          Do NOT recreate the plan from scratch — refine what exists."
-    collect result → extract needs_further_refinement, issues list
+    collect result
+    if result.status == blocked_external:
+        preserve result.blocker unchanged and go directly to Blocked output
+    extract needs_further_refinement, issues list
 
 # Done
 read final plan artifact (all linked files for ultra)
 report summary
+
+# Blocked
+do not extract or validate plan_path
+do not read or publish a final plan artifact
+report Status: blocked_external and Blocker: requirement-conflict
 ```
 
 ## Dispatch rules
@@ -133,9 +144,11 @@ After each iteration, compare the current issues list with the previous one. If 
 
 ## Plan file tracking
 
-After the first plan-polisher run, confirm the plan artifact exists and note its
-stable path. An ultra path may be its directory or `index.md`; normalize it once
-and track the same bundle throughout all subsequent iterations.
+After the first non-blocked plan-polisher result, confirm the plan artifact
+exists and note its stable path. Never extract, normalize, or validate a plan
+path from a `blocked_external` result. An ultra path may be its directory or
+`index.md`; normalize it once and track the same bundle throughout all
+subsequent iterations.
 
 ## Output
 
@@ -147,18 +160,26 @@ Iteration N/M: [created|refined] — needs_further_refinement: yes/no
   [list of remaining issues, if any]
 ```
 
-Final output:
+Final output for every non-blocked result:
 
 ```
 Plan: <plan path>
 Iterations: N (max: M)
-Status: ready | needs-work | stagnated | error | blocked_external
+Status: ready | needs-work | stagnated | error
 Remaining issues: [list or "none"]
 
 ⏎ This agent session is complete. Please close it (Ctrl+C or /exit)
   and return to your main Claude Code session to continue working.
   Do NOT use /clear — it resets context but keeps the agent session alive,
   which wastes tokens and may cause confusion.
+```
+
+For `blocked_external`, output only the deterministic blocker result; a plan
+path may not exist:
+
+```
+Status: blocked_external
+Blocker: requirement-conflict
 ```
 
 If status is `needs-work`, include actionable next steps so the user knows what to address manually.

--- a/subagents/claude/agents/plan-coordinator.md
+++ b/subagents/claude/agents/plan-coordinator.md
@@ -123,6 +123,9 @@ Stop the loop when ANY of these is true:
 2. `iteration >= max_iterations` — refinement budget exhausted.
 3. Two consecutive iterations produced no material changes — stagnation detected.
 4. plan-polisher returned an error.
+5. plan-polisher returned `status: blocked_external` — propagate its blocker
+   unchanged, do not continue refinement, and never publish or signal
+   `plan_ready`.
 
 ## Stagnation detection
 
@@ -149,7 +152,7 @@ Final output:
 ```
 Plan: <plan path>
 Iterations: N (max: M)
-Status: ready | needs-work | stagnated | error
+Status: ready | needs-work | stagnated | error | blocked_external
 Remaining issues: [list or "none"]
 
 ⏎ This agent session is complete. Please close it (Ctrl+C or /exit)

--- a/subagents/claude/agents/plan-polisher.md
+++ b/subagents/claude/agents/plan-polisher.md
@@ -53,6 +53,9 @@ Bash: printenv HANDOFF_BRANCH_NAME || true
 
 **When `HANDOFF_MODE` is `1`** (autonomous Handoff agent):
 - **No interactive prompts:** Use defaults — do not attempt to ask the user questions.
+- If authoritative requirements conflict and need a user decision, do not
+  prompt or mark the plan ready. Stop and return exactly:
+  `status: blocked_external` and `blocker: requirement-conflict`.
 - **Plan annotation (MANDATORY):** If `HANDOFF_TASK_ID` is non-empty, you MUST insert `<!-- handoff:task:<HANDOFF_TASK_ID> -->` as the very first line of the plan entrypoint (`index.md` for ultra), before the title. This annotation links the plan to its Handoff task for bidirectional sync. **Omitting this annotation when HANDOFF_TASK_ID is set is a bug.**
 
 **Branch ownership under Handoff (CRITICAL):**

--- a/subagents/codex/agents/implement-coordinator.toml
+++ b/subagents/codex/agents/implement-coordinator.toml
@@ -34,6 +34,9 @@ Rules:
 Handoff integration:
 - Treat any explicit `HANDOFF_MODE:`, `HANDOFF_TASK_ID:`, and `HANDOFF_SKIP_REVIEW:` text in the parent prompt as authoritative context.
 - When `HANDOFF_MODE: 1`, you are running inside the autonomous Handoff pipeline. Do not ask interactive questions, do not stop for confirmations, and do not perform Handoff MCP sync yourself. The parent Handoff coordinator already owns task status transitions and database writes.
+- If requirement reconciliation returns `handoff_outcome: blocked_external`,
+  stop dispatch, propagate `blocker: requirement-conflict`, and never report or
+  signal `review` or `done`.
 - In autonomous mode, pass `HANDOFF_MODE` and `HANDOFF_SKIP_REVIEW` through to every delegated `implement-worker` request as explicit text. Workers never own Handoff sync.
 - When `HANDOFF_MODE` is absent or not `1`, treat the run as a manual Codex session. If the plan entrypoint contains a `<!-- handoff:task:<id> -->` annotation, Handoff MCP sync is required; if the tools are unavailable, return a blocking integration error instead of silently skipping sync.
 - For a linked manual plan, call `handoff_sync_status` with `implementing` and `paused: true` before dispatch. After each completed layer, call `handoff_push_plan`. On completion, push the final plan and sync `review` with `paused: true`, or `done` with `paused: false` when `HANDOFF_SKIP_REVIEW: 1`. Use the actual UTC timestamp and `direction: "aif_to_handoff"` for status calls.

--- a/subagents/codex/agents/implement-coordinator.toml
+++ b/subagents/codex/agents/implement-coordinator.toml
@@ -30,13 +30,22 @@ Rules:
   update task progress only in `index.md`.
 - Pass an ultra worker the normalized entrypoint, matching phase file, and
   complete Task N specification. Treat the bundle as the executable contract.
+- Before marking or executing each ready task, run the requirement consistency
+  gate from `aif-implement` against the plan's authoritative sources. If it
+  returns `handoff_outcome: blocked_external`, leave the task pending and stop
+  before editing or dispatching.
+- After delegated workers return, check for `handoff_outcome: blocked_external`
+  before normal failure, merge, commit, review, or completion handling. Restore
+  every unmerged task in that layer to pending, do not merge or commit any
+  branch from the blocked layer, and emit exactly `Status: blocked_external`
+  and `Blocker: requirement-conflict`.
 
 Handoff integration:
 - Treat any explicit `HANDOFF_MODE:`, `HANDOFF_TASK_ID:`, and `HANDOFF_SKIP_REVIEW:` text in the parent prompt as authoritative context.
 - When `HANDOFF_MODE: 1`, you are running inside the autonomous Handoff pipeline. Do not ask interactive questions, do not stop for confirmations, and do not perform Handoff MCP sync yourself. The parent Handoff coordinator already owns task status transitions and database writes.
 - If requirement reconciliation returns `handoff_outcome: blocked_external`,
-  stop dispatch, propagate `blocker: requirement-conflict`, and never report or
-  signal `review` or `done`.
+  stop dispatch, propagate `blocker: requirement-conflict` unchanged, and never
+  report or signal `review` or `done`.
 - In autonomous mode, pass `HANDOFF_MODE` and `HANDOFF_SKIP_REVIEW` through to every delegated `implement-worker` request as explicit text. Workers never own Handoff sync.
 - When `HANDOFF_MODE` is absent or not `1`, treat the run as a manual Codex session. If the plan entrypoint contains a `<!-- handoff:task:<id> -->` annotation, Handoff MCP sync is required; if the tools are unavailable, return a blocking integration error instead of silently skipping sync.
 - For a linked manual plan, call `handoff_sync_status` with `implementing` and `paused: true` before dispatch. After each completed layer, call `handoff_push_plan`. On completion, push the final plan and sync `review` with `paused: true`, or `done` with `paused: false` when `HANDOFF_SKIP_REVIEW: 1`. Use the actual UTC timestamp and `direction: "aif_to_handoff"` for status calls.

--- a/subagents/codex/agents/implement-worker.toml
+++ b/subagents/codex/agents/implement-worker.toml
@@ -19,6 +19,17 @@ Rules:
 - Never update plan progress or phase files; report verified completion to the
   coordinator, which owns `index.md`.
 - Return concise output: what changed, what was verified, and any remaining blockers.
+- Before editing, run the requirement consistency gate: read `## Requirements
+  Reconciliation` when present; resolve research citations only against the
+  embedded `## Research Context`; apply any declared source priority; and
+  compare the task behavior and supported selector/state/mode/input combinations
+  with the cited authoritative requirements. The live research file is only a
+  drift signal unless the user explicitly rebases the plan. For an older plan,
+  use the task, Original Request, embedded Research Context, project rules, and
+  authoritative sources explicitly referenced by them.
+- On a clear authoritative conflict, make no edits. In `HANDOFF_MODE: 1`, do
+  not prompt; return exactly `handoff_outcome: blocked_external` and
+  `blocker: requirement-conflict`. Outside Handoff mode, stop for clarification.
 
 Handoff integration:
 - If the parent prompt includes `HANDOFF_MODE:` or `HANDOFF_TASK_ID:`, treat them as execution context only.

--- a/subagents/codex/agents/plan-coordinator.toml
+++ b/subagents/codex/agents/plan-coordinator.toml
@@ -33,6 +33,8 @@ Handoff integration:
 - Treat any explicit `HANDOFF_MODE:` and `HANDOFF_TASK_ID:` text in the parent prompt as authoritative context.
 - When `HANDOFF_MODE: 1`, you are running inside the autonomous Handoff pipeline. Do not ask interactive questions, do not pause for confirmations, and do not perform Handoff MCP sync yourself. The parent Handoff coordinator already owns status transitions and database writes.
 - When `HANDOFF_MODE: 1`, pass both `HANDOFF_MODE` and `HANDOFF_TASK_ID` through to every delegated `plan-polisher` request as explicit text. Do not assume child agents can read environment variables directly.
+- If a polisher returns `status: blocked_external`, stop refinement, propagate
+  the blocker unchanged, and never report or signal `plan_ready`.
 - When `HANDOFF_MODE` is absent or not `1`, treat the run as a manual Codex session. If an existing plan contains a `<!-- handoff:task:<id> -->` annotation, Handoff MCP sync is required; if the tools are unavailable, return a blocking integration error instead of silently skipping sync.
 - Pass the linked task ID to every manual `plan-polisher` request so refinement preserves the first-line annotation.
 - For a linked manual plan, call `handoff_sync_status` with `planning` and `paused: true` before refinement. On completion, call `handoff_push_plan`, then `handoff_sync_status` with `plan_ready` and `paused: true`. Use the actual UTC timestamp and `direction: "aif_to_handoff"` for status calls.

--- a/subagents/codex/agents/plan-polisher.toml
+++ b/subagents/codex/agents/plan-polisher.toml
@@ -35,6 +35,9 @@ Rules:
 Handoff integration:
 - If the parent prompt includes `HANDOFF_MODE:` and `HANDOFF_TASK_ID:`, treat them as authoritative.
 - When `HANDOFF_MODE: 1`, you are operating for the autonomous Handoff pipeline. Do not ask interactive questions; use the explicit plan path, tests/docs policy, and defaults provided by the parent.
+- If authoritative requirements conflict and need a user decision in
+  `HANDOFF_MODE: 1`, do not prompt or mark the plan ready. Stop and return
+  exactly `status: blocked_external` and `blocker: requirement-conflict`.
 - When `HANDOFF_MODE: 1` and `HANDOFF_TASK_ID` is non-empty, insert
   `<!-- handoff:task:<HANDOFF_TASK_ID> -->` as the first line of the plan
   entrypoint (`index.md` for ultra). Omitting it is a contract violation.


### PR DESCRIPTION
## Summary

- reconcile authoritative sources and unresolved conflicts before implementation planning
- capture material supported behavior combinations and representative repository artifacts in plan evidence
- enforce requirement consistency during plan refinement and execution
- verify the full requirements-to-plan-to-implementation-to-evidence chain

## Motivation

A workflow can become internally consistent while still drifting from authoritative requirements, especially when constraints are distributed across multiple artifacts or independent behavior dimensions are validated only in isolation. These gates make such conflicts explicit before implementation and during verification without introducing domain-specific assumptions.

## Validation

- npm run build
- npm test: 147 passed, 0 failed